### PR TITLE
Ensure switchdev service dependencies

### DIFF
--- a/bindata/manifests/switchdev-config/files/switchdev-configuration-after-nm.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/switchdev-configuration-after-nm.sh.yaml
@@ -1,6 +1,6 @@
 mode: 0755
 overwrite: true
-path: "/usr/local/bin/switchdev-configuration-after-NM.sh"
+path: "/usr/local/bin/switchdev-configuration-after-nm.sh"
 contents:
   inline: |
     #!/bin/bash

--- a/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
@@ -1,6 +1,6 @@
 mode: 0755
 overwrite: true
-path: "/usr/local/bin/switchdev-configuration-before-NM.sh"
+path: "/usr/local/bin/switchdev-configuration-before-nm.sh"
 contents:
   inline: |
     #!/bin/bash

--- a/bindata/manifests/switchdev-config/switchdev-units/NetworkManager.service.yaml
+++ b/bindata/manifests/switchdev-config/switchdev-units/NetworkManager.service.yaml
@@ -3,5 +3,7 @@ dropins:
 - name: 10-switchdev.conf
   contents: |
     [Unit]
-    Wants=switchdev-configuration-before-NM.service
-    After=switchdev-configuration-before-NM.service
+    Wants=switchdev-configuration-before-nm.service
+    Wants=switchdev-configuration-after-nm.service
+    After=switchdev-configuration-before-nm.service
+    Before=switchdev-configuration-after-nm.service

--- a/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-after-nm.yaml
+++ b/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-after-nm.yaml
@@ -9,11 +9,11 @@ contents: |
 
   [Service]
   Type=oneshot
-  ExecStart=/usr/local/bin/switchdev-configuration-after-NM.sh
+  ExecStart=/usr/local/bin/switchdev-configuration-after-nm.sh
   StandardOutput=journal+console
   StandardError=journal+console
 
   [Install]
   WantedBy=network-online.target
 enabled: true
-name: switchdev-configuration-after-NM.service
+name: switchdev-configuration-after-nm.service

--- a/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-before-nm.yaml
+++ b/bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-before-nm.yaml
@@ -9,11 +9,11 @@ contents: |
 
   [Service]
   Type=oneshot
-  ExecStart=/usr/local/bin/switchdev-configuration-before-NM.sh
+  ExecStart=/usr/local/bin/switchdev-configuration-before-nm.sh
   StandardOutput=journal+console
   StandardError=journal+console
 
   [Install]
   WantedBy=network-online.target
 enabled: true
-name: switchdev-configuration-before-NM.service
+name: switchdev-configuration-before-nm.service


### PR DESCRIPTION
It is found that VF netdev disappears after it was successfully
created (observed via ip link show). While investigating the root
cause, setting addtional dependency in NetworkManager.service
as temporary fix to the issue.

This commits also changes service and script names to lower case

Signed-off-by: Zenghui Shi <zshi@redhat.com>