### PR TITLE
Skip adding linkType selector for vfio-pci devices

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -559,14 +559,16 @@ func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(pl *srio
 			if len(p.Spec.NicSelector.PfNames) > 0 {
 				netDeviceSelectors.PfNames = sriovnetworkv1.UniqueAppend(netDeviceSelectors.PfNames, p.Spec.NicSelector.PfNames...)
 			}
-			if p.Spec.LinkType != "" {
-				linkType := linkTypeEthernet
-				if strings.ToLower(p.Spec.LinkType) == "ib" {
-					linkType = linkTypeInfiniband
-				}
-
-				if !sriovnetworkv1.StringInArray(linkType, netDeviceSelectors.LinkTypes) {
-					netDeviceSelectors.LinkTypes = sriovnetworkv1.UniqueAppend(netDeviceSelectors.LinkTypes, linkType)
+			// vfio-pci device link type is not detectable
+			if p.Spec.DeviceType != "vfio-pci" {
+				if p.Spec.LinkType != "" {
+					linkType := linkTypeEthernet
+					if strings.ToLower(p.Spec.LinkType) == "ib" {
+						linkType = linkTypeInfiniband
+					}
+					if !sriovnetworkv1.StringInArray(linkType, netDeviceSelectors.LinkTypes) {
+						netDeviceSelectors.LinkTypes = sriovnetworkv1.UniqueAppend(netDeviceSelectors.LinkTypes, linkType)
+					}
 				}
 			}
 			if len(p.Spec.NicSelector.RootDevices) > 0 {
@@ -622,12 +624,15 @@ func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(pl *srio
 			if len(p.Spec.NicSelector.PfNames) > 0 {
 				netDeviceSelectors.PfNames = append(netDeviceSelectors.PfNames, p.Spec.NicSelector.PfNames...)
 			}
-			if p.Spec.LinkType != "" {
-				linkType := linkTypeEthernet
-				if strings.ToLower(p.Spec.LinkType) == "ib" {
-					linkType = linkTypeInfiniband
+			// vfio-pci device link type is not detectable
+			if p.Spec.DeviceType != "vfio-pci" {
+				if p.Spec.LinkType != "" {
+					linkType := linkTypeEthernet
+					if strings.ToLower(p.Spec.LinkType) == "ib" {
+						linkType = linkTypeInfiniband
+					}
+					netDeviceSelectors.LinkTypes = sriovnetworkv1.UniqueAppend(netDeviceSelectors.LinkTypes, linkType)
 				}
-				netDeviceSelectors.LinkTypes = sriovnetworkv1.UniqueAppend(netDeviceSelectors.LinkTypes, linkType)
 			}
 			if len(p.Spec.NicSelector.RootDevices) > 0 {
 				netDeviceSelectors.RootDevices = append(netDeviceSelectors.RootDevices, p.Spec.NicSelector.RootDevices...)


### PR DESCRIPTION
LinkType is not detectable for eth vfio-pci device using
netlink library which results in failure when exposing
vfio-pci resources.

Signed-off-by: Zenghui Shi <zshi@redhat.com>