### PR TITLE
Replace nodeSelector with nodeAffinity master role

### DIFF
--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -24,7 +24,13 @@ spec:
       serviceAccountName: operator-webhook-sa
       nodeSelector:
         beta.kubernetes.io/os: linux
-        node-role.kubernetes.io/master:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: Exists

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -27,7 +27,13 @@ spec:
       serviceAccountName: network-resources-injector-sa
       nodeSelector:
         beta.kubernetes.io/os: linux
-        node-role.kubernetes.io/master:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - key: "node-role.kubernetes.io/master"
         operator: Exists

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,8 +12,13 @@ spec:
       labels:
         name: sriov-network-operator
     spec:
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/master
+                operator: Exists
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master


### PR DESCRIPTION
Label node-role.kubernetes.io/master has traditionally no value
associated inherited from kubeadm deplyments but some platforms use
"true" as value. Use node affinity instead of node selector ignoring the
value of the label.