### PR TITLE
NRI: use control switch configmap to enable hugepage injection

### DIFF
--- a/bindata/manifests/webhook/004-configmap.yaml
+++ b/bindata/manifests/webhook/004-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nri-control-switches
+  namespace: {{.Namespace}}
+data:
+  config.json: |
+    {
+      "features": {
+        "enableHugePageDownApi": true
+      }
+    }

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -56,7 +56,6 @@ spec:
         - -tls-cert-file=/etc/tls/tls.crt
         - -alsologtostderr=true
         - -insecure=true
-        - -injectHugepageDownApi=true
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
Network Resource Injector (NRI) has switches to config map to enable
optional features such as enableHugePageDownApi,
enableHonorExistingResources etc. This commit allows Operator to
create controlSwitch configmap for NRI and removes injectHugepageDownApi
from webhook-server container arguments.