### PR TITLE
Tests: Make the stable waiting timeout longer.

### DIFF
--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -1832,7 +1832,7 @@ func waitForSRIOVStable() {
 	// the status won't never go to not stable and the test will fail.
 	// TODO: find a better way to handle this scenario
 
-	time.Sleep(5 * time.Second)
+	time.Sleep(10 * time.Second)
 
 	fmt.Println("Waiting for the sriov state to stable")
 	Eventually(func() bool {

--- a/test/util/images/images.go
+++ b/test/util/images/images.go
@@ -18,7 +18,7 @@ func init() {
 
 	cnfTestsImage = os.Getenv("CNF_TESTS_IMAGE")
 	if cnfTestsImage == "" {
-		cnfTestsImage = "cnf-tests:4.5"
+		cnfTestsImage = "cnf-tests:4.7"
 	}
 }
 


### PR DESCRIPTION
In case of single node cluster, with the drain disabled, it takes longer than 5 seconds to transition to the "In Progress" state. With this, we make the waiting time longer. Also, we updgrade the cnf-tests image to use the latest tag.