### PR TITLE
Add verification that nic is SRIOV capable

### DIFF
--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -99,7 +99,7 @@ func (n *EnabledNodes) FindSriovDevices(node string) ([]*sriovv1.InterfaceExt, e
 func (n *EnabledNodes) FindOneVfioSriovDevice() (string, sriovv1.InterfaceExt) {
 	for _, node := range n.Nodes {
 		for _, nic := range n.States[node].Status.Interfaces {
-			if nic.Vendor == "8086" {
+			if nic.Vendor == "8086" && nic.TotalVfs > 0 {
 				return node, nic
 			}
 		}


### PR DESCRIPTION
Before this change a nic that doesn't support SRIOV could be picked
for the vfio-pci tests, resulting in a failure.