### PR TITLE
Set webhook failurePolicy to Ignore on controller pod shutdown

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -219,12 +219,15 @@ func StringInArray(val string, array []string) bool {
 	return false
 }
 
-func RemoveString(s string, slice []string) (result []string) {
-	for _, item := range slice {
-		if item == s {
-			continue
+func RemoveString(s string, slice []string) (result []string, found bool) {
+	if len(slice) != 0 {
+		for _, item := range slice {
+			if item == s {
+				found = true
+				continue
+			}
+			result = append(result, item)
 		}
-		result = append(result, item)
 	}
 	return
 }

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -18,33 +18,13 @@ package controllers
 
 import (
 	"os"
-	"time"
-)
 
-const (
-	ResyncPeriod                        = 5 * time.Minute
-	DEFAULT_CONFIG_NAME                 = "default"
-	CONFIG_DAEMON_PATH                  = "./bindata/manifests/daemon"
-	INJECTOR_WEBHOOK_PATH               = "./bindata/manifests/webhook"
-	OPERATOR_WEBHOOK_PATH               = "./bindata/manifests/operator-webhook"
-	SERVICE_CA_CONFIGMAP_ANNOTATION     = "service.beta.openshift.io/inject-cabundle"
-	INJECTOR_WEBHOOK_NAME               = "network-resources-injector-config"
-	OPERATOR_WEBHOOK_NAME               = "sriov-operator-webhook-config"
-	DEPRECATED_OPERATOR_WEBHOOK_NAME    = "operator-webhook-config"
-	PLUGIN_PATH                         = "./bindata/manifests/plugins"
-	DAEMON_PATH                         = "./bindata/manifests/daemon"
-	DEFAULT_POLICY_NAME                 = "default"
-	CONFIGMAP_NAME                      = "device-plugin-config"
-	DP_CONFIG_FILENAME                  = "config.json"
-	OVS_HWOL_MACHINE_CONFIG_NAME_SUFFIX = "ovs-hw-offload"
-
-	linkTypeEthernet   = "ether"
-	linkTypeInfiniband = "infiniband"
+	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 )
 
 var webhooks = map[string](string){
-	INJECTOR_WEBHOOK_NAME: INJECTOR_WEBHOOK_PATH,
-	OPERATOR_WEBHOOK_NAME: OPERATOR_WEBHOOK_PATH,
+	constants.INJECTOR_WEBHOOK_NAME: constants.INJECTOR_WEBHOOK_PATH,
+	constants.OPERATOR_WEBHOOK_NAME: constants.OPERATOR_WEBHOOK_PATH,
 }
 
 var namespace = os.Getenv("NAMESPACE")

--- a/controllers/sriovibnetwork_controller.go
+++ b/controllers/sriovibnetwork_controller.go
@@ -98,9 +98,12 @@ func (r *SriovIBNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 				return reconcile.Result{}, err
 			}
 			// remove our finalizer from the list and update it.
-			instance.ObjectMeta.Finalizers = sriovnetworkv1.RemoveString(sriovnetworkv1.NETATTDEFFINALIZERNAME, instance.ObjectMeta.Finalizers)
-			if err := r.Update(context.Background(), instance); err != nil {
-				return reconcile.Result{}, err
+			var found bool
+			instance.ObjectMeta.Finalizers, found = sriovnetworkv1.RemoveString(sriovnetworkv1.NETATTDEFFINALIZERNAME, instance.ObjectMeta.Finalizers)
+			if found {
+				if err := r.Update(context.Background(), instance); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		}
 		return reconcile.Result{}, err

--- a/controllers/sriovnetwork_controller.go
+++ b/controllers/sriovnetwork_controller.go
@@ -99,9 +99,12 @@ func (r *SriovNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request
 				return reconcile.Result{}, err
 			}
 			// remove our finalizer from the list and update it.
-			instance.ObjectMeta.Finalizers = sriovnetworkv1.RemoveString(sriovnetworkv1.NETATTDEFFINALIZERNAME, instance.ObjectMeta.Finalizers)
-			if err := r.Update(context.Background(), instance); err != nil {
-				return reconcile.Result{}, err
+			var found bool
+			instance.ObjectMeta.Finalizers, found = sriovnetworkv1.RemoveString(sriovnetworkv1.NETATTDEFFINALIZERNAME, instance.ObjectMeta.Finalizers)
+			if found {
+				if err := r.Update(context.Background(), instance); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		}
 		return reconcile.Result{}, err

--- a/controllers/sriovnetworkpoolconfig_controller.go
+++ b/controllers/sriovnetworkpoolconfig_controller.go
@@ -16,6 +16,7 @@ import (
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	render "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/render"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
+	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
@@ -86,15 +87,18 @@ func (r *SriovNetworkPoolConfigReconciler) Reconcile(ctx context.Context, req ct
 				}
 			}
 			// remove our finalizer from the list and update it.
-			instance.ObjectMeta.Finalizers = sriovnetworkv1.RemoveString(sriovnetworkv1.POOLCONFIGFINALIZERNAME, instance.ObjectMeta.Finalizers)
-			if err := r.Update(context.Background(), instance); err != nil {
-				return reconcile.Result{}, err
+			var found bool
+			instance.ObjectMeta.Finalizers, found = sriovnetworkv1.RemoveString(sriovnetworkv1.POOLCONFIGFINALIZERNAME, instance.ObjectMeta.Finalizers)
+			if found {
+				if err := r.Update(context.Background(), instance); err != nil {
+					return reconcile.Result{}, err
+				}
 			}
 		}
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{RequeueAfter: ResyncPeriod}, nil
+	return reconcile.Result{RequeueAfter: constants.ResyncPeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -108,7 +112,7 @@ func (r *SriovNetworkPoolConfigReconciler) syncOvsHardwareOffloadMachineConfigs(
 	logger := log.Log.WithName("syncOvsHardwareOffloadMachineConfigs")
 
 	mcpName := nc.Spec.OvsHardwareOffloadConfig.Name
-	mcName := "00-" + mcpName + "-" + OVS_HWOL_MACHINE_CONFIG_NAME_SUFFIX
+	mcName := "00-" + mcpName + "-" + constants.OVS_HWOL_MACHINE_CONFIG_NAME_SUFFIX
 
 	foundMC := &mcfgv1.MachineConfig{}
 	mcp := &mcfgv1.MachineConfigPool{}

--- a/controllers/sriovnetworkpoolconfig_controller_test.go
+++ b/controllers/sriovnetworkpoolconfig_controller_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 )
 
@@ -22,7 +23,7 @@ var _ = Describe("Operator", func() {
 			config.SetName("ovs-hw-offload-config")
 			mcpName := "worker"
 			mc := &mcfgv1.MachineConfig{}
-			mcName := "00-" + mcpName + "-" + OVS_HWOL_MACHINE_CONFIG_NAME_SUFFIX
+			mcName := "00-" + mcpName + "-" + constants.OVS_HWOL_MACHINE_CONFIG_NAME_SUFFIX
 			err := k8sClient.Get(goctx.TODO(), types.NamespacedName{Name: mcName, Namespace: testNamespace}, mc)
 			Expect(errors.IsNotFound(err)).Should(BeTrue())
 

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -39,6 +39,7 @@ import (
 	apply "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/apply"
 	render "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/render"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
+	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 )
 
 // SriovOperatorConfigReconciler reconciles a SriovOperatorConfig object
@@ -74,12 +75,12 @@ func (r *SriovOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.
 	}
 	defaultConfig := &sriovnetworkv1.SriovOperatorConfig{}
 	err := r.Get(context.TODO(), types.NamespacedName{
-		Name: DEFAULT_CONFIG_NAME, Namespace: namespace}, defaultConfig)
+		Name: constants.DEFAULT_CONFIG_NAME, Namespace: namespace}, defaultConfig)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Default Config object not found, create it.
 			defaultConfig.SetNamespace(namespace)
-			defaultConfig.SetName(DEFAULT_CONFIG_NAME)
+			defaultConfig.SetName(constants.DEFAULT_CONFIG_NAME)
 			defaultConfig.Spec = sriovnetworkv1.SriovOperatorConfigSpec{
 				EnableInjector:           func() *bool { b := enableAdmissionController; return &b }(),
 				EnableOperatorWebhook:    func() *bool { b := enableAdmissionController; return &b }(),
@@ -89,7 +90,7 @@ func (r *SriovOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.
 			err = r.Create(context.TODO(), defaultConfig)
 			if err != nil {
 				logger.Error(err, "Failed to create default Operator Config", "Namespace",
-					namespace, "Name", DEFAULT_CONFIG_NAME)
+					namespace, "Name", constants.DEFAULT_CONFIG_NAME)
 				return reconcile.Result{}, err
 			}
 			return reconcile.Result{}, nil
@@ -116,7 +117,7 @@ func (r *SriovOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{RequeueAfter: ResyncPeriod}, nil
+	return reconcile.Result{RequeueAfter: constants.ResyncPeriod}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -178,7 +179,7 @@ func (r *SriovOperatorConfigReconciler) syncConfigDaemonSet(dc *sriovnetworkv1.S
 		logger.Info("New cni bin found", "CNIBinPath", envCniBinPath)
 		data.Data["CNIBinPath"] = envCniBinPath
 	}
-	objs, err := render.RenderDir(CONFIG_DAEMON_PATH, &data)
+	objs, err := render.RenderDir(constants.CONFIG_DAEMON_PATH, &data)
 	if err != nil {
 		logger.Error(err, "Fail to render config daemon manifests")
 		return err
@@ -230,7 +231,7 @@ func (r *SriovOperatorConfigReconciler) syncWebhookObjs(dc *sriovnetworkv1.Sriov
 		}
 
 		// Delete injector webhook
-		if *dc.Spec.EnableInjector != true && path == INJECTOR_WEBHOOK_PATH {
+		if *dc.Spec.EnableInjector != true && path == constants.INJECTOR_WEBHOOK_PATH {
 			for _, obj := range objs {
 				err = r.deleteWebhookObject(obj)
 				if err != nil {
@@ -243,7 +244,7 @@ func (r *SriovOperatorConfigReconciler) syncWebhookObjs(dc *sriovnetworkv1.Sriov
 			continue
 		}
 		// Delete operator webhook
-		if *dc.Spec.EnableOperatorWebhook != true && path == OPERATOR_WEBHOOK_PATH {
+		if *dc.Spec.EnableOperatorWebhook != true && path == constants.OPERATOR_WEBHOOK_PATH {
 			for _, obj := range objs {
 				err = r.deleteWebhookObject(obj)
 				if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -41,6 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -151,7 +152,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	config := &sriovnetworkv1.SriovOperatorConfig{}
 	config.SetNamespace(testNamespace)
-	config.SetName(DEFAULT_CONFIG_NAME)
+	config.SetName(constants.DEFAULT_CONFIG_NAME)
 	config.Spec = sriovnetworkv1.SriovOperatorConfigSpec{
 		EnableInjector:           func() *bool { b := true; return &b }(),
 		EnableOperatorWebhook:    func() *bool { b := true; return &b }(),
@@ -162,7 +163,7 @@ var _ = BeforeSuite(func(done Done) {
 
 	poolConfig := &sriovnetworkv1.SriovNetworkPoolConfig{}
 	poolConfig.SetNamespace(testNamespace)
-	poolConfig.SetName(DEFAULT_CONFIG_NAME)
+	poolConfig.SetName(constants.DEFAULT_CONFIG_NAME)
 	poolConfig.Spec = sriovnetworkv1.SriovNetworkPoolConfigSpec{}
 	Expect(k8sClient.Create(context.TODO(), poolConfig)).Should(Succeed())
 	close(done)

--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func main() {
 	}()
 
 	// Remove all finalizers after controller is shut down
-	defer utils.Shutdown(mgr.GetClient())
+	defer utils.Shutdown()
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(stopCh); err != nil {

--- a/pkg/utils/constants.go
+++ b/pkg/utils/constants.go
@@ -1,0 +1,24 @@
+package utils
+
+import "time"
+
+const (
+	ResyncPeriod                        = 5 * time.Minute
+	DEFAULT_CONFIG_NAME                 = "default"
+	CONFIG_DAEMON_PATH                  = "./bindata/manifests/daemon"
+	INJECTOR_WEBHOOK_PATH               = "./bindata/manifests/webhook"
+	OPERATOR_WEBHOOK_PATH               = "./bindata/manifests/operator-webhook"
+	SERVICE_CA_CONFIGMAP_ANNOTATION     = "service.beta.openshift.io/inject-cabundle"
+	INJECTOR_WEBHOOK_NAME               = "network-resources-injector-config"
+	OPERATOR_WEBHOOK_NAME               = "sriov-operator-webhook-config"
+	DEPRECATED_OPERATOR_WEBHOOK_NAME    = "operator-webhook-config"
+	PLUGIN_PATH                         = "./bindata/manifests/plugins"
+	DAEMON_PATH                         = "./bindata/manifests/daemon"
+	DEFAULT_POLICY_NAME                 = "default"
+	CONFIGMAP_NAME                      = "device-plugin-config"
+	DP_CONFIG_FILENAME                  = "config.json"
+	OVS_HWOL_MACHINE_CONFIG_NAME_SUFFIX = "ovs-hw-offload"
+
+	LinkTypeEthernet   = "ether"
+	LinkTypeInfiniband = "infiniband"
+)

--- a/pkg/utils/shutdown.go
+++ b/pkg/utils/shutdown.go
@@ -3,28 +3,101 @@ package utils
 import (
 	"context"
 
+	snclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned"
+	admv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	conf "sigs.k8s.io/controller-runtime/pkg/client/config"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 )
 
-func Shutdown(c client.Client) {
-	shutdownLog := ctrl.Log.WithName("shutdown")
+var shutdownLog = ctrl.Log.WithName("shutdown")
+
+var sriovnetworksGVR = schema.GroupVersionResource{
+	Group:    "sriovnetwork.openshift.io",
+	Version:  "v1",
+	Resource: "sriovnetworks",
+}
+
+var failurePolicyIgnore = admv1.Ignore
+
+func Shutdown() {
+	updateFinalizers()
+	updateWebhooks()
+}
+
+func updateFinalizers() {
 	shutdownLog.Info("Clearing finalizers on exit")
-	networkList := &sriovnetworkv1.SriovNetworkList{}
-	err := c.List(context.TODO(), networkList)
+	c, err := snclientset.NewForConfig(conf.GetConfigOrDie())
+	if err != nil {
+		shutdownLog.Error(err, "Error creating client")
+	}
+	sriovNetworkClient := c.SriovnetworkV1()
+	networkList, err := sriovNetworkClient.SriovNetworks("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		shutdownLog.Error(err, "Failed to list SriovNetworks")
 	} else {
 		for _, instance := range networkList.Items {
-			shutdownLog.Info("Clearing finalizers on SriovNetwork ", "namespace", instance.GetNamespace(), "name", instance.GetName())
-			instance.ObjectMeta.Finalizers = sriovnetworkv1.RemoveString(sriovnetworkv1.NETATTDEFFINALIZERNAME, instance.ObjectMeta.Finalizers)
-			err := c.Update(context.TODO(), &instance)
+			if instance.ObjectMeta.Finalizers == nil || len(instance.ObjectMeta.Finalizers) == 0 {
+				continue
+			}
 			if err != nil {
-				shutdownLog.Error(err, "Failed to remove finalizer")
+				shutdownLog.Error(err, "Failed get finalizers map")
+			}
+			shutdownLog.Info("Clearing finalizers on SriovNetwork ", "namespace", instance.GetNamespace(), "name", instance.GetName())
+			var found bool
+			instance.ObjectMeta.Finalizers, found = sriovnetworkv1.RemoveString(sriovnetworkv1.NETATTDEFFINALIZERNAME, instance.ObjectMeta.Finalizers)
+			if found {
+				_, err = sriovNetworkClient.SriovNetworks(instance.GetNamespace()).Update(context.TODO(), &instance, metav1.UpdateOptions{})
+				if err != nil {
+					shutdownLog.Error(err, "Failed to remove finalizer")
+				}
 			}
 		}
 	}
 	shutdownLog.Info("Done clearing finalizers on exit")
+}
+
+func updateWebhooks() {
+	shutdownLog.Info("Seting webhook failure policies to Ignore on exit")
+	clientset, err := kubernetes.NewForConfig(conf.GetConfigOrDie())
+	if err != nil {
+		shutdownLog.Error(err, "Error getting client")
+	}
+	updateValidatingWebhook(clientset)
+	updateMutatingWebhooks(clientset)
+	shutdownLog.Info("Done seting webhook failure policies to Ignore")
+}
+
+func updateValidatingWebhook(c *kubernetes.Clientset) {
+	validatingWebhookClient := c.AdmissionregistrationV1().ValidatingWebhookConfigurations()
+	webhook, err := validatingWebhookClient.Get(context.TODO(), OPERATOR_WEBHOOK_NAME, metav1.GetOptions{})
+	if err != nil {
+		shutdownLog.Error(err, "Error getting webhook")
+	}
+	webhook.Webhooks[0].FailurePolicy = &failurePolicyIgnore
+	_, err = validatingWebhookClient.Update(context.TODO(), webhook, metav1.UpdateOptions{})
+	if err != nil {
+		shutdownLog.Error(err, "Error updating webhook")
+	}
+}
+
+func updateMutatingWebhooks(c *kubernetes.Clientset) {
+	mutatingWebhookClient := c.AdmissionregistrationV1().MutatingWebhookConfigurations()
+	for _, name := range []string{OPERATOR_WEBHOOK_NAME, INJECTOR_WEBHOOK_NAME} {
+		mutatingWebhook, err := mutatingWebhookClient.Get(context.TODO(), name, metav1.GetOptions{})
+		if err != nil {
+			shutdownLog.Error(err, "Error getting webhook")
+			continue
+		}
+		mutatingWebhook.Webhooks[0].FailurePolicy = &failurePolicyIgnore
+		_, err = mutatingWebhookClient.Update(context.TODO(), mutatingWebhook, metav1.UpdateOptions{})
+		if err != nil {
+			shutdownLog.Error(err, "Error updating webhook")
+		}
+	}
 }


### PR DESCRIPTION
This PR sets the failurePolicy of sriov webhooks to Ignore when an operator pod is exiting. This ensures that the policy does not cause incoming resources to fail when the sriov pods are down. The policy is changed to back to Fail on the next sriovconfig reconciliation loop (for example when the controller pod is started again).

The PR also changes the kubernetes API used in the shutdown function from the controller-runtime api to the basic client-go api.
This is due issues with the controller api during the controller shutdown. It was noticed that the api calls sometimes failed due to Informer not able to sync, probably caused by the manager being closed before the shutdown function was invoked.