### PR TITLE
Continue node drain after reboot

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -498,20 +498,23 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	}
 
 	if reqDrain {
-		if !dn.disableDrain {
-			ctx, cancel := context.WithCancel(context.TODO())
-			defer cancel()
+		if !dn.isNodeDraining() {
+			if !dn.disableDrain {
+				ctx, cancel := context.WithCancel(context.TODO())
+				defer cancel()
 
-			glog.Infof("nodeStateSyncHandler(): get drain lock for sriov daemon")
-			done := make(chan bool)
-			go dn.getDrainLock(ctx, done)
-			<-done
-		}
+				glog.Infof("nodeStateSyncHandler(): get drain lock for sriov daemon")
+				done := make(chan bool)
+				go dn.getDrainLock(ctx, done)
+				<-done
 
-		if utils.ClusterType == utils.ClusterTypeOpenshift {
-			glog.Infof("nodeStateSyncHandler(): pause MCP")
-			if err := dn.pauseMCP(); err != nil {
-				return err
+			}
+
+			if utils.ClusterType == utils.ClusterTypeOpenshift {
+				glog.Infof("nodeStateSyncHandler(): pause MCP")
+				if err := dn.pauseMCP(); err != nil {
+					return err
+				}
 			}
 		}
 
@@ -545,12 +548,12 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 		glog.Errorf("nodeStateSyncHandler(): fail to restart device plugin pod: %v", err)
 		return err
 	}
-	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == annoDraining || anno == annoMcpPaused) {
+	if dn.isNodeDraining() {
 		if err := dn.completeDrain(); err != nil {
 			glog.Errorf("nodeStateSyncHandler(): failed to complete draining: %v", err)
 			return err
 		}
-	} else if !ok {
+	} else {
 		if err := dn.annotateNode(dn.name, annoIdle); err != nil {
 			glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
 			return err
@@ -565,6 +568,13 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	// wait for writer to refresh the status
 	<-dn.syncCh
 	return nil
+}
+
+func (dn *Daemon) isNodeDraining() bool {
+	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == annoDraining || anno == annoMcpPaused) {
+		return true
+	}
+	return false
 }
 
 func (dn *Daemon) completeDrain() error {
@@ -810,7 +820,7 @@ func (dn *Daemon) getDrainLock(ctx context.Context, done chan bool) {
 						done <- true
 						return
 					}
-					glog.V(3).Info("getDrainLock(): other node is draining, wait...")
+					glog.V(2).Info("getDrainLock(): other node is draining, wait...")
 				}
 			},
 			OnStoppedLeading: func() {

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -554,9 +554,11 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 			return err
 		}
 	} else {
-		if err := dn.annotateNode(dn.name, annoIdle); err != nil {
-			glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
-			return err
+		if !dn.nodeHasAnnotation(annoKey, annoIdle) {
+			if err := dn.annotateNode(dn.name, annoIdle); err != nil {
+				glog.Errorf("nodeStateSyncHandler(): failed to annotate node: %v", err)
+				return err
+			}
 		}
 	}
 	glog.Info("nodeStateSyncHandler(): sync succeeded")
@@ -568,6 +570,14 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 	// wait for writer to refresh the status
 	<-dn.syncCh
 	return nil
+}
+
+func (dn *Daemon) nodeHasAnnotation(annoKey string, value string) bool {
+	// Check if node already contains annotation
+	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == value) {
+		return true
+	}
+	return false
 }
 
 func (dn *Daemon) isNodeDraining() bool {


### PR DESCRIPTION
Since drain operation started we don't need to requires
drain lock for this node because node already has required
annotation.

It's safe to continue node drain procedure without lock.

Closes: #230

Signed-off-by: Ivan Kolodyazhny <ikolodiazhny@nvidia.com>