### PR TITLE
webhook: relax NIC validation when using NetFilter selector

### DIFF
--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -260,11 +260,15 @@ func keys(m map[string]([]string)) []string {
 }
 
 func validateNicModel(selector *sriovnetworkv1.SriovNetworkNicSelector, iface *sriovnetworkv1.InterfaceExt, node *corev1.Node) bool {
-	if selector.Vendor != "" && selector.Vendor != iface.Vendor {
-		return false
-	}
-	if selector.DeviceID != "" && selector.DeviceID != iface.DeviceID {
-		return false
+	// Assume that when NetFilter is set, we don't require a Vendor or a DeviceID
+	// since the device will be found by the NetFilter in the node.
+	if selector.NetFilter == "" {
+		if selector.Vendor != "" && selector.Vendor != iface.Vendor {
+			return false
+		}
+		if selector.DeviceID != "" && selector.DeviceID != iface.DeviceID {
+			return false
+		}
 	}
 	if len(selector.RootDevices) > 0 && !sriovnetworkv1.StringInArray(iface.PciAddress, selector.RootDevices) {
 		return false


### PR DESCRIPTION
When using NetFilter (for virtualized platforms), we do not provide a
DeviceID or a Vendor into the NIC selector. It's being figured out when
matching the network and the interface on the host.

So let's not fail early and let the validation process to continue,
later there is a function that tests if the VF is valid anyway.