### PR TITLE
Add support for vhost-net device mount

### DIFF
--- a/api/v1/sriovnetworknodepolicy_types.go
+++ b/api/v1/sriovnetworknodepolicy_types.go
@@ -46,6 +46,8 @@ type SriovNetworkNodePolicySpec struct {
 	DeviceType string `json:"deviceType,omitempty"`
 	// RDMA mode. Defaults to false.
 	IsRdma bool `json:"isRdma,omitempty"`
+	// mount vhost-net device. Defaults to false.
+	NeedVhostNet bool `json:"needVhostNet,omitempty"`
 	// +kubebuilder:validation:Enum=eth;ETH;ib;IB
 	// NIC Link Type. Allowed value "eth", "ETH", "ib", and "IB".
 	LinkType string `json:"linkType,omitempty"`

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -66,6 +66,9 @@ spec:
                 description: MTU of VF
                 minimum: 1
                 type: integer
+              needVhostNet:
+                description: mount vhost-net device. Defaults to false.
+                type: boolean
               nicSelector:
                 description: NicSelector selects the NICs to be configured
                 properties:

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -654,6 +654,7 @@ func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(pl *srio
 				ResourceName: p.Spec.ResourceName,
 			}
 			netDeviceSelectors.IsRdma = p.Spec.IsRdma
+			netDeviceSelectors.NeedVhostNet = p.Spec.NeedVhostNet
 
 			if p.Spec.NicSelector.Vendor != "" {
 				netDeviceSelectors.Vendors = append(netDeviceSelectors.Vendors, p.Spec.NicSelector.Vendor)

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -66,6 +66,9 @@ spec:
                 description: MTU of VF
                 minimum: 1
                 type: integer
+              needVhostNet:
+                description: mount vhost-net device. Defaults to false.
+                type: boolean
               nicSelector:
                 description: NicSelector selects the NICs to be configured
                 properties:


### PR DESCRIPTION
This commit adds support to the sriov-network-operator to request from the sriov-device-plugin to mount the /dev/vhost-net device into the container.

Signed-off-by: Sebastian Sch <sebassch@gmail.com>