### PR TITLE
Ignore not found resources during uninstallation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ install: manifests kustomize
 
 # Uninstall CRDs from a cluster
 uninstall: manifests kustomize
-	$(KUSTOMIZE) build config/crd | kubectl delete -f -
+	$(KUSTOMIZE) build config/crd | kubectl --ignore-not-found delete -f -
 
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 # deploy: manifests kustomize


### PR DESCRIPTION
Ignore not found resources during uninstallation. 
Other dependencies such as make undeploy will be able to run even if
a specific resource was not found for uninstallation.

Signed-off-by: Andreas Karis <ak.karis@gmail.com>