### PR TITLE
upgrade PROJECT config file from 3-alpha to version 3

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -3,21 +3,51 @@ layout: go.kubebuilder.io/v2
 projectName: sriov-network-operator
 repo: github.com/k8snetworkplumbingwg/sriov-network-operator
 resources:
-- group: sriovnetwork
+-
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  controller: true
+  domain: openshift.io
+  group: sriovnetwork
   kind: SriovNetwork
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
   version: v1
-- group: sriovnetwork
+-
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  controller: true
+  domain: openshift.io
+  group: sriovnetwork
   kind: SriovIBNetwork
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
   version: v1
-- group: sriovnetwork
+-
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  controller: true
+  domain: openshift.io
+  group: sriovnetwork
   kind: SriovNetworkNodePolicy
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
   version: v1
-- group: sriovnetwork
+-
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  controller: true
+  domain: openshift.io
+  group: sriovnetwork
   kind: SriovNetworkNodeState
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
   version: v1
-- group: sriovnetwork
+-
+  # TODO(user): Uncomment the below line if this resource implements a controller, else delete it.
+  controller: true
+  domain: openshift.io
+  group: sriovnetwork
   kind: SriovOperatorConfig
+  # TODO(user): Update the package path for your API if the below value is incorrect.
+  path: github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1
   version: v1
-version: 3-alpha
+version: "3"
 plugins:
   go.sdk.operatorframework.io/v2-alpha: {}


### PR DESCRIPTION
Hitting warning when create new api as below:

WARN[0000] Config version 3-alpha has been stabilized as 3,
and 3-alpha is no longer supported. Run `operator-sdk alpha
config-3alpha-to-3` to upgrade your PROJECT config file to
version 3.

Upgraded PROJECT config via the following cmd:

$ operator-sdk alpha config-3alpha-to-3

Signed-off-by: Zenghui Shi <zshi@redhat.com>