### PR TITLE
[wip] Support containerized OpenVSwitch for hardware offload

### DIFF
--- a/api/v1/sriovoperatorconfig_types.go
+++ b/api/v1/sriovoperatorconfig_types.go
@@ -24,6 +24,8 @@ type SriovOperatorConfigSpec struct {
 	DisableDrain bool `json:"disableDrain,omitempty"`
 	// Flag to enable OVS hardware offload. Set to 'true' to provision switchdev-configuration.service and enable OpenvSwitch hw-offload on nodes.
 	EnableOvsOffload bool `json:"enableOvsOffload,omitempty"`
+	// Flag to support deploying containerized ovs and skip maintaining ovs-vswitchd service for OvsOffload.
+	ContainerizedOvs bool `json:"containerizedOvs,omitempty"`
 }
 
 // SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
@@ -42,6 +42,10 @@ spec:
                   type: string
                 description: NodeSelector selects the nodes to be configured
                 type: object
+              containerizedOvs:
+                description: Flag to support deploying containerized ovs and skip
+                  maintaining ovs-vswitchd service for OvsOffload.
+                type: boolean
               disableDrain:
                 description: Flag to disable nodes drain during debugging
                 type: boolean

--- a/pkg/service/filter.go
+++ b/pkg/service/filter.go
@@ -1,0 +1,17 @@
+package service
+
+type Filter interface {
+	Match(*Service) bool
+}
+
+type FilterList []Filter
+
+func (fl *FilterList) Match(service *Service) bool {
+	for _, filter := range *fl {
+		if filter.Match(service) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/service/name_filter.go
+++ b/pkg/service/name_filter.go
@@ -1,0 +1,13 @@
+package service
+
+type nameFilter struct {
+	name string
+}
+
+func NewNameFilter(name string) Filter {
+	return &nameFilter{name}
+}
+
+func (f *nameFilter) Match(service *Service) bool {
+	return f.name == service.Name
+}


### PR DESCRIPTION
Add new flag `ContainerizedOvs` for `SriovOperatorConfig`, this change is needed to avoid failing the operator in case an OpenVSwitch was deployed in the container which will conflict with OpenVSwitch deployed on host