### PR TITLE
Fix sriov test

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -1415,7 +1415,7 @@ var _ = Describe("[sriov] operator", func() {
 						}
 						return true
 
-					}, 1*time.Minute, 10*time.Second).Should(BeTrue())
+					}, 2*time.Minute, 10*time.Second).Should(BeTrue())
 
 					Eventually(func() bool {
 						serviceList, err := clients.Services(operatorNamespace).List(context.Background(), metav1.ListOptions{})
@@ -1426,7 +1426,7 @@ var _ = Describe("[sriov] operator", func() {
 							}
 						}
 						return true
-					}, 1*time.Minute, 10*time.Second).Should(BeTrue())
+					}, 2*time.Minute, 10*time.Second).Should(BeTrue())
 
 					Eventually(func() bool {
 						crs := rbacv1.ClusterRoleList{}

--- a/test/util/network/network.go
+++ b/test/util/network/network.go
@@ -31,6 +31,9 @@ func CreateSriovNetwork(clientSet *testclient.ClientSet, intf *sriovv1.Interface
 			ResourceName:     resourceName,
 			IPAM:             ipam,
 			NetworkNamespace: namespace,
+			// Enable the linkState instead of auto so even if the PF is down we can still use the VF
+			// for pod to pod connectivity tests in the same host
+			LinkState: "enable",
 		}}
 
 	for _, o := range options {


### PR DESCRIPTION
This commit fix one sriov test by enable the linkState to be enable,
this will allow the pod to have a nic state up even if the PF is down.

This commit also extend the time we wait for the webhook pod to be remove

Signed-off-by: Sebastian Sch <sebassch@gmail.com>