### PR TITLE
Automate network-resources-injector-secret deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,9 @@ export WATCH_NAMESPACE?=openshift-sriov-network-operator
 export GOFLAGS+=-mod=vendor
 export GO111MODULE=on
 PKGS=$(shell go list ./... | grep -v -E '/vendor/|/test|/examples')
+# github.com/jetstack/cert-manager latest version
+export CERT_MANAGER_VERSION?=v1.7.0
+export ENABLE_CERT_MANAGER?=true
 
 # go source files, ignore vendor directory
 SRC = $(shell find . -type f -name '*.go' -not -path "./vendor/*")

--- a/deploy/cert-manager.yaml
+++ b/deploy/cert-manager.yaml
@@ -1,0 +1,31 @@
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: sriov-network-operator-selfsigned-issuer
+  namespace: $NAMESPACE
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: operator-webhook-service
+  namespace: $NAMESPACE
+spec:
+  secretName: operator-webhook-service
+  dnsNames:
+  - operator-webhook-service.sriov-network-operator.svc
+  issuerRef:
+    name: sriov-network-operator-selfsigned-issuer
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: network-resources-injector-service
+  namespace: $NAMESPACE
+spec:
+  secretName: network-resources-injector-secret
+  dnsNames:
+  - network-resources-injector-service.sriov-network-operator.svc
+  issuerRef:
+    name: sriov-network-operator-selfsigned-issuer

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -58,54 +58,13 @@ Webhooks are disabled when deploying on a Kubernetes cluster as per the instruct
    kubectl -n sriov-network-operator create secret tls operator-webhook-service --cert=cert.pem --key=key.pem
    kubectl -n sriov-network-operator create secret tls network-resources-injector-secret --cert=cert.pem --key=key.pem
    export ENABLE_ADMISSION_CONTROLLER=true
+   export ENABLE_CERT_MANAGER=false
    export WEBHOOK_CA_BUNDLE=$(base64 -w 0 < cacert.pem)
    make deploy-setup-k8s
    ```
 
 2. Using https://cert-manager.io/, deploy it as:
-   ```bash
-   kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.3.0/cert-manager.yaml
-   ```
 
-   Define the appropriate Issuer and Certificates, as an example:
-   ```bash
-   kubectl create ns sriov-network-operator
-   cat <<EOF | kubectl apply -f -
-   apiVersion: cert-manager.io/v1
-   kind: Issuer
-   metadata:
-     name: sriov-network-operator-selfsigned-issuer
-     namespace: sriov-network-operator
-   spec:
-     selfSigned: {}
-   ---
-   apiVersion: cert-manager.io/v1
-   kind: Certificate
-   metadata:
-     name: operator-webhook-service
-     namespace: sriov-network-operator
-   spec:
-     secretName: operator-webhook-service
-     dnsNames:
-     - operator-webhook-service.sriov-network-operator.svc
-     issuerRef:
-       name: sriov-network-operator-selfsigned-issuer
-   ---
-   apiVersion: cert-manager.io/v1
-   kind: Certificate
-   metadata:
-     name: network-resources-injector-service
-     namespace: sriov-network-operator
-   spec:
-     secretName: network-resources-injector-secret
-     dnsNames:
-     - network-resources-injector-service.sriov-network-operator.svc
-     issuerRef:
-       name: sriov-network-operator-selfsigned-issuer
-   EOF
-   ```
-
-    And then deploy the operator:
     ```bash
     export ENABLE_ADMISSION_CONTROLLER=true
     make deploy-setup-k8s

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -20,7 +20,13 @@ load_manifest() {
       
       envsubst< namespace.yaml | ${OPERATOR_EXEC} apply -f -
     fi
-    files="service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml operator.yaml"
+    files=
+    if [[ "${CLUSTER_TYPE}" == "kubernetes" && "${ENABLE_ADMISSION_CONTROLLER}" == "true" && "${ENABLE_CERT_MANAGER}" == "true" ]]; then
+        ${OPERATOR_EXEC} apply -f https://github.com/jetstack/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml
+        files="cert-manager.yaml "
+    fi
+
+    files="${files}service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml operator.yaml"
     for m in ${files}; do
       if [ "$(echo ${EXCLUSIONS[@]} | grep -o ${m} | wc -w | xargs)" == "0" ] ; then
         envsubst< ${m} | ${OPERATOR_EXEC} apply ${namespace:-} --validate=false -f -


### PR DESCRIPTION
This patch is for when deploying on Kubernetes clusters, not OpenShift;
where it already has certificate management.

When deploying the Operator from source with the desire of using the
Webhook, a network-resources-injector-secret resource has to be created
and it depends on certificates.

Before, we were documented 2 options on how we can achieve it.
Now we automate the second option that is easy to use.

* Option 1: Using its own certs, then export ENABLE_CERT_MANAGER=false.

* Option 2 (default): it'll use jetstack/cert-manager to generate
  certificates and the secret for network-resources-injector.

Later, when the operator is created and webhook enabled, it'll not fail
because the `tls` volume can't be found.
