### PR TITLE
don't drain the node if current NumVfs == 0

### DIFF
--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -190,7 +190,7 @@ func needDrainNode(desired sriovnetworkv1.Interfaces, current sriovnetworkv1.Int
 					// ignore swichdev device
 					break
 				}
-				if iface.NumVfs != ifaceStatus.NumVfs {
+				if iface.NumVfs != ifaceStatus.NumVfs && ifaceStatus.NumVfs != 0 {
 					glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect NumVfs %v, current NumVfs %v", iface.NumVfs, ifaceStatus.NumVfs)
 					needDrain = true
 					return


### PR DESCRIPTION
we don't need to remove PODs if none of them has VF(s)
This happends in the case that the current NumVfs == 0

Signed-off-by: Moshe Levi <moshele@nvidia.com>