### PR TITLE
daemon, Fix unsupported-nics logic in case VF device ID already exists

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -184,6 +184,10 @@ func (dn *Daemon) annotateUnsupportedNicIdConfigMap(cm *v1.ConfigMap, nodeName s
 	if err != nil {
 		return nil, err
 	}
+
+	if cm.ObjectMeta.Annotations == nil {
+		cm.ObjectMeta.Annotations = make(map[string]string)
+	}
 	cm.ObjectMeta.Annotations["openshift.io/"+nodeName] = string(jsonData)
 	return dn.kubeClient.CoreV1().ConfigMaps(namespace).Update(context.Background(), cm, metav1.UpdateOptions{})
 }


### PR DESCRIPTION
In case unsupported nic has a VF device id which already exists
in the udev rule, the rule won't be updated, as it depends only on the
VF device ids, and not on the tuple (Vendor, PF_ID, VF_ID).

Therefore:
* Fix logic to update the annotation even if the file contents are the same,
but the annotation is different or doesn't exist at all.
    
Note: since the annotation has the configMap data itself, both on the creation
and validation, it will be robust to configMap updates,
because if the annotation exists but the data in the annotation is different
from the configMap data, it will be rejected, until a new rule will be created,
if needed, and the updated annotation will be written.

Additional problems that were addressed:

* tryCreateUdevRule creates a udev file by using WriteFile
WriteFile will not create the directory hierarchy in case
it doesn't exist [1].
Therefore create the folder in case it doesn't exist.

* In case the daemon updates the unsupported-nic configmap
annotations, before k8s adds `last-applied-configuration` annotation,
a panic will occur at `annotateUnsupportedNicIdConfigMap`:
"Observed a panic: assignment to entry in nil map (assignment to entry in nil map)"
Fix it by allocation the map in case it is still nil.

[1] https://github.com/golang/go/issues/32916

Fixes: https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/10

Signed-off-by: Or Shoval <oshoval@redhat.com>