### PR TITLE
Do not set DpConfigVersion for node state by default

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -270,7 +270,6 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(np *sriovne
 	if err != nil {
 		logger.Info("Fail to get SriovNetworkNodeState", "namespace", ns.Namespace, "name", ns.Name)
 		if errors.IsNotFound(err) {
-			ns.Spec.DpConfigVersion = cksum
 			err = r.Create(context.TODO(), ns)
 			if err != nil {
 				return fmt.Errorf("Couldn't create SriovNetworkNodeState: %v", err)


### PR DESCRIPTION
DpConfigVersion is needed only if node policy is created and node
state contains interfaces spec.

If we set DpConfigVersion for an empty node state it will lead to
unexpected behaviour after node reboot durin SR-IOV enabling:
device config daemon will ignore new state and won't apply it to
the node.