### PR TITLE
Add Supported hardware doc

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -2,28 +2,9 @@
 
 ## Prerequisites
 
-1. A supported SRIOV hardware on the cluster nodes. Currently the supported models are:
-  
-| Model                    | Vendor ID | Device ID |
-| ------------------------ | --------- | --------- |
-| Intel XXV710 Family |  8086 | 158b |
-| Intel E810-CQDA2/2CQDA2 Family | 8086  | 1592 |
-| Intel E810-XXVDA4 Family | 8086  | 1593 |
-| Intel E810-XXVDA2 Family | 8086  | 159b |
-| Mellanox MT27700 Family [ConnectX-4] | 15b3 | 1013 |
-| Mellanox MT27710 Family [ConnectX-4 Lx] | 15b3 | 1015 |
-| Mellanox MT27800 Family [ConnectX-5] | 15b3 | 1017 |
-| Mellanox MT28800 Family [ConnectX-5 Ex] | 15b3 | 1019 |
-| Mellanox MT28908 Family [ConnectX-6] | 15b3 | 101b |
-| Mellanox MT28908 Family [ConnectX-6 Dx] | 15b3 | 101d |
-| Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | 15b3 | a2d6 |
-| Qlogic QL45000 Series 50GbE Controller | 1077 | 1654 |
-
+1. A supported SRIOV hardware on the cluster nodes. Supported models can be found [here](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/supported-hardware.md).
 2. Kubernetes or Openshift cluster running on bare metal nodes.
 3. Multus-cni is deployed as default CNI plugin, and there is a default CNI plugin (flannel, openshift-sdn etc.) available for Multus-cni.
-
-> **Note:** As for unsupported SRIOV NICs, that is not guaranteed, but might work as well.
-> For that to happen, after installing the SR_IOV operator, you have to add the unsupported SRIOV NICs information to the ConfigMap supported-nic-ids in following format: `<nic_name>: <vender_id> <pf_device_id> <vf_device_id>`. Then restart the config daemon and operator webhook pods.
 
 ## Installation
 

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -1,0 +1,81 @@
+# Supported Hardware
+
+The following SR-IOV capable hardware is supported with sriov-network-operator:
+
+| Model                    | Vendor ID | Device ID |
+| ------------------------ | --------- | --------- |
+| Intel XXV710 Family |  8086 | 158b |
+| Intel E810-CQDA2/2CQDA2 Family | 8086  | 1592 |
+| Intel E810-XXVDA4 Family | 8086  | 1593 |
+| Intel E810-XXVDA2 Family | 8086  | 159b |
+| Mellanox MT27700 Family [ConnectX-4] | 15b3 | 1013 |
+| Mellanox MT27710 Family [ConnectX-4 Lx] | 15b3 | 1015 |
+| Mellanox MT27800 Family [ConnectX-5] | 15b3 | 1017 |
+| Mellanox MT28800 Family [ConnectX-5 Ex] | 15b3 | 1019 |
+| Mellanox MT28908 Family [ConnectX-6] | 15b3 | 101b |
+| Mellanox MT28908 Family [ConnectX-6 Dx] | 15b3 | 101d |
+| Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | 15b3 | a2d6 |
+| Qlogic QL45000 Series 50GbE Controller | 1077 | 1654 |
+
+> **Note:** sriov-network-operator maintains a list of supported NICs which it supports.
+> These are stored in supported-nic-ids [configMap](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/deployment/sriov-network-operator/templates/configmap.yaml).
+> The operator uses this list to enforce it only operates on NICs that are supported. For unsupported SR-IOV NICs, that is not guaranteed, but might work as well.
+> To have sriov-network-operator operate on an unsupported NIC, after installing the operator, you have to add the unsupported SR-IOV NICs information to the ConfigMap
+> in following format: `<nic_name>: <vender_id> <pf_device_id> <vf_device_id>`.
+> Then restart the config daemon and operator webhook pods.
+
+## Supported features per hardware
+
+The following table depicts the supported SR-IOV hardware features of each supported hardware:
+
+| Model                    | SR-IOV Kernel | SR-IOV DPDK | SR-IOV Hardware Offload (switchdev) |
+| ------------------------ | ------------- | ----------- |------------------------------------ |
+| Intel XXV710 Family | V | V | X |
+| Intel E810-CQDA2/2CQDA2 Family | V | V | X |
+| Intel E810-XXVDA4 Family | V | V | X |
+| Intel E810-XXVDA2 Family | V | V | X |
+| Mellanox MT27700 Family [ConnectX-4] | V | V | V |
+| Mellanox MT27710 Family [ConnectX-4 Lx] | V | V | V |
+| Mellanox MT27800 Family [ConnectX-5] | V | V | V |
+| Mellanox MT28800 Family [ConnectX-5 Ex] | V | V | V |
+| Mellanox MT28908 Family [ConnectX-6] | V | V | V |
+| Mellanox MT28908 Family [ConnectX-6 Dx] | V | V | V |
+| Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | V | V | V |
+| Qlogic QL45000 Series 50GbE Controller | V | X | X |
+
+# Adding new Hardware
+
+## Initial support
+Vendors (or other parties) interested in adding a new supported hardware to the supported list of devices of sriov-network-operator
+should follow the following procedure:
+
+* Open an Issue requesting to add support for new hardware
+  * Specify which hardware it is (Model, Vendor ID, Device ID)
+* Perform Testing on requested hardware using:
+  * Kubernetes last release
+  * Either last release version or master version of sriov-network-operator
+  * Note: We do not have a specifc list of test-cases however you should at a minimum ensure
+      sriov-network-operator is able to properly discover your device, configure SR-IOV and
+      expose them as a kubernetes node resource, and you are able to run workloads consuming
+      those resources.
+* Add information of what was tested to the issue opened
+* Add contact point information to [vendor-support.md](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/vendor-support.md), so we know who to reach out if issues arise when running sriov-network-operator against the specified hardware.
+* Submit PR to add your device to this file as well as to supported-nic-ids configMap [here](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/deployment/sriov-network-operator/templates/configmap.yaml) and [here](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/deploy/configmap.yaml).
+  * The tables above should be updated according to what was tested 
+
+## Continuous support
+To ensure sriov-network-operator continues to operate as expected on supported hardware it is recommended that hardware vendors (or another party)
+adds CI which runs against PRs in the project. Without it we cannot commit for sriov-network-operator to continue to work properly on the specified
+hardware.
+
+Additional information on how to add Vendor/3rd-party CI can be found [here](https://github.com/k8snetworkplumbingwg/sriov-network-operator/tree/master/ci).
+
+### E2E tests
+
+sriov-network-operator offers a set of e2e tests vendors can run on their hardware. These tests utilize [Kind](https://kind.sigs.k8s.io/) to spin up
+a Kubernetes cluster and run tests. Information on how to run e2e tests can be found [here](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/testing-kind.md).
+These tests may be used as part of vendor CIs added to the project to validate sriov-network-operator is able to operate
+on the relevant hardware.
+
+>**Note:** The maintainers of this project reserve the right to remove a device from the supported list if issues arise on that hardware.
+> this will be done only after attempting to contact the contact point provided by a specific vendor to address the issues.

--- a/doc/vendor-support.md
+++ b/doc/vendor-support.md
@@ -1,0 +1,15 @@
+# Vendor Support
+
+Below is a list of contact points for hardware vendors that are supported by sriov-network operator.
+Before contacting the relevant vendor, please open a github issue with relevant information so we
+can first see if indeed the issue is hardware related.
+
+Some vendors are actively involved in the development of sriov-network-operator. They are marked
+as `active-in-project` in the table below.
+
+| Vendor | Contact |
+|--------|---------|
+| Nvidia(Mellanox) | active-in-project |
+| Intel | active-in-project |
+| HPE(Marvell Qlogic) | BSN_dev_support@hpe.com |
+


### PR DESCRIPTION
This commit adds a dedicated document for supported hardware
which lists the current hardware supported by sriov-network-operator
as well as defines a process to add support for new hardware
in sriov-network-operator

Signed-off-by: Adrian Chiris <adrianc@nvidia.com>