### PR TITLE
Set CLUSTER_TYPE env variable in manifests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,6 +196,7 @@ deploy-setup-k8s: export NAMESPACE=sriov-network-operator
 deploy-setup-k8s: export ENABLE_ADMISSION_CONTROLLER=false
 deploy-setup-k8s: export CNI_BIN_PATH=/opt/cni/bin
 deploy-setup-k8s: export OPERATOR_EXEC=kubectl
+deploy-setup-k8s: export CLUSTER_TYPE=kubernetes
 deploy-setup-k8s: deploy-setup
 
 test-e2e-conformance:

--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -47,6 +47,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          - name: CLUSTER_TYPE
+            value: "{{.ClusterType}}"
         volumeMounts:
         - name: host
           mountPath: /host

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -169,6 +169,7 @@ func (r *SriovOperatorConfigReconciler) syncConfigDaemonSet(dc *sriovnetworkv1.S
 	data.Data["Image"] = os.Getenv("SRIOV_NETWORK_CONFIG_DAEMON_IMAGE")
 	data.Data["Namespace"] = namespace
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASEVERSION")
+	data.Data["ClusterType"] = utils.ClusterType
 	objs, err := render.RenderDir(CONFIG_DAEMON_PATH, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render config daemon manifests")

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -61,3 +61,5 @@ spec:
               value: 4.3.0
             - name: SRIOV_CNI_BIN_PATH
               value: $CNI_BIN_PATH
+            - name: CLUSTER_TYPE
+              value: $CLUSTER_TYPE


### PR DESCRIPTION
Add CLUSTER_TYPE to the manifests so it can be customized without the
need to rebuild the images.

fixes: #48 