### PR TITLE
Do not skip VFs configuration for BlueField 2 NICs in legacy mode

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -36,7 +36,6 @@ const (
 	ClusterTypeOpenshift  = "openshift"
 	ClusterTypeKubernetes = "kubernetes"
 	VendorMellanox        = "15b3"
-	DeviceBF2             = "a2d6"
 )
 
 var InitialState sriovnetworkv1.SriovNetworkNodeState
@@ -173,15 +172,10 @@ func SyncNodeState(newState *sriovnetworkv1.SriovNetworkNodeState) error {
 	return nil
 }
 
-// skip config VF for switchdev mode or BF-2 NICs
+// SkipConfigVf for switchdev mode or BF-2 NICs
 func SkipConfigVf(ifSpec sriovnetworkv1.Interface, ifStatus sriovnetworkv1.InterfaceExt) bool {
 	if ifSpec.EswitchMode == sriovnetworkv1.ESWITCHMODE_SWITCHDEV {
 		glog.V(2).Infof("SkipConfigVf(): skip config VF for switchdev device")
-		return true
-	}
-	// Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx
-	if ifStatus.Vendor == VendorMellanox && ifStatus.DeviceID == DeviceBF2 {
-		glog.V(2).Infof("SkipConfigVf(): skip config VF for BF2 device")
 		return true
 	}
 	return false


### PR DESCRIPTION
Let's configure VFs for BlueField 2 NICs in legacy mode if user
wants to use these NICs in a such way.

Signed-off-by: Ivan Kolodyazhny <ikolodiazhny@nvidia.com>