### PR TITLE
Fix network injector webhook

### DIFF
--- a/bindata/manifests/webhook/003-webhook.yaml
+++ b/bindata/manifests/webhook/003-webhook.yaml
@@ -14,6 +14,7 @@ webhooks:
   - name: network-resources-injector-config.k8s.io
     sideEffects: None
     admissionReviewVersions: [v1]
+    failurePolicy: Ignore
     clientConfig:
       service:
         name: network-resources-injector-service


### PR DESCRIPTION
This commit fix the network injector webhook to stuck the all cluster.

https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/116 move the admission version to v1

In v1 the default `FailurePolicy` is `Fail` and not `Ignore` as v1Beta1

Signed-off-by: Sebastian Sch <sebassch@gmail.com>