### PR TITLE
Remove SriovNetworkNodeConfigPolicy from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The SR-IOV network operator introduces following new CRDs:
 
 - SriovNetworkNodeState
 
-- SriovNetworkNodeConfigPolicy
+- SriovNetworkNodePolicy
 
 ### SriovNetwork
 
@@ -108,7 +108,7 @@ The custom resource to represent the SR-IOV interface states of each host, which
 - The ‘spec’ of this CR represents the desired configuration which should be applied to the interfaces and SR-IOV device plugin.
 - The ‘status’ contains current states of those PFs (baremetal only), and the states of the VFs. It helps user to discover SR-IOV network hardware on node, or attached VFs in the case of a virtual deployment.
 
-The spec is rendered by sriov-policy-controller, and consumed by sriov-config-daemon. Sriov-config-daemon is responsible for updating the ‘status’ field to reflect the latest status, this information can be used as input to create SriovNetworkNodeConfigPolicy CR.
+The spec is rendered by sriov-policy-controller, and consumed by sriov-config-daemon. Sriov-config-daemon is responsible for updating the ‘status’ field to reflect the latest status, this information can be used as input to create SriovNetworkNodePolicy CR.
 
 An example of SriovNetworkNodeState CR:
 
@@ -158,9 +158,9 @@ status:
     vendor: "8086"
 ```
 
-From this example, in status field, the user can find out there are 2 SRIOV capable NICs on node 'work-node-1'; in spec field, user can learn what the expected configure is generated from the combination of SriovNetworkNodeConfigPolicy CRs.  In the virtual deployment case, a single VF will be associated with each device.
+From this example, in status field, the user can find out there are 2 SRIOV capable NICs on node 'work-node-1'; in spec field, user can learn what the expected configure is generated from the combination of SriovNetworkNodePolicy CRs.  In the virtual deployment case, a single VF will be associated with each device.
 
-### SriovNetworkNodeConfigPolicy
+### SriovNetworkNodePolicy
 
 This CRD is the key of SR-IOV network operator. This custom resource should be managed by cluster admin, to instruct the operator to:
 
@@ -168,7 +168,7 @@ This CRD is the key of SR-IOV network operator. This custom resource should be m
 2. Deploy SR-IOV CNI plugin and device plugin on selected node.
 3. Generate the configuration of SR-IOV device plugin.
 
-An example of SriovNetworkNodeConfigPolicy CR:
+An example of SriovNetworkNodePolicy CR:
 
 ```yaml
 apiVersion: sriovnetwork.openshift.io/v1
@@ -207,7 +207,7 @@ This operator is split into 2 components:
 
 The controller is responsible for:
 
-1. Read the SriovNetworkNodeConfigPolicy CRs and SriovNetwork CRs as input.
+1. Read the SriovNetworkNodePolicy CRs and SriovNetwork CRs as input.
 2. Render the manifests for SR-IOV CNI plugin and device plugin daemons.
 3. Render the spec of SriovNetworkNodeState CR for each node.
 


### PR DESCRIPTION
While going through the documentation I found that README.md was referring the type `SriovNetworkNodeConfigPolicy`, but the correct name of the CR is `SriovNetworkNodePolicy`.

Let me know if I got wrong while interpreting the docs.

Regards,