### PR TITLE
Don't run k8s-plugin when CLUSTER_TYPE is OpenShift

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -491,6 +491,9 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	mcoReboot := false
 	for k, p := range dn.LoadedPlugins {
 		d, r := false, false
+		if k == K8sPlugin && utils.ClusterType == utils.ClusterTypeOpenshift {
+			continue
+		}
 		if dn.nodeState.GetName() == "" {
 			d, r, err = p.OnNodeStateAdd(latestState)
 		} else {


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>