### PR TITLE
Run generic plugin Apply when no vender plugin loaded

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -514,7 +514,7 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 		}
 	}
 
-	if len(dn.LoadedPlugins) > 1 && !reqReboot {
+	if !reqReboot {
 		// Apply generic_plugin last
 		err = dn.LoadedPlugins[GenericPlugin].Apply()
 		if err != nil {


### PR DESCRIPTION
Fix the issue that generic plugin Apply won't be invoked if no supported
vendor NICs in the host.

https://bugzilla.redhat.com/show_bug.cgi?id=1914414