### PR TITLE
Add missing CLUSTER_TYPE=kubernetes to vanilla k8s images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,5 @@ FROM centos:7
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/manager /usr/bin/sriov-network-operator
 COPY bindata /bindata
 ENV OPERATOR_NAME=sriov-network-operator
+ENV CLUSTER_TYPE=kubernetes
 CMD ["/usr/bin/sriov-network-operator"]

--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -12,4 +12,5 @@ COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operat
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/pkg/plugins /plugins
 COPY bindata /bindata
 ENV PLUGINSPATH=/plugins
+ENV CLUSTER_TYPE=kubernetes
 CMD ["/usr/bin/sriov-network-config-daemon"]

--- a/Makefile
+++ b/Makefile
@@ -193,7 +193,6 @@ deploy-setup-k8s: export NAMESPACE=sriov-network-operator
 deploy-setup-k8s: export ENABLE_ADMISSION_CONTROLLER=false
 deploy-setup-k8s: export CNI_BIN_PATH=/opt/cni/bin
 deploy-setup-k8s: export OPERATOR_EXEC=kubectl
-deploy-setup-k8s: export CLUSTER_TYPE=kubernetes
 deploy-setup-k8s: deploy-setup
 
 test-e2e-conformance:


### PR DESCRIPTION
PR 51 try to fix it by adding the CLUSTER_TYPE=kubernetes in Makefile
which is wrong. The CLUSTER_TYPE=kubernetes should be exposed in the
sriov-operator and sriov-network-config-daemon Pods so that they will
behave according to the cluster type

This commit fix it by removing the CLUSTER_TYPE=kubernetes from the Makefile
and add it to sriov-operator and .sriov-network-config-daemon Dockerfile.

Fixes: #48
Signed-off-by: Moshe Levi <moshele@nvidia.com>