### PR TITLE
Fix BlueField2 SR-IOV configuration

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -173,14 +173,14 @@ func SyncNodeState(newState *sriovnetworkv1.SriovNetworkNodeState) error {
 	return nil
 }
 
-// skip config VF for switchdev mode or BF-2 NICs
+// SkipConfigVf Use systemd service to configure switchdev mode or BF-2 NICs in OpenShift
 func SkipConfigVf(ifSpec sriovnetworkv1.Interface, ifStatus sriovnetworkv1.InterfaceExt) bool {
 	if ifSpec.EswitchMode == sriovnetworkv1.ESWITCHMODE_SWITCHDEV {
 		glog.V(2).Infof("SkipConfigVf(): skip config VF for switchdev device")
 		return true
 	}
-	// Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx
-	if ifStatus.Vendor == VendorMellanox && ifStatus.DeviceID == DeviceBF2 {
+	// Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx in OpenShift
+	if ClusterType == ClusterTypeOpenshift && ifStatus.Vendor == VendorMellanox && ifStatus.DeviceID == DeviceBF2 {
 		glog.V(2).Infof("SkipConfigVf(): skip config VF for BF2 device")
 		return true
 	}


### PR DESCRIPTION
This patch fixes current behaviour for BF2 NICs to configure
SR-IOV VFs in vanilla Kubernetes cluster.

PR https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/201 broke BF2 NICs configration in Kubernetes. It assumes
that BF2 will be configured via systemd service in OpenShift
using MachineConfigPool object.

Signed-off-by: Ivan Kolodyazhny <ikolodiazhny@nvidia.com>