### PR TITLE
Return err for reconciling when pod deletion fails

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -315,9 +315,10 @@ func (r *SriovNetworkNodePolicyReconciler) syncPluginDaemonObjs(dp *sriovnetwork
 	logger.Info("Start to sync sriov daemons objects")
 
 	if len(pl.Items) < 2 {
-		r.tryDeleteDsPods(namespace, "sriov-device-plugin")
-		r.tryDeleteDsPods(namespace, "sriov-cni")
-		return nil
+		err := r.tryDeleteDsPods(namespace, "sriov-device-plugin")
+		if err != nil { return err }
+		err = r.tryDeleteDsPods(namespace, "sriov-cni")
+		if err != nil { return err }
 	}
 	// render RawCNIConfig manifests
 	data := render.MakeRenderData()


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>

Sriov cni/dp daemonsets are reconciled by two controllers, being
node policy controller and operator config controller, there is a
chance that policy controller may fail to delete daemonset pod
as reported here: https://bugzilla.redhat.com/show_bug.cgi?id=1905362
This commit returns error when pod deletion fails which trigger
reconciling of the pod deletion again.