### PR TITLE
Add switchdev-configuration-after-NM service

### DIFF
--- a/bindata/manifests/switchdev-config/files/switchdev-configuration-after-NM.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/switchdev-configuration-after-NM.sh.yaml
@@ -1,0 +1,35 @@
+mode: 0755
+overwrite: true
+path: "/usr/local/bin/switchdev-configuration-after-NM.sh"
+contents:
+  inline: |
+    #!/bin/bash
+    set -eux
+    input="/etc/sriov_config.json"
+
+    if [ ! -f $input ]; then
+      echo "File /etc/sriov_config.json not exist."
+      exit
+    fi
+
+    # Required for NetworkManager configuration(e.g. bond) to settle down
+    sleep 3
+
+    jq -c '.interfaces[]' $input | while read iface;
+    do
+      eswitch_mode=$(echo $iface | jq '.eSwitchMode' -r)
+      if [[ "$eswitch_mode" == "switchdev" ]]; then
+        pci_addr=$(echo $iface | jq '.pciAddress' -r)
+        name=$(echo $iface | jq '.name' -r)
+
+        echo "load VF driver for $pci_addr"
+        VfDirs=$(ls /sys/bus/pci/devices/${pci_addr} | grep virtfn)
+
+        # load VF driver
+        for VfDir in $VfDirs
+        do
+          VfPciAddr=$(basename "$( readlink -f /sys/bus/pci/devices/${pci_addr}/$VfDir )")
+          echo $VfPciAddr > /sys/bus/pci/drivers_probe
+        done
+      fi
+    done

--- a/bindata/manifests/switchdev-config/files/switchdev-configuration-before-NM.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/switchdev-configuration-before-NM.sh.yaml
@@ -1,6 +1,6 @@
 mode: 0755
 overwrite: true
-path: "/usr/local/bin/configure-switchdev.sh"
+path: "/usr/local/bin/switchdev-configuration-before-NM.sh"
 contents:
   inline: |
     #!/bin/bash
@@ -72,12 +72,5 @@ contents:
 
         # turn hw-tc-offload on
         /usr/sbin/ethtool -K ${name} hw-tc-offload on
-
-        # load VF driver
-        for VfDir in $VfDirs
-        do
-          VfPciAddr=$(basename "$( readlink -f /sys/bus/pci/devices/${pci_addr}/$VfDir )")
-          echo $VfPciAddr > /sys/bus/pci/drivers_probe
-        done
       fi
     done

--- a/bindata/manifests/switchdev-config/switchdev-units/NetworkManager.service.yaml
+++ b/bindata/manifests/switchdev-config/switchdev-units/NetworkManager.service.yaml
@@ -3,5 +3,5 @@ dropins:
 - name: 10-switchdev.conf
   contents: |
     [Unit]
-    Wants=switchdev-configuration.service
-    After=switchdev-configuration.service
+    Wants=switchdev-configuration-before-NM.service
+    After=switchdev-configuration-before-NM.service

--- a/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-after-NM.yaml
+++ b/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-after-NM.yaml
@@ -1,0 +1,19 @@
+contents: |
+  [Unit]
+  Description=Binds SRIOV VFs to switchdev driver
+  # Removal of this file signals firstboot completion
+  ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
+  # This service is used to rebind SR-IOV netdev driver after switchdev and NetworkManager configurations
+  Wants=NetworkManager.service
+  After=NetworkManager.service
+
+  [Service]
+  Type=oneshot
+  ExecStart=/usr/local/bin/switchdev-configuration-after-NM.sh
+  StandardOutput=journal+console
+  StandardError=journal+console
+
+  [Install]
+  WantedBy=network-online.target
+enabled: true
+name: switchdev-configuration-after-NM.service

--- a/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-before-NM.yaml
+++ b/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-before-NM.yaml
@@ -1,19 +1,19 @@
 contents: |
   [Unit]
-  Description=Configures SRIOV NIC into switchdev mode
+  Description=Configures SRIOV NIC to switchdev mode
   # Removal of this file signals firstboot completion
   ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
-  # This service is used to move a SRIOV NIC into switchdev mode
+  # This service is used to move a SRIOV NIC to switchdev mode
   Wants=network-pre.target
   Before=network-pre.target
 
   [Service]
   Type=oneshot
-  ExecStart=/usr/local/bin/configure-switchdev.sh
+  ExecStart=/usr/local/bin/switchdev-configuration-before-NM.sh
   StandardOutput=journal+console
   StandardError=journal+console
 
   [Install]
   WantedBy=network-online.target
 enabled: true
-name: switchdev-configuration.service
+name: switchdev-configuration-before-NM.service


### PR DESCRIPTION
Switchdev-configuration-after-NM service rebinds VF to its
driver and executes after NetworkManager service, this is
required for features such as VF LAG to take effect when
bond or other network configurtion are configured through
NetworkManager service.

Signed-off-by: Zenghui Shi <zshi@redhat.com>