### PR TITLE
Remove SriovNetwork finalizers on controller shutdown

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/controllers"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -172,6 +173,9 @@ func main() {
 			os.Exit(1)
 		}
 	}()
+
+	// Remove all finalizers after controller is shut down
+	defer utils.Shutdown(mgr.GetClient())
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(stopCh); err != nil {

--- a/pkg/utils/shutdown.go
+++ b/pkg/utils/shutdown.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"context"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+)
+
+func Shutdown(c client.Client) {
+	shutdownLog := ctrl.Log.WithName("shutdown")
+	shutdownLog.Info("Clearing finalizers on exit")
+	networkList := &sriovnetworkv1.SriovNetworkList{}
+	err := c.List(context.TODO(), networkList)
+	if err != nil {
+		shutdownLog.Error(err, "Failed to list SriovNetworks")
+	} else {
+		for _, instance := range networkList.Items {
+			shutdownLog.Info("Clearing finalizers on SriovNetwork ", "namespace", instance.GetNamespace(), "name", instance.GetName())
+			instance.ObjectMeta.Finalizers = sriovnetworkv1.RemoveString(sriovnetworkv1.NETATTDEFFINALIZERNAME, instance.ObjectMeta.Finalizers)
+			err := c.Update(context.TODO(), &instance)
+			if err != nil {
+				shutdownLog.Error(err, "Failed to remove finalizer")
+			}
+		}
+	}
+	shutdownLog.Info("Done clearing finalizers on exit")
+}


### PR DESCRIPTION
The PR is added in response to customer complaints about SriovNetworks being stuck as terminating after uninstalling the sriov operator.
This PR removes the "netattdef.finalizers.sriovnetwork.openshift.io" finalizer from SriovNetworks when the sriovnetwork controller is deleted.  This finalizer is added to each SriovNetwork on reconciliation, but it is not removed when the operator is uninstalled, leaving SriovNetworks with finalizers and the SriovNetwork crd hanging in the terminating state forever.
The finalizers will be removed whenever the sriov operator pod is shut down, including pod restarts. The removed finalizer will be added when the pod restarts and the networks are reconciled.

