### PR TITLE
Support setting VF to different MTU with PF partitioning

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -390,6 +390,7 @@ func (p *SriovNetworkNodePolicy) generateVfGroup(iface *InterfaceExt) (*VfGroup,
 		DeviceType:   p.Spec.DeviceType,
 		VfRange:      rng,
 		PolicyName:   p.GetName(),
+		Mtu:          p.Spec.Mtu,
 	}, nil
 }
 

--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -29,6 +29,7 @@ type VfGroup struct {
 	DeviceType   string `json:"deviceType,omitempty"`
 	VfRange      string `json:"vfRange,omitempty"`
 	PolicyName   string `json:"policyName,omitempty"`
+	Mtu          int    `json:"mtu,omitempty"`
 }
 
 type Interfaces []Interface

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -59,6 +59,8 @@ spec:
                         properties:
                           deviceType:
                             type: string
+                          mtu:
+                            type: integer
                           policyName:
                             type: string
                           resourceName:


### PR DESCRIPTION
The PF MTU is still set to the largest value among the partitions. The VF MTU is set to the value of the sriovnetworknodepolicy.

Fix #57 