### PR TITLE
Revert "Configure OVS Offload tc-policy to skip_sw by default"

### DIFF
--- a/bindata/manifests/machine-config/ovs-units/ovs-vswitchd.service.yaml
+++ b/bindata/manifests/machine-config/ovs-units/ovs-vswitchd.service.yaml
@@ -4,4 +4,3 @@ dropins:
   contents: |
     [Service]
     ExecStartPre=/bin/ovs-vsctl set Open_vSwitch . other_config:hw-offload=true
-    ExecStartPre=/bin/ovs-vsctl set Open_vSwitch . other_config:tc-policy=skip_sw


### PR DESCRIPTION
This reverts commit c78723a62d254600ca76da460634df3999ba7f0f.

Hardware ct offload cannot work with skip_sw as it relies on tc sw to
instantiate flow tables.