### PR TITLE
Support test-e2e-k8s rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,7 +205,10 @@ test-e2e-conformance:
 test-e2e: generate vet manifests skopeo
 	mkdir -p ${ENVTEST_ASSETS_DIR}
 	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/master/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); source hack/env.sh; go test ./test/e2e/... -coverprofile cover.out -v
+	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); source hack/env.sh; go test ./test/e2e/... -timeout 60m -coverprofile cover.out -v
+
+test-e2e-k8s: export NAMESPACE=sriov-network-operator
+test-e2e-k8s: test-e2e
 
 test-%: generate vet manifests
 	mkdir -p ${ENVTEST_ASSETS_DIR}

--- a/hack/env.sh
+++ b/hack/env.sh
@@ -33,3 +33,4 @@ export OPERATOR_NAME=sriov-network-operator
 export RESOURCE_PREFIX=${RESOURCE_PREFIX:-openshift.io}
 export ENABLE_ADMISSION_CONTROLLER=${ENABLE_ADMISSION_CONTROLLER:-"true"}
 export CLUSTER_TYPE=${CLUSTER_TYPE:-openshift}
+export NAMESPACE=${NAMESPACE:-"openshift-sriov-network-operator"}

--- a/test/e2e/e2e_tests_suite_test.go
+++ b/test/e2e/e2e_tests_suite_test.go
@@ -31,11 +31,10 @@ import (
 var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
+var testNamespace string
 
 // Define utility constants for object names and testing timeouts/durations and intervals.
 const (
-	testNamespace = "openshift-sriov-network-operator"
-
 	timeout  = time.Second * 30
 	duration = time.Second * 300
 	interval = time.Second * 1
@@ -43,6 +42,9 @@ const (
 
 func TestSriovTests(t *testing.T) {
 	RegisterFailHandler(Fail)
+
+	testNamespace = os.Getenv("NAMESPACE")
+	Expect(testNamespace).NotTo(Equal(""))
 
 	RunSpecsWithDefaultAndCustomReporters(t,
 		"E2E Suite",


### PR DESCRIPTION
This patch adds the support for the `test-e2e-k8` make rule by
making the operator namespace in the e2e tests configurable then
setting the namespace value in the Makefile.