### PR TITLE
Add Broadcom BCM57414 & BCM75508 device IDs in NicIdMap

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -50,6 +50,8 @@ var NicIdMap = []string{
 	"15b3 101b 101c", // ConnectX-6
 	"15b3 101d 101e", // ConnectX-6 Dx
 	"15b3 a2d6 101e", // MT42822 BlueField-2 integrated ConnectX-6 Dx
+	"14e4 16d7 16dc", // BCM57414 2x25G
+	"14e4 1750 1806", // BCM75508 2x100G
 }
 
 // NetFilterType Represents the NetFilter tags to be used


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>