### PR TITLE
Add Dockerfiles with Go 1.17 and CentOS Stream 9

### DIFF
--- a/.github/workflows/pr-ci-build-container-images-cs9.yml
+++ b/.github/workflows/pr-ci-build-container-images-cs9.yml
@@ -1,0 +1,86 @@
+name: "Test build of CentOS Stream 9 based container images"
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  test-build-image-operator:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sriov-network-operator
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+          file: ./Dockerfile
+
+  test-build-image-config-daemon:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-config-daemon
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sriov-network-operator-config-daemon
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+          file: ./Dockerfile.sriov-network-config-daemon
+
+  test-build-image-webhook:
+    runs-on: ubuntu-20.04
+    env:
+      IMAGE_NAME: ghcr.io/${{ github.repository }}-webhook
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push sriov-network-operator-webhook
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: false
+          tags: |
+            ${{ env.IMAGE_NAME }}:latest
+          file: ./Dockerfile.webhook

--- a/Dockerfile.el9
+++ b/Dockerfile.el9
@@ -1,0 +1,10 @@
+FROM golang:1.17 AS builder
+WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
+COPY . .
+RUN make _build-manager BIN_PATH=build/_output/cmd
+
+FROM centos:stream9
+COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/manager /usr/bin/sriov-network-operator
+COPY bindata /bindata
+ENV OPERATOR_NAME=sriov-network-operator
+CMD ["/usr/bin/sriov-network-operator"]

--- a/Dockerfile.sriov-network-config-daemon.el9
+++ b/Dockerfile.sriov-network-config-daemon.el9
@@ -1,0 +1,16 @@
+FROM golang:1.17 AS builder
+WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
+COPY . .
+RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
+RUN make plugins BIN_PATH=build/_output/pkg
+
+FROM centos:stream9
+ARG MSTFLINT=mstflint
+RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && yum -y install hwdata $ARCH_DEP_PKGS && yum clean all
+LABEL io.k8s.display-name="sriov-network-config-daemon" \
+      io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
+COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/
+COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/pkg/plugins /plugins
+COPY bindata /bindata
+ENV PLUGINSPATH=/plugins
+CMD ["/usr/bin/sriov-network-config-daemon"]

--- a/Dockerfile.webhook.el9
+++ b/Dockerfile.webhook.el9
@@ -1,0 +1,10 @@
+FROM golang:1.17 AS builder
+WORKDIR /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator
+COPY . .
+RUN make _build-webhook BIN_PATH=build/_output/cmd
+
+FROM centos:stream9
+LABEL io.k8s.display-name="sriov-network-webhook" \
+      io.k8s.description="This is an admission controller webhook that mutates and validates customer resources of sriov network operator."
+COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/webhook /usr/bin/webhook
+CMD ["/usr/bin/webhook"]


### PR DESCRIPTION
The current version of Go is 1.17, so this allows validating that the
build chain works with this new version. It also introduces the CentOS
Stream 9 base image for the final image. This allows checking future
releases of Red Hat Enterprise Linux 9 ahead of time.

Signed-off-by: Fabien Dupont <fabiendupont@pm.me>