### PR TITLE
Skip enabling hw-offload for ovs-vswitchd when containerized OpenVSwitch is used

### DIFF
--- a/api/v1/sriovoperatorconfig_types.go
+++ b/api/v1/sriovoperatorconfig_types.go
@@ -24,6 +24,8 @@ type SriovOperatorConfigSpec struct {
 	DisableDrain bool `json:"disableDrain,omitempty"`
 	// Flag to enable OVS hardware offload. Set to 'true' to provision switchdev-configuration.service and enable OpenvSwitch hw-offload on nodes.
 	EnableOvsOffload bool `json:"enableOvsOffload,omitempty"`
+	// Flag to support deploying containerized ovs and skip maintaining ovs-vswitchd service for OvsOffload.
+	ContainerizedOvs bool `json:"containerizedOvs,omitempty"`
 }
 
 // SriovOperatorConfigStatus defines the observed state of SriovOperatorConfig

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
@@ -42,6 +42,10 @@ spec:
                   type: string
                 description: NodeSelector selects the nodes to be configured
                 type: object
+              containerizedOvs:
+                description: Flag to support deploying containerized ovs and skip
+                  maintaining ovs-vswitchd service for OvsOffload.
+                type: boolean
               disableDrain:
                 description: Flag to disable nodes drain during debugging
                 type: boolean

--- a/pkg/service/filter.go
+++ b/pkg/service/filter.go
@@ -1,0 +1,17 @@
+package service
+
+type Filter interface {
+	Match(*Service) bool
+}
+
+type FilterList []Filter
+
+func (fl *FilterList) Match(service *Service) bool {
+	for _, filter := range *fl {
+		if filter.Match(service) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/service/name_filter.go
+++ b/pkg/service/name_filter.go
@@ -1,0 +1,13 @@
+package service
+
+type nameFilter struct {
+	name string
+}
+
+func NewNameFilter(name string) Filter {
+	return &nameFilter{name}
+}
+
+func (f *nameFilter) Match(service *Service) bool {
+	return f.name == service.Name
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"fmt"
+	snclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned"
 	"io/ioutil"
 	"math/rand"
 	"net"
@@ -21,6 +22,8 @@ import (
 	"github.com/jaypipes/ghw"
 	"github.com/vishvananda/netlink"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 )
@@ -740,4 +743,22 @@ func hasMellanoxInterfacesInSpec(newState *sriovnetworkv1.SriovNetworkNodeState)
 		}
 	}
 	return false
+}
+
+func GetKubernetesClient() (snclientset.Interface, error) {
+	var config *rest.Config
+	var err error
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	} else {
+		// creates the in-cluster config
+		config, err = rest.InClusterConfig()
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return snclientset.NewForConfig(config)
 }


### PR DESCRIPTION
HW Offload needs to be enabled on OpenVSwitch which will fail if OpenVSwitch is deployed in a container.

This PR introduces a new flag `ContainerizedOvs` for `SriovOperatorConfig`, which makes the operator skip enabling hw-offload for ovs-vswitchd, in case OpenVSwitch is deployed in a container or maintained by 3rd party