### PR TITLE
Load tun kernel module

### DIFF
--- a/bindata/scripts/load-kmod.sh
+++ b/bindata/scripts/load-kmod.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # chroot /host/ modprobe $1
 kmod_name=$(tr "-" "_" <<< $1)
-chroot /host/ lsmod | grep $1 >& /dev/null
+chroot /host/ lsmod | grep "^$1" >& /dev/null
 
 if [ $? -eq 0 ]
 then

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -231,6 +231,7 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 	defer dn.workqueue.ShutDown()
 
 	tryEnableRdma()
+	tryEnableTun()
 
 	if err := sriovnetworkv1.InitNicIdMap(dn.kubeClient, namespace); err != nil {
 		return err
@@ -940,6 +941,12 @@ func registerPlugins(ns *sriovnetworkv1.SriovNetworkNodeState) []string {
 		nameList[i] = rawList[i].String()
 	}
 	return nameList
+}
+
+func tryEnableTun() {
+	if err := utils.LoadKernelModule("tun"); err != nil {
+		glog.Errorf("tryEnableTun(): TUN kernel module not loaded: %v", err)
+	}
 }
 
 func tryEnableRdma() (bool, error) {


### PR DESCRIPTION
The sriov-network-config-daemon will try to load the tun kernel driver when started

This PR is needed to continue to the PR merged in the sriov-device-plugin to allow the mount of tun device inside the container to create TAP devices.

The TAP devices are in use by dpdk applications that want to interact using a slow path with the Linux kernel networking.