### PR TITLE
Add HPE Synergy 6820C 25/50Gb Converged Network Adapter - Marvell FastLinQ QL45000 

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -20,3 +20,4 @@ data:
   Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
+  Qlogic_qede_QL45000_50G: "1077 1654 1664"


### PR DESCRIPTION
kind: ConfigMap
metadata:
name: supported-nic-ids
data:
Intel_i40e_XXV710: "8086 158a 154c"
Intel_i40e_25G_SFP28: "8086 158b 154c"
Intel_i40e_10G_X710_SFP: "8086 1572 154c"
Intel_i40e_XXV710_N3000: "8086 0d58 154c"
Intel_i40e_40G_XL710_QSFP: "8086 1583 154c"
Intel_ice_Columbiaville_E810-CQDA2_2CQDA2: "8086 1592 1889"
Intel_ice_Columbiaville_E810-XXVDA4: "8086 1593 1889"
Intel_ice_Columbiaville_E810-XXVDA2: "8086 159b 1889"
Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"
Nvidia_mlx5_ConnectX-5_Ex: "15b3 1019 101a"
Nvidia_mlx5_ConnectX-6: "15b3 101b 101c"
Nvidia_mlx5_ConnectX-6_Dx: "15b3 101d 101e"
Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
Qlogic_qede_QL45000_50G: "1077 1654 1664"

[supported-nic-ids.yaml.txt](https://github.com/k8snetworkplumbingwg/sriov-network-operator/files/8118211/supported-nic-ids.yaml.txt)


https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/234 
