### PR TITLE
Update DiscoverSriovDevices to list only pfs with networking devices

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -78,6 +78,18 @@ func DiscoverSriovDevices() ([]sriovnetworkv1.InterfaceExt, error) {
 			glog.Warningf("DiscoverSriovDevices(): unable to parse device driver for device %+v %q", device, err)
 			continue
 		}
+
+		deviceNames, err := dputils.GetNetNames(device.Address)
+		if err != nil {
+			glog.Warningf("DiscoverSriovDevices(): unable to get device names for device %+v %q", device, err)
+			continue
+		}
+
+		if len(deviceNames) == 0 {
+			// no network devices found, skipping device
+			continue
+		}
+
 		iface := sriovnetworkv1.InterfaceExt{
 			PciAddress: device.Address,
 			Driver:     driver,


### PR DESCRIPTION
Currently `DiscoverSriovDevices` creates a list of interfaces,
by scanning `/sys/devices/pci`.
Some of them might not have a networking devices.
The interfaces without networking devices won't be available,
but would still be reset, as they won't be part of the node policy.
    
Updating `DiscoverSriovDevices` to list only pfs which have networking devices.
As a result sriov-operator will support namespace isolation,
because `/sys/class/net` entries are network-namespaced.

Fixes: https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/2

Signed-off-by: Or Shoval <oshoval@redhat.com>