### PR TITLE
Use ConfigMap to store supported NIC model list

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -12,8 +12,10 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -36,25 +38,7 @@ var VfIds = []string{}
 
 // NicIdMap contains supported mapping of IDs with each in the format of:
 // Vendor ID, Physical Function Device ID, Virtual Function Device ID
-var NicIdMap = []string{
-	"8086 158a 154c", // I40e XXV710
-	"8086 158b 154c", // I40e 25G SFP28
-	"8086 1572 154c", // I40e 10G X710 SFP+
-	"8086 0d58 154c", // I40e XXV710 N3000
-	"8086 1583 154c", // I40e 40G XL710 QSFP+
-	"8086 1592 1889", // Columbiaville E810-CQDA2/2CQDA2
-	"8086 1593 1889", // Columbiaville E810-XXVDA4
-	"8086 159b 1889", // Columbiaville E810-XXVDA2
-	"15b3 1013 1014", // ConnectX-4
-	"15b3 1015 1016", // ConnectX-4LX
-	"15b3 1017 1018", // ConnectX-5, PCIe 3.0
-	"15b3 1019 101a", // ConnectX-5 Ex
-	"15b3 101b 101c", // ConnectX-6
-	"15b3 101d 101e", // ConnectX-6 Dx
-	"15b3 a2d6 101e", // MT42822 BlueField-2 integrated ConnectX-6 Dx
-	"14e4 16d7 16dc", // BCM57414 2x25G
-	"14e4 1750 1806", // BCM75508 2x100G
-}
+var NicIdMap = []string{}
 
 // NetFilterType Represents the NetFilter tags to be used
 type NetFilterType int
@@ -62,6 +46,8 @@ type NetFilterType int
 const (
 	// OpenstackNetworkID network UUID
 	OpenstackNetworkID NetFilterType = iota
+
+	SUPPORTED_NIC_ID_CONFIGMAP = "supported-nic-ids"
 )
 
 func (e NetFilterType) String() string {
@@ -71,6 +57,22 @@ func (e NetFilterType) String() string {
 	default:
 		return fmt.Sprintf("%d", int(e))
 	}
+}
+
+func InitNicIdMap(client *kubernetes.Clientset, namespace string) error {
+	cm, err := client.CoreV1().ConfigMaps(namespace).Get(
+		context.Background(),
+		SUPPORTED_NIC_ID_CONFIGMAP,
+		metav1.GetOptions{},
+	)
+	// if the configmap does not exist, return false
+	if err != nil {
+		return err
+	}
+	for _, v := range cm.Data {
+		NicIdMap = append(NicIdMap, v)
+	}
+	return nil
 }
 
 func IsSupportedVendor(vendorId string) bool {
@@ -108,30 +110,6 @@ func IsEnabledUnsupportedVendor(vendorId string, unsupportedNicIdMap map[string]
 		if IsValidPciString(n) {
 			ids := strings.Split(n, " ")
 			if vendorId == ids[0] {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func IsEnabledUnsupportedDevice(deviceId string, unsupportedNicIdMap map[string]string) bool {
-	for _, n := range unsupportedNicIdMap {
-		if IsValidPciString(n) {
-			ids := strings.Split(n, " ")
-			if deviceId == ids[1] {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-func IsEnabledUnsupportedModel(vendorId, deviceId string, unsupportedNicIdMap map[string]string) bool {
-	for _, n := range unsupportedNicIdMap {
-		if IsValidPciString(n) {
-			ids := strings.Split(n, " ")
-			if vendorId == ids[0] && deviceId == ids[1] {
 				return true
 			}
 		}
@@ -183,50 +161,13 @@ func GetSupportedVfIds() []string {
 			vfIds = append(vfIds, vfId)
 		}
 	}
-	return vfIds
-}
-
-func GetUnsupportedVfIds(unsupportedNicIdMap map[string]string) []string {
-	var vfIds []string
-	for k, n := range unsupportedNicIdMap {
-		if !IsValidPciString(n) {
-			log.Info("GetUnsupportedVfIds():", "name", k,
-				"Invalid Pci string", n)
-			continue
-		}
-		ids := strings.Split(n, " ")
-		vfId := "0x" + ids[2]
-		if !StringInArray(vfId, vfIds) {
-			vfIds = append(vfIds, vfId)
-		}
-	}
-	return vfIds
-}
-
-func GetMergedVfIds(unsupportedNicIdMap map[string]string) []string {
-	supportedVfIds := VfIds
-	unsupportedVfIds := GetUnsupportedVfIds(unsupportedNicIdMap)
-	var mergedVfIds []string
-
-	mergedVfIdsSet := make(map[string]struct{})
-	for _, v := range supportedVfIds {
-		mergedVfIdsSet[v] = struct{}{}
-	}
-	for _, v := range unsupportedVfIds {
-		mergedVfIdsSet[v] = struct{}{}
-	}
-	for k := range mergedVfIdsSet {
-		mergedVfIds = append(mergedVfIds, k)
-	}
-
 	// return a sorted slice so that udev rule is stable
-	sort.Slice(mergedVfIds, func(i, j int) bool {
-		ip, _ := strconv.ParseInt(mergedVfIds[i], 0, 32)
-		jp, _ := strconv.ParseInt(mergedVfIds[j], 0, 32)
+	sort.Slice(vfIds, func(i, j int) bool {
+		ip, _ := strconv.ParseInt(vfIds[i], 0, 32)
+		jp, _ := strconv.ParseInt(vfIds[j], 0, 32)
 		return ip < jp
 	})
-
-	return mergedVfIds
+	return vfIds
 }
 
 func GetVfDeviceId(deviceId string) string {
@@ -237,10 +178,6 @@ func GetVfDeviceId(deviceId string) string {
 		}
 	}
 	return ""
-}
-
-func init() {
-	VfIds = GetSupportedVfIds()
 }
 
 type ByPriority []SriovNetworkNodePolicy

--- a/cmd/webhook/start.go
+++ b/cmd/webhook/start.go
@@ -136,6 +136,11 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 		panic(err)
 	}
 
+	if err := webhook.RetriveSupportedNics(); err != nil {
+		glog.Error(err)
+		panic(err)
+	}
+
 	keyPair, err := webhook.NewTlsKeypairReloader(certFile, keyFile)
 	if err != nil {
 		glog.Fatalf("error load certificate: %s", err.Error())

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: supported-nic-ids
+data:
+  Intel_i40e_XXV710: "8086 158a 154c"
+  Intel_i40e_25G_SFP28: "8086 158b 154c"
+  Intel_i40e_10G_X710_SFP: "8086 1572 154c"
+  Intel_i40e_XXV710_N3000: "8086 0d58 154c"
+  Intel_i40e_40G_XL710_QSFP: "8086 1583 154c"
+  Intel_ice_Columbiaville_E810-CQDA2_2CQDA2: "8086 1592 1889"
+  Intel_ice_Columbiaville_E810-XXVDA4: "8086 1593 1889"
+  Intel_ice_Columbiaville_E810-XXVDA2: "8086 159b 1889"
+  Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
+  Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
+  Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"
+  Nvidia_mlx5_ConnectX-5_Ex: "15b3 1019 101a"
+  Nvidia_mlx5_ConnectX-6: "15b3 101b 101c"
+  Nvidia_mlx5_ConnectX-6_Dx: "15b3 101d 101e"
+  Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
+  Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
+  Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: supported-nic-ids
+data:
+  Intel_i40e_XXV710: "8086 158a 154c"
+  Intel_i40e_25G_SFP28: "8086 158b 154c"
+  Intel_i40e_10G_X710_SFP: "8086 1572 154c"
+  Intel_i40e_XXV710_N3000: "8086 0d58 154c"
+  Intel_i40e_40G_XL710_QSFP: "8086 1583 154c"
+  Intel_ice_Columbiaville_E810-CQDA2_2CQDA2: "8086 1592 1889"
+  Intel_ice_Columbiaville_E810-XXVDA4: "8086 1593 1889"
+  Intel_ice_Columbiaville_E810-XXVDA2: "8086 159b 1889"
+  Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
+  Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
+  Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"
+  Nvidia_mlx5_ConnectX-5_Ex: "15b3 1019 101a"
+  Nvidia_mlx5_ConnectX-6: "15b3 101b 101c"
+  Nvidia_mlx5_ConnectX-6_Dx: "15b3 101d 101e"
+  Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
+  Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
+  Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -23,16 +23,7 @@
 3. Multus-cni is deployed as default CNI plugin, and there is a default CNI plugin (flannel, openshift-sdn etc.) available for Multus-cni.
 
 > **Note:** As for unsupported SRIOV NICs, that is not guaranteed, but might work as well.
-> For that to happen, after you install the SR_IOV operator, one must disable the SR-IOV operator admission controller webhook.
-> If the operator was deployed with `make deploy-setup-k8s` the webhook is disabled by default and you can skip the next step. Else, one has to so manually:
-> First, make sure you have the OpenShift Command-line Interface (oc) installed and that you are logged in with  `cluster-admin` privileges.
-> Then, set the `enableOperatorWebhook` field to `false`:
-> ```
-> $ oc patch sriovoperatorconfig default --type=merge \
->   -n openshift-sriov-network-operator \
->   --patch '{ "spec": { "enableOperatorWebhook": false } }'
-> ```
-
+> For that to happen, after installing the SR_IOV operator, you have to add the unsupported SRIOV NICs information to the ConfigMap supported-nic-ids in following format: `<nic_name>: <vender_id> <pf_device_id> <vf_device_id>`. Then restart the config daemon and operator webhook pods.
 
 ## Installation
 

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.19.0
+	k8s.io/apiextensions-apiserver v0.19.0
 	k8s.io/apimachinery v0.19.0
 	k8s.io/client-go v0.19.0
 	k8s.io/code-generator v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -829,7 +829,6 @@ golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
@@ -969,14 +968,12 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200606014950-c42cb6316fb6/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
-golang.org/x/tools v0.0.0-20200616133436-c1934b75d054 h1:HHeAlu5H9b71C+Fx0K+1dGgVFN1DM1/wz4aoGOA5qS8=
 golang.org/x/tools v0.0.0-20200616133436-c1934b75d054/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a h1:CB3a9Nez8M13wwlr/E2YtwoU+qYHKfC+JrDa45RXXoQ=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -20,7 +20,7 @@ load_manifest() {
       
       envsubst< namespace.yaml | ${OPERATOR_EXEC} apply -f -
     fi
-    files="service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml operator.yaml"
+    files="service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml operator.yaml"
     for m in ${files}; do
       if [ "$(echo ${EXCLUSIONS[@]} | grep -o ${m} | wc -w | xargs)" == "0" ] ; then
         envsubst< ${m} | ${OPERATOR_EXEC} apply ${namespace:-} --validate=false -f -

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -10,7 +10,7 @@ if [ -n "${namespace}" ] ; then
 fi
 
 pushd ${repo_dir}/deploy
-files="operator.yaml service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml"
+files="operator.yaml service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml"
 for file in ${files}; do
   envsubst< ${file} | ${OPERATOR_EXEC} delete --ignore-not-found ${namespace} -f -
 done

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -12,6 +12,29 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
+func TestMain(m *testing.M) {
+	NicIdMap = []string{
+		"8086 158a 154c", // I40e XXV710
+		"8086 158b 154c", // I40e 25G SFP28
+		"8086 1572 154c", // I40e 10G X710 SFP+
+		"8086 0d58 154c", // I40e XXV710 N3000
+		"8086 1583 154c", // I40e 40G XL710 QSFP+
+		"8086 1592 1889", // Columbiaville E810-CQDA2/2CQDA2
+		"8086 1593 1889", // Columbiaville E810-XXVDA4
+		"8086 159b 1889", // Columbiaville E810-XXVDA2
+		"15b3 1013 1014", // ConnectX-4
+		"15b3 1015 1016", // ConnectX-4LX
+		"15b3 1017 1018", // ConnectX-5, PCIe 3.0
+		"15b3 1019 101a", // ConnectX-5 Ex
+		"15b3 101b 101c", // ConnectX-6
+		"15b3 101d 101e", // ConnectX-6 Dx
+		"15b3 a2d6 101e", // MT42822 BlueField-2 integrated ConnectX-6 Dx
+		"14e4 16d7 16dc", // BCM57414 2x25G
+		"14e4 1750 1806", // BCM75508 2x100G
+	}
+	os.Exit(m.Run())
+}
+
 func newNodeState() *SriovNetworkNodeState {
 	return &SriovNetworkNodeState{
 		Spec: SriovNetworkNodeStateSpec{

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -13,6 +13,13 @@ import (
 
 var namespace = os.Getenv("NAMESPACE")
 
+func RetriveSupportedNics() error {
+	if err := sriovnetworkv1.InitNicIdMap(kubeclient, namespace); err != nil {
+		return err
+	}
+	return nil
+}
+
 func MutateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 	glog.V(2).Info("mutating custom resource")
 


### PR DESCRIPTION
Use a ConfigMap 'supported-nic-ids' to store the NIC model list
to replace the current hardcoded list. Deprecate the ConfigMap
'unsupported-nic-ids'.

Also deprecate the machanism which allow users can change the
content of ConfigMap on the fly. Now users have to restart the
webhook and config daemon pods after changing the ConfigMap.