### PR TITLE
Fix daemon pod log

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -168,8 +168,7 @@ func New(
 				if usingEviction {
 					verbStr = "Evicted"
 				}
-				glog.Info(fmt.Sprintf("%s pod from Node", verbStr),
-					"pod", fmt.Sprintf("%s/%s", pod.Name, pod.Namespace))
+				glog.Info(fmt.Sprintf("%s pod from Node %s/%s", verbStr, pod.Namespace, pod.Name))
 			},
 			Out:    writer{glog.Info},
 			ErrOut: writer{glog.Error},


### PR DESCRIPTION
Some spaces were missing and the namespace should be before the pod name.