### PR TITLE
Configure OVS Offload tc-policy to skip_sw by default

### DIFF
--- a/bindata/manifests/machine-config/ovs-units/ovs-vswitchd.service.yaml
+++ b/bindata/manifests/machine-config/ovs-units/ovs-vswitchd.service.yaml
@@ -4,3 +4,4 @@ dropins:
   contents: |
     [Service]
     ExecStartPre=/bin/ovs-vsctl set Open_vSwitch . other_config:hw-offload=true
+    ExecStartPre=/bin/ovs-vsctl set Open_vSwitch . other_config:tc-policy=skip_sw


### PR DESCRIPTION
When tc software datapath is used in local gateway mode,
host networked pod fails to access k8s API via service IP.

https://bugzilla.redhat.com/show_bug.cgi?id=1908570

Signed-off-by: Zenghui Shi <zshi@redhat.com>