### PR TITLE
Add image push workflows

### DIFF
--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -1,0 +1,89 @@
+name: "Push images on merge to master"
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-push-image-operator:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_IMAGE_REGISTRY_TOKEN }}
+
+      - name: Build and push sriov-network-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          file: ./Dockerfile
+
+  build-and-push-image-config-daemon:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-config-daemon
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_IMAGE_REGISTRY_TOKEN }}
+
+      - name: Build and push sriov-network-operator-config-daemon
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          file: ./Dockerfile.sriov-network-config-daemon
+
+  build-and-push-image-webhook:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-webhook
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_IMAGE_REGISTRY_TOKEN }}
+
+      - name: Build and push sriov-network-operator-webhook
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+            ${{ env.IMAGE_NAME }}:${{ github.sha }}
+          file: ./Dockerfile.webhook

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,0 +1,107 @@
+name: "Push images on release"
+on:
+  push:
+    tags:
+      - v*
+jobs:
+  build-and-push-image-operator:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_IMAGE_REGISTRY_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tag-latest: false
+
+      - name: Build and push sriov-network-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          file: ./Dockerfile
+
+  build-and-push-image-config-daemon:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-config-daemon
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_IMAGE_REGISTRY_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tag-latest: false
+
+      - name: Build and push sriov-network-operator-config-daemon
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          file: ./Dockerfile.sriov-network-config-daemon
+
+  build-and-push-image-webhook:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-webhook
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GH_IMAGE_REGISTRY_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tag-latest: false
+
+      - name: Build and push sriov-network-operator-webhook
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ steps.docker_meta.outputs.tags }}
+          file: ./Dockerfile.webhook


### PR DESCRIPTION
This commit adds two new workflows to github action

1. image-push-master: Job to build sriov-network-operator
   container images on push to master event. The new images
   are then pushed to ghcr.io

1. image-push-release: Job to build sriov-network-operator
   container images on release tag event. The new images
   are then pushed to ghcr.io

Container images generated:

- sriov-network-operator
- sriov-network-operator-config-daemon
- sriov-network-operator-webhook

Note: For the jobs to successfully login to ghcr.io it is
      required to issue a github PAT(Personal access token)
      and store it as a secret in the project with the
      following secret name: GH_IMAGE_REGISTRY_TOKEN

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>