### PR TITLE
Add management workload annotations

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -14,6 +14,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sriov-network-config-daemon
         component: network

--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -18,6 +18,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: operator-webhook
     spec:

--- a/bindata/manifests/plugins/sriov-cni.yaml
+++ b/bindata/manifests/plugins/sriov-cni.yaml
@@ -16,6 +16,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sriov-cni
         component: network

--- a/bindata/manifests/plugins/sriov-device-plugin.yaml
+++ b/bindata/manifests/plugins/sriov-device-plugin.yaml
@@ -16,6 +16,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: sriov-device-plugin
         component: network

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -18,6 +18,8 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: network-resources-injector
         component: network

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -7,6 +7,9 @@ metadata:
   namespace: system
 spec:
   template:
+    metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: kube-rbac-proxy

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: system
 spec:
   template:
+    metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
     spec:
       containers:
       - name: manager

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -1,6 +1,8 @@
 apiVersion: v1
 kind: Namespace
 metadata:
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
     control-plane: controller-manager
   name: system
@@ -19,6 +21,8 @@ spec:
   replicas: 1
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         control-plane: controller-manager
     spec:

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -2,5 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: $NAMESPACE
+  annotations:
+    workload.openshift.io/allowed: "management"
   labels:
     name: $NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -9,6 +9,8 @@ spec:
       name: sriov-network-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: sriov-network-operator
     spec:

--- a/deployment/sriov-network-operator/templates/operator.yaml
+++ b/deployment/sriov-network-operator/templates/operator.yaml
@@ -11,6 +11,8 @@ spec:
       name: sriov-network-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: sriov-network-operator
     spec:

--- a/manifests/4.7/sriov-network-operator.v4.7.0.clusterserviceversion.yaml
+++ b/manifests/4.7/sriov-network-operator.v4.7.0.clusterserviceversion.yaml
@@ -294,6 +294,8 @@ spec:
               name: sriov-network-operator
           template:
             metadata:
+              annotations:
+                workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
               labels:
                 name: sriov-network-operator
             spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.