### PR TITLE
Add support for Intel X710/X557-AT

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -40,6 +40,7 @@ var NicIdMap = []string{
 	"8086 158b 154c", // I40e 25G SFP28
 	"8086 1572 154c", // I40e 10G X710 SFP+
 	"8086 0d58 154c", // I40e XXV710 N3000
+	"8086 1589 154c", // I40e X710/X557-AT
 	"15b3 1015 1016", // ConnectX-4LX
 	"15b3 1017 1018", // ConnectX-5, PCIe 3.0
 	"15b3 101b 101c", // ConnectX-6

--- a/api/v1/sriovnetworknodepolicy_types.go
+++ b/api/v1/sriovnetworknodepolicy_types.go
@@ -44,7 +44,7 @@ type SriovNetworkNodePolicySpec struct {
 type SriovNetworkNicSelector struct {
 	// The vendor hex code of SR-IoV device. Allowed value "8086", "15b3".
 	Vendor string `json:"vendor,omitempty"`
-	// The device hex code of SR-IoV device. Allowed value "0d58", "1572", "158b", "1013", "1015", "1017", "101b".
+	// The device hex code of SR-IoV device. Allowed value "0d58", "1572", "158b", "1013", "1015", "1017", "101b", "1589".
 	DeviceID string `json:"deviceID,omitempty"`
 	// PCI address of SR-IoV PF.
 	RootDevices []string `json:"rootDevices,omitempty"`

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -71,7 +71,7 @@ spec:
                 properties:
                   deviceID:
                     description: The device hex code of SR-IoV device. Allowed value
-                      "0d58", "1572", "158b", "1013", "1015", "1017", "101b".
+                      "0d58", "1572", "158b", "1013", "1015", "1017", "101b", "1589".
                     type: string
                   netFilter:
                     description: Infrastructure Networking selection filter. Allowed


### PR DESCRIPTION
Add Intel X710/X557 to `NicIdMap` supported nics map.
This way the webhook will not reject node policies of it.

Signed-off-by: Or Shoval <oshoval@redhat.com>