### PR TITLE
Add support for link types selector

### DIFF
--- a/api/v1/sriovnetworknodepolicy_types.go
+++ b/api/v1/sriovnetworknodepolicy_types.go
@@ -52,6 +52,8 @@ type SriovNetworkNicSelector struct {
 	PfNames []string `json:"pfNames,omitempty"`
 	// Infrastructure Networking selection filter. Allowed value "openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 	NetFilter string `json:"netFilter,omitempty"`
+	// Link type of SR-IOV PF.
+	LinkTypes []string `json:"linkTypes,omitempty"`
 }
 
 // SriovNetworkNodePolicyStatus defines the observed state of SriovNetworkNodePolicy

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -77,6 +77,11 @@ spec:
                     description: Infrastructure Networking selection filter. Allowed
                       value "openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
                     type: string
+                  linkTypes:
+                    description: Link type of SR-IOV PF.
+                    items:
+                      type: string
+                    type: array
                   pfNames:
                     description: Name of SR-IoV PF.
                     items:

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -563,6 +563,9 @@ func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(pl *srio
 			if len(p.Spec.NicSelector.PfNames) > 0 {
 				netDeviceSelectors.PfNames = sriovnetworkv1.UniqueAppend(netDeviceSelectors.PfNames, p.Spec.NicSelector.PfNames...)
 			}
+			if len(p.Spec.NicSelector.LinkTypes) > 0 {
+				netDeviceSelectors.LinkTypes = sriovnetworkv1.UniqueAppend(netDeviceSelectors.LinkTypes, p.Spec.NicSelector.LinkTypes...)
+			}
 			if len(p.Spec.NicSelector.RootDevices) > 0 {
 				netDeviceSelectors.RootDevices = sriovnetworkv1.UniqueAppend(netDeviceSelectors.RootDevices, p.Spec.NicSelector.RootDevices...)
 			}
@@ -615,6 +618,9 @@ func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(pl *srio
 			}
 			if len(p.Spec.NicSelector.PfNames) > 0 {
 				netDeviceSelectors.PfNames = append(netDeviceSelectors.PfNames, p.Spec.NicSelector.PfNames...)
+			}
+			if len(p.Spec.NicSelector.LinkTypes) > 0 {
+				netDeviceSelectors.LinkTypes = append(netDeviceSelectors.LinkTypes, p.Spec.NicSelector.LinkTypes...)
 			}
 			if len(p.Spec.NicSelector.RootDevices) > 0 {
 				netDeviceSelectors.RootDevices = append(netDeviceSelectors.RootDevices, p.Spec.NicSelector.RootDevices...)


### PR DESCRIPTION
Currently, the operator has no way to determine a specific link type
NICs for the deployed device plugin e.g. determining a node to be
only ethernet or InfiniBand NICs only
This patch adds support for "linkTypes" selector of SR-IOV network
device plugin, which provides a more flexible selection of the NICs
