### PR TITLE
api: log unsupported models

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -103,6 +103,7 @@ func IsSupportedModel(vendorId, deviceId string) bool {
 			return true
 		}
 	}
+	log.Info("IsSupportedModel():", "Unsupported model:", "vendorId:", vendorId, "deviceId:", deviceId)
 	return false
 }
 
@@ -113,6 +114,7 @@ func IsVfSupportedModel(vendorId, deviceId string) bool {
 			return true
 		}
 	}
+	log.Info("IsVfSupportedModel():", "Unsupported VF model:", "vendorId:", vendorId, "deviceId:", deviceId)
 	return false
 }
 


### PR DESCRIPTION
It can be really useful to provide logs when a device (PF or VF) is not
supported and give the vendorId + deviceId; so the deployer can check
what device is being selected and compare with the ConfigMap which
describes the supported nics.
