### PR TITLE
Add rbac rules for network-resources-injector to access configmaps

### DIFF
--- a/bindata/manifests/webhook/002-rbac.yaml
+++ b/bindata/manifests/webhook/002-rbac.yaml
@@ -22,6 +22,7 @@ rules:
   - replicasets
   - daemonsets
   - statefulsets
+  - configmaps
   verbs:
   - '*'
 - apiGroups:

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -48,6 +48,11 @@ spec:
         - -alsologtostderr=true
         - -insecure=true
         - -injectHugepageDownApi=true
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         volumeMounts:
         - mountPath: /etc/tls
           name: tls


### PR DESCRIPTION
Signed-off-by: Zenghui Shi <zshi@redhat.com>