### PR TITLE
Support Switchdev for kernel 5.8 and above

### DIFF
--- a/bindata/manifests/switchdev-config/files/configure-switchdev.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/configure-switchdev.sh.yaml
@@ -6,10 +6,32 @@ contents:
     #!/bin/bash
     set -eux
     input="/etc/switchdev.conf"
+    UDEV_RULE_FILE='/etc/udev/rules.d/10-persistent-net.rules'
+
     if [ ! -f $input ]; then
       echo "File /etc/switchdev.conf not exist."
       exit
     fi
+
+    append_to_file(){
+      content="$1"
+      file_name="$2"
+      if ! test -f "$file_name"
+      then
+        echo "$content" > "$file_name"
+      else
+        if ! grep -Fxq "$content" "$file_name"
+        then
+          echo "$content" >> "$file_name"
+        fi
+      fi
+    }
+
+    add_udev_rule_for_sriov_pf(){
+        pf_pci=$(grep PCI_SLOT_NAME /sys/class/net/$1/device/uevent | cut -d'=' -f2)
+        udev_data_line="SUBSYSTEM==\"net\", ACTION==\"add\", DRIVERS==\"?*\", KERNELS==\"$pf_pci\", NAME=\"$1\""
+        append_to_file "$udev_data_line" "$UDEV_RULE_FILE"
+    }
 
     names=()
 
@@ -17,7 +39,11 @@ contents:
     do
       echo "Set $num_vfs VFs on device $pci_addr"
 
-      names+=($(ls /sys/bus/pci/devices/${pci_addr}/net/))
+      name=$(ls /sys/bus/pci/devices/${pci_addr}/net/)
+      names+=($name)
+      # Create udev rule to save PF name
+      add_udev_rule_for_sriov_pf $name
+
       # create VFs
       echo $num_vfs > /sys/bus/pci/devices/${pci_addr}/sriov_numvfs
     done <"$input"
@@ -39,10 +65,6 @@ contents:
       # set PF to switchdev mode
       devlink dev eswitch set pci/${pci_addr} mode switchdev
 
-      # reset the pf name
-      new_name=$(ls /sys/bus/pci/devices/${pci_addr}/net/)
-      ip link set ${new_name} down
-      ip link set ${new_name} name ${names[i]}
       ip link set ${names[i]} up
 
       # turn hw-tc-offload on

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"syscall"
@@ -37,6 +38,8 @@ const (
 
 var InitialState sriovnetworkv1.SriovNetworkNodeState
 var ClusterType string
+
+var pfPhysPortNameRe = regexp.MustCompile(`p\d+`)
 
 func init() {
 	ClusterType = os.Getenv("CLUSTER_TYPE")
@@ -375,8 +378,26 @@ func tryGetInterfaceName(pciAddr string) string {
 	if err != nil || len(names) < 1 {
 		return ""
 	}
-	glog.V(2).Infof("tryGetInterfaceName(): name is %s", names[0])
-	return names[0]
+	netDevName := names[0]
+
+	// Switchdev PF and their VFs representors are existing under the same PCI address since kernel 5.8
+	// if device is switchdev then return PF name
+	for _, name := range names {
+		if !isSwitchdev(name) {
+			continue
+		}
+		// Try to get the phys port name, if not exists then fallback to check without it
+		// phys_port_name should be in formant p<port-num> e.g p0,p1,p2 ...etc.
+		if physPortName, err := GetPhysPortName(name); err == nil {
+			if !pfPhysPortNameRe.MatchString(physPortName) {
+				continue
+			}
+		}
+		return name
+	}
+
+	glog.V(2).Infof("tryGetInterfaceName(): name is %s", netDevName)
+	return netDevName
 }
 
 func getNetdevMTU(pciAddr string) int {
@@ -666,4 +687,13 @@ func GetPhysPortName(name string) (string, error) {
 		return strings.TrimSpace(string(physPortName)), nil
 	}
 	return "", nil
+}
+
+func isSwitchdev(name string) bool {
+	switchID, err := GetPhysSwitchID(name)
+	if err != nil || switchID == "" {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
Till kernel 5.7 VF representors are exposed as virtual devices, they are not linked to a PCI address.

Starting from kernel 5.8 the VF representors are linked to their PF PCI address, so /sys/bus/pci/devices/<pf-pci-address>/net contains the PF net device and it VF representors net devices.

The new kernel behaviour affects 'tryGetInterfaceName' if PF in switchdev and configure-switchdev script

This commit brings needed changes to cope with new kernel behviour.