### PR TITLE
Remove sriov-cni check from E2E tests

### DIFF
--- a/test/e2e/sriovoperatornodepolicy_test.go
+++ b/test/e2e/sriovoperatornodepolicy_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Operator", func() {
 
 				By("provision the cni and device plugin daemonsets")
 				cniDaemonSet := &appsv1.DaemonSet{}
-				err = WaitForDaemonSetReady(cniDaemonSet, k8sClient, testNamespace, "sriov-cni", RetryInterval, Timeout)
+				err = WaitForDaemonSetReady(cniDaemonSet, k8sClient, testNamespace, "sriov-network-config-daemon", RetryInterval, Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				dpDaemonSet := &appsv1.DaemonSet{}
@@ -249,7 +249,7 @@ var _ = Describe("Operator", func() {
 
 				By("provision the cni and device plugin daemonsets")
 				cniDaemonSet := &appsv1.DaemonSet{}
-				err = WaitForDaemonSetReady(cniDaemonSet, k8sClient, testNamespace, "sriov-cni", RetryInterval, Timeout)
+				err = WaitForDaemonSetReady(cniDaemonSet, k8sClient, testNamespace, "sriov-network-config-daemon", RetryInterval, Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				dpDaemonSet := &appsv1.DaemonSet{}
@@ -393,7 +393,7 @@ var _ = Describe("Operator", func() {
 
 				By("provision the cni and device plugin daemonsets")
 				cniDaemonSet := &appsv1.DaemonSet{}
-				err = WaitForDaemonSetReady(cniDaemonSet, k8sClient, testNamespace, "sriov-cni", RetryInterval, Timeout)
+				err = WaitForDaemonSetReady(cniDaemonSet, k8sClient, testNamespace, "sriov-network-config-daemon", RetryInterval, Timeout)
 				Expect(err).NotTo(HaveOccurred())
 
 				dpDaemonSet := &appsv1.DaemonSet{}


### PR DESCRIPTION
Following k8snetworkplumbingwg/sriov-network-operator#149, sriov-cni
daemonset is no longer deployed separatly but as part of the config
daemon daemonset. This breaks the E2E tests, since the E2E
tests wait for the sriov-cni daemonsets to be ready.

This patch fix that by replacing the wait condition from the sriov-cni
to the config-daemon daemonset.