### PR TITLE
Move to admissionregistration.k8s.io/v1

### DIFF
--- a/bindata/manifests/operator-webhook/003-webhook.yaml
+++ b/bindata/manifests/operator-webhook/003-webhook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{.SRIOVMutatingWebhookName}}
@@ -8,6 +8,8 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
   - name: operator-webhook.sriovnetwork.openshift.io
+    sideEffects: None
+    admissionReviewVersions: [v1]
     failurePolicy: Fail
     clientConfig:
       service:
@@ -21,7 +23,7 @@ webhooks:
         resources: ["sriovnetworknodepolicies"]
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{.SRIOVMutatingWebhookName}}
@@ -30,6 +32,8 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
   - name: operator-webhook.sriovnetwork.openshift.io
+    sideEffects: None
+    admissionReviewVersions: [v1]
     failurePolicy: Fail
     clientConfig:
       service:

--- a/bindata/manifests/webhook/003-webhook.yaml
+++ b/bindata/manifests/webhook/003-webhook.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{.SRIOVMutatingWebhookName}}
@@ -8,6 +8,8 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
   - name: network-resources-injector-config.k8s.io
+    sideEffects: None
+    admissionReviewVersions: [v1]
     clientConfig:
       service:
         name: network-resources-injector-service

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,13 +1,13 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: mutating-webhook-configuration
   annotations:
     cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -25,7 +25,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/openshift/machine-config-operator/lib/resourcemerge"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -273,7 +273,7 @@ func (r *SriovOperatorConfigReconciler) syncWebhookObject(dc *sriovnetworkv1.Sri
 	scheme := kscheme.Scheme
 	switch kind := obj.GetKind(); kind {
 	case "MutatingWebhookConfiguration":
-		whs := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
+		whs := &admissionregistrationv1.MutatingWebhookConfiguration{}
 		err = scheme.Convert(obj, whs, nil)
 		r.syncMutatingWebhook(dc, whs)
 		if err != nil {
@@ -281,7 +281,7 @@ func (r *SriovOperatorConfigReconciler) syncWebhookObject(dc *sriovnetworkv1.Sri
 			return err
 		}
 	case "ValidatingWebhookConfiguration":
-		whs := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
+		whs := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 		err = scheme.Convert(obj, whs, nil)
 		r.syncValidatingWebhook(dc, whs)
 		if err != nil {
@@ -297,14 +297,14 @@ func (r *SriovOperatorConfigReconciler) syncWebhookObject(dc *sriovnetworkv1.Sri
 	return nil
 }
 
-func (r *SriovOperatorConfigReconciler) syncMutatingWebhook(cr *sriovnetworkv1.SriovOperatorConfig, in *admissionregistrationv1beta1.MutatingWebhookConfiguration) error {
+func (r *SriovOperatorConfigReconciler) syncMutatingWebhook(cr *sriovnetworkv1.SriovOperatorConfig, in *admissionregistrationv1.MutatingWebhookConfiguration) error {
 	logger := r.Log.WithName("syncMutatingWebhook")
 	logger.Info("Start to sync mutating webhook", "Name", in.Name, "Namespace", in.Namespace)
 
 	if err := controllerutil.SetControllerReference(cr, in, r.Scheme); err != nil {
 		return err
 	}
-	whs := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
+	whs := &admissionregistrationv1.MutatingWebhookConfiguration{}
 	err := r.Get(context.TODO(), types.NamespacedName{Name: in.Name}, whs)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -319,7 +319,7 @@ func (r *SriovOperatorConfigReconciler) syncMutatingWebhook(cr *sriovnetworkv1.S
 	}
 
 	// Delete deprecated operator mutating webhook CR
-	deprecated_webhook := &admissionregistrationv1beta1.MutatingWebhookConfiguration{}
+	deprecated_webhook := &admissionregistrationv1.MutatingWebhookConfiguration{}
 	err = r.Get(context.TODO(), types.NamespacedName{Name: DEPRECATED_OPERATOR_WEBHOOK_NAME}, deprecated_webhook)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -343,14 +343,14 @@ func (r *SriovOperatorConfigReconciler) syncMutatingWebhook(cr *sriovnetworkv1.S
 	return nil
 }
 
-func (r *SriovOperatorConfigReconciler) syncValidatingWebhook(cr *sriovnetworkv1.SriovOperatorConfig, in *admissionregistrationv1beta1.ValidatingWebhookConfiguration) error {
+func (r *SriovOperatorConfigReconciler) syncValidatingWebhook(cr *sriovnetworkv1.SriovOperatorConfig, in *admissionregistrationv1.ValidatingWebhookConfiguration) error {
 	logger := r.Log.WithName("syncValidatingWebhook")
 	logger.Info("Start to sync validating webhook", "Name", in.Name, "Namespace", in.Namespace)
 
 	if err := controllerutil.SetControllerReference(cr, in, r.Scheme); err != nil {
 		return err
 	}
-	whs := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
+	whs := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 	err := r.Get(context.TODO(), types.NamespacedName{Name: in.Name}, whs)
 	if err != nil {
 		if errors.IsNotFound(err) {
@@ -365,7 +365,7 @@ func (r *SriovOperatorConfigReconciler) syncValidatingWebhook(cr *sriovnetworkv1
 	}
 
 	// Delete deprecated operator validating webhook CR
-	deprecated_webhook := &admissionregistrationv1beta1.ValidatingWebhookConfiguration{}
+	deprecated_webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{}
 	err = r.Get(context.TODO(), types.NamespacedName{Name: DEPRECATED_OPERATOR_WEBHOOK_NAME}, deprecated_webhook)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -3,7 +3,7 @@ package controllers
 import (
 	goctx "context"
 
-	admv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,11 +54,11 @@ var _ = Describe("Operator", func() {
 		})
 
 		It("should have webhook enable", func() {
-			mutateCfg := &admv1beta1.MutatingWebhookConfiguration{}
+			mutateCfg := &admv1.MutatingWebhookConfiguration{}
 			err := util.WaitForNamespacedObject(mutateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			validateCfg := &admv1beta1.ValidatingWebhookConfiguration{}
+			validateCfg := &admv1.ValidatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObject(validateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -89,7 +89,7 @@ var _ = Describe("Operator", func() {
 			err = util.WaitForNamespacedObjectDeleted(daemonSet, k8sClient, testNamespace, "network-resources-injector", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			mutateCfg := &admv1beta1.MutatingWebhookConfiguration{}
+			mutateCfg := &admv1.MutatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObjectDeleted(mutateCfg, k8sClient, testNamespace, "network-resources-injector-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -105,7 +105,7 @@ var _ = Describe("Operator", func() {
 			err = util.WaitForNamespacedObject(daemonSet, k8sClient, testNamespace, "network-resources-injector", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			mutateCfg = &admv1beta1.MutatingWebhookConfiguration{}
+			mutateCfg = &admv1.MutatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObject(mutateCfg, k8sClient, testNamespace, "network-resources-injector-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 		})
@@ -125,11 +125,11 @@ var _ = Describe("Operator", func() {
 			err = util.WaitForNamespacedObjectDeleted(daemonSet, k8sClient, testNamespace, "operator-webhook", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			mutateCfg := &admv1beta1.MutatingWebhookConfiguration{}
+			mutateCfg := &admv1.MutatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObjectDeleted(mutateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			validateCfg := &admv1beta1.ValidatingWebhookConfiguration{}
+			validateCfg := &admv1.ValidatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObjectDeleted(validateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -145,11 +145,11 @@ var _ = Describe("Operator", func() {
 			err = util.WaitForNamespacedObject(daemonSet, k8sClient, testNamespace, "operator-webhook", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			mutateCfg = &admv1beta1.MutatingWebhookConfiguration{}
+			mutateCfg = &admv1.MutatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObject(mutateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			validateCfg = &admv1beta1.ValidatingWebhookConfiguration{}
+			validateCfg = &admv1.ValidatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObject(validateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", interval, timeout)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/pkg/webhook/mutate.go
+++ b/pkg/webhook/mutate.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"k8s.io/api/admission/v1beta1"
+	"k8s.io/api/admission/v1"
 )
 
 var (
@@ -16,9 +16,9 @@ var (
 	InfiniBandIsRdmaPatch  = map[string]interface{}{"op": "add", "path": "/spec/isRdma", "value": true}
 )
 
-func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1beta1.AdmissionResponse, error) {
+func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1.AdmissionResponse, error) {
 	glog.V(2).Infof("mutateSriovNetworkNodePolicy(): set default value")
-	reviewResponse := v1beta1.AdmissionResponse{}
+	reviewResponse := v1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 
 	name := cr["metadata"].(map[string]interface{})["name"]
@@ -56,7 +56,7 @@ func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1beta1.Admission
 		return nil, err
 	}
 
-	pt := v1beta1.PatchTypeJSONPatch
+	pt := v1.PatchTypeJSONPatch
 	reviewResponse.PatchType = &pt
 	return &reviewResponse, nil
 }

--- a/pkg/webhook/scheme.go
+++ b/pkg/webhook/scheme.go
@@ -1,8 +1,8 @@
 package webhook
 
 import (
-	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -20,7 +20,7 @@ func init() {
 
 func addToScheme(scheme *runtime.Scheme) {
 	utilruntime.Must(corev1.AddToScheme(scheme))
-	utilruntime.Must(admissionv1beta1.AddToScheme(scheme))
-	utilruntime.Must(admissionregistrationv1beta1.AddToScheme(scheme))
+	utilruntime.Must(admissionv1.AddToScheme(scheme))
+	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
 	utilruntime.Must(sriovnetworkv1.AddToScheme(scheme))
 }

--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/golang/glog"
-	"k8s.io/api/admission/v1beta1"
+	"k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -30,7 +30,7 @@ var (
 	interfaceSelected bool
 )
 
-func validateSriovOperatorConfig(cr *sriovnetworkv1.SriovOperatorConfig, operation v1beta1.Operation) (bool, []string, error) {
+func validateSriovOperatorConfig(cr *sriovnetworkv1.SriovOperatorConfig, operation v1.Operation) (bool, []string, error) {
 	glog.V(2).Infof("validateSriovOperatorConfig: %v", cr)
 	var warnings []string
 
@@ -47,7 +47,7 @@ func validateSriovOperatorConfig(cr *sriovnetworkv1.SriovOperatorConfig, operati
 	return false, warnings, fmt.Errorf("only default SriovOperatorConfig is used")
 }
 
-func validateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy, operation v1beta1.Operation) (bool, []string, error) {
+func validateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy, operation v1.Operation) (bool, []string, error) {
 	glog.V(2).Infof("validateSriovNetworkNodePolicy: %v", cr)
 	var warnings []string
 


### PR DESCRIPTION
Switch to admission v1 from v1beta1. This PR drops support for k8s <= 1.15. 

Requires: https://github.com/k8snetworkplumbingwg/network-resources-injector/pull/96