### PR TITLE
Rename vf representor with udev rules

### DIFF
--- a/bindata/manifests/machine-config/files/switchdev-vf-link-name.sh.yaml
+++ b/bindata/manifests/machine-config/files/switchdev-vf-link-name.sh.yaml
@@ -1,0 +1,9 @@
+mode: 0755
+overwrite: true
+path: "/etc/udev/switchdev-vf-link-name.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    set -x
+    PORT="$1"
+    echo "NUMBER=${PORT##pf*vf}"

--- a/bindata/scripts/load-udev.sh
+++ b/bindata/scripts/load-udev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Reload udev rules: /usr/sbin/udevadm control --reload-rules"
+chroot /host/ /usr/sbin/udevadm control --reload-rules
+
+echo "Trigger udev event: /usr/sbin/udevadm trigger --action add --attr-match subsystem=net"
+chroot /host/ /usr/sbin/udevadm trigger --action add --attr-match subsystem=net

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -620,3 +620,27 @@ func GetNicSriovMode(pciAddress string) (string, error) {
 	}
 	return devLink.Attrs.Eswitch.Mode, nil
 }
+
+func GetPhysSwitchID(name string) (string, error) {
+	swIDFile := filepath.Join(sysClassNet, name, "phys_switch_id")
+	physSwitchID, err := ioutil.ReadFile(swIDFile)
+	if err != nil {
+		return "", err
+	}
+	if physSwitchID != nil {
+		return strings.TrimSpace(string(physSwitchID)), nil
+	}
+	return "", nil
+}
+
+func GetPhysPortName(name string) (string, error) {
+	devicePortNameFile := filepath.Join(sysClassNet, name, "phys_port_name")
+	physPortName, err := ioutil.ReadFile(devicePortNameFile)
+	if err != nil {
+		return "", err
+	}
+	if physPortName != nil {
+		return strings.TrimSpace(string(physPortName)), nil
+	}
+	return "", nil
+}


### PR DESCRIPTION
VF representor is named in the format of ethX, where X is an incremental
number, it doesn't tell which PF it belongs to and which VF is the peer device.
By renaming it with udev rules, VF rep name will be in the format of PF_[vf-index].
This commit add udev rules file and relevant script for machine config plugin,
which work only with openshift clusterType.


Signed-off-by: Zenghui Shi <zshi@redhat.com>