### PR TITLE
Use systemd service to set numVFs for BF-2

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -131,7 +131,6 @@ github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA
 github.com/certifi/gocertifi v0.0.0-20180905225744-ee1a9a0726d2/go.mod h1:GJKEexRPVJrBSOjoqN5VNOIKJ5Q3RViH6eu3puDRwx4=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
-github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
 github.com/cespare/xxhash/v2 v2.1.2/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=

--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -170,10 +170,6 @@ func needDrainNode(desired sriovnetworkv1.Interfaces, current sriovnetworkv1.Int
 		for _, iface := range desired {
 			if iface.PciAddress == ifaceStatus.PciAddress {
 				configured = true
-				if iface.EswitchMode == sriovnetworkv1.ESWITCHMODE_SWITCHDEV {
-					// ignore swichdev device
-					break
-				}
 				if ifaceStatus.NumVfs != 0 {
 					if iface.NumVfs != ifaceStatus.NumVfs {
 						glog.V(2).Infof("generic-plugin needDrainNode(): need drain, expect NumVfs %v, current NumVfs %v", iface.NumVfs, ifaceStatus.NumVfs)
@@ -213,15 +209,13 @@ func needRebootNode(state *sriovnetworkv1.SriovNetworkNodeState, loadVfioDriver 
 		}
 	}
 
-	if utils.IsSwitchdevModeSpec(state.Spec) {
-		update, err := utils.WriteSwitchdevConfFile(state)
-		if err != nil {
-			glog.Errorf("generic-plugin needRebootNode(): fail to write switchdev device config file")
-		}
-		if update {
-			glog.V(2).Infof("generic-plugin needRebootNode(): need reboot for updating switchdev device configuration")
-		}
-		needReboot = needReboot || update
+	update, err := utils.WriteSwitchdevConfFile(state)
+	if err != nil {
+		glog.Errorf("generic-plugin needRebootNode(): fail to write switchdev device config file")
 	}
+	if update {
+		glog.V(2).Infof("generic-plugin needRebootNode(): need reboot for updating switchdev device configuration")
+	}
+	needReboot = needReboot || update
 	return
 }

--- a/pkg/utils/switchdev.go
+++ b/pkg/utils/switchdev.go
@@ -29,9 +29,37 @@ func IsSwitchdevModeSpec(spec sriovnetworkv1.SriovNetworkNodeStateSpec) bool {
 }
 
 func WriteSwitchdevConfFile(newState *sriovnetworkv1.SriovNetworkNodeState) (update bool, err error) {
+	cfg := config{}
+	for _, iface := range newState.Spec.Interfaces {
+		for _, ifaceStatus := range newState.Status.Interfaces {
+			if iface.PciAddress != ifaceStatus.PciAddress {
+				continue
+			}
+			if !SkipConfigVf(iface, ifaceStatus) {
+				continue
+			}
+			i := sriovnetworkv1.Interface{}
+			if iface.NumVfs > 0 {
+				i = sriovnetworkv1.Interface{
+					// Not passing all the contents, since only NumVfs and EswitchMode can be configured by configure-switchdev.sh currently.
+					Name:       iface.Name,
+					PciAddress: iface.PciAddress,
+					NumVfs:     iface.NumVfs,
+				}
+
+				if iface.EswitchMode == sriovnetworkv1.ESWITCHMODE_SWITCHDEV {
+					i.EswitchMode = iface.EswitchMode
+				}
+				cfg.Interfaces = append(cfg.Interfaces, i)
+			}
+		}
+	}
 	_, err = os.Stat(switchDevConfPath)
 	if err != nil {
 		if os.IsNotExist(err) {
+			if len(cfg.Interfaces) == 0 {
+				return
+			}
 			glog.V(2).Infof("WriteSwitchdevConfFile(): file not existed, create it")
 			_, err = os.Create(switchDevConfPath)
 			if err != nil {
@@ -42,35 +70,26 @@ func WriteSwitchdevConfFile(newState *sriovnetworkv1.SriovNetworkNodeState) (upd
 			return
 		}
 	}
-	cfg := config{}
-	for _, iface := range newState.Spec.Interfaces {
-		if iface.EswitchMode == sriovnetworkv1.ESWITCHMODE_SWITCHDEV {
-			// Not passing all the contents, since only NumVfs and EswitchMode can be configured by configure-switchdev.sh currently.
-			i := sriovnetworkv1.Interface{
-				Name:        iface.Name,
-				PciAddress:  iface.PciAddress,
-				EswitchMode: iface.EswitchMode,
-				NumVfs:      iface.NumVfs,
-			}
-			cfg.Interfaces = append(cfg.Interfaces, i)
-		}
-	}
 	oldContent, err := ioutil.ReadFile(switchDevConfPath)
 	if err != nil {
 		glog.Errorf("WriteSwitchdevConfFile(): fail to read file: %v", err)
 		return
 	}
-	newContent, err := json.Marshal(cfg)
-	if err != nil {
-		glog.Errorf("WriteSwitchdevConfFile(): fail to marshal config: %v", err)
-		return
+	var newContent []byte
+	if len(cfg.Interfaces) != 0 {
+		newContent, err = json.Marshal(cfg)
+		if err != nil {
+			glog.Errorf("WriteSwitchdevConfFile(): fail to marshal config: %v", err)
+			return
+		}
 	}
+
 	if bytes.Equal(newContent, oldContent) {
 		glog.V(2).Info("WriteSwitchdevConfFile(): no update")
 		return
 	}
 	update = true
-	glog.V(2).Infof("WriteSwitchdevConfFile(): write %s to switchdev.conf", newContent)
+	glog.V(2).Infof("WriteSwitchdevConfFile(): write '%s' to switchdev.conf", newContent)
 	err = ioutil.WriteFile(switchDevConfPath, []byte(newContent), 0644)
 	if err != nil {
 		glog.Errorf("WriteSwitchdevConfFile(): fail to write file: %v", err)


### PR DESCRIPTION
To enable OVN hardware offloading with BlueField-2, VFs shall be
created before ovnkube-node running in dpu-host mode starts.