### PR TITLE
Support SKIP_VAR_SET in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -170,7 +170,7 @@ KUSTOMIZE=$(shell which kustomize)
 endif
 
 skopeo:
-	if ! which skopeo; then if [ -f /etc/redhat-release ]; then dnf -y install skopeo; elif [ -f /etc/lsb-release ]; then sudo apt-get -y update; sudo apt-get -y install skopeo; fi; fi
+	if ! which skopeo; then if [ -z ${SKIP_VAR_SET} ]; then if [ -f /etc/redhat-release ]; then dnf -y install skopeo; elif [ -f /etc/lsb-release ]; then sudo apt-get -y update; sudo apt-get -y install skopeo; fi; fi; fi
 
 # Generate bundle manifests and metadata, then validate generated files.
 .PHONY: bundle


### PR DESCRIPTION
In case a non empty SKIP_VAR_SET is exported,
Makefile would respect it and not install skopeo
in case skopeo doesn't exists.

This will allow to use the sriov-operator with non root users.

See please https://github.com/openshift/sriov-network-operator/blob/52480752f6582cf2829845f291a147d75c23756e/hack/env.sh#L1
for more details about `SKIP_VAR_SET` and its purpose to allow
running without `skopeo` installed, when env vars are overridden by the user.

Signed-off-by: Or Shoval <oshoval@redhat.com>