### PR TITLE
Watch net-att-def CRs by SriovNetwork controller

### DIFF
--- a/controllers/sriovibnetwork_controller.go
+++ b/controllers/sriovibnetwork_controller.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 )
@@ -45,6 +47,8 @@ type SriovIBNetworkReconciler struct {
 
 func (r *SriovIBNetworkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
+	// The SriovNetwork CR shall only be defined in operator namespace.
+	req.Namespace = namespace
 	reqLogger := r.Log.WithValues("sriovnetwork", req.NamespacedName)
 
 	reqLogger.Info("Reconciling SriovIBNetwork")
@@ -154,6 +158,6 @@ func (r *SriovIBNetworkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, err
 func (r *SriovIBNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sriovnetworkv1.SriovIBNetwork{}).
-		Owns(&netattdefv1.NetworkAttachmentDefinition{}).
+		Watches(&source.Kind{Type: &netattdefv1.NetworkAttachmentDefinition{}}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/controllers/sriovnetwork_controller.go
+++ b/controllers/sriovnetwork_controller.go
@@ -28,7 +28,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 )
@@ -45,6 +47,8 @@ type SriovNetworkReconciler struct {
 
 func (r *SriovNetworkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
+	// The SriovNetwork CR shall only be defined in operator namespace.
+	req.Namespace = namespace
 	reqLogger := r.Log.WithValues("sriovnetwork", req.NamespacedName)
 
 	reqLogger.Info("Reconciling SriovNetwork")
@@ -154,6 +158,6 @@ func (r *SriovNetworkReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error
 func (r *SriovNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sriovnetworkv1.SriovNetwork{}).
-		Owns(&netattdefv1.NetworkAttachmentDefinition{}).
+		Watches(&source.Kind{Type: &netattdefv1.NetworkAttachmentDefinition{}}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }


### PR DESCRIPTION
When upgrade to operator-sdk 1.0.1, the watch logic was migrated in an incorrect way.
This patch fix it.