### PR TITLE
virtual/openstack: configure VFIO with NIOMMU by default

### DIFF
--- a/bindata/scripts/load-kmod.sh
+++ b/bindata/scripts/load-kmod.sh
@@ -1,11 +1,16 @@
 #!/bin/sh
 # chroot /host/ modprobe $1
 kmod_name=$(tr "-" "_" <<< $1)
+kmod_args="${@:2}"
 chroot /host/ lsmod | grep "^$1" >& /dev/null
 
 if [ $? -eq 0 ]
 then
+        # NOTE: We do not check if the module is loaded with specific options
+        #       so a manual reload is required if the module is loaded with
+        #       new or different options.
+        echo "Module $kmod_name already loaded; no change will be applied..."
         exit 0 
 else
-        chroot /host/ modprobe $kmod_name
+        chroot /host/ modprobe $kmod_name $kmod_args
 fi

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -534,12 +534,13 @@ func getVfInfo(pciAddr string, devices []*ghw.PCIDevice) sriovnetworkv1.VirtualF
 	return vf
 }
 
-func LoadKernelModule(name string) error {
-	glog.Infof("LoadKernelModule(): try to load kernel module %s", name)
-	cmd := exec.Command("/bin/sh", scriptsPath, name)
+func LoadKernelModule(name string, args ...string) error {
+	glog.Infof("LoadKernelModule(): try to load kernel module %s with arguments '%s'", name, args)
+	cmdArgs := strings.Join(args, " ")
+	cmd := exec.Command("/bin/sh", scriptsPath, name, cmdArgs)
 	err := cmd.Run()
 	if err != nil {
-		glog.Errorf("LoadKernelModule(): fail to load kernel module %s: %v", name, err)
+		glog.Errorf("LoadKernelModule(): fail to load kernel module %s with arguments '%s': %v", name, args, err)
 		return err
 	}
 	return nil


### PR DESCRIPTION
As well known and well documented, in virtual deployments of Kubernetes such as running on top
of OpenStack where the underlying virtualization platform is KVM, it does not support a virtualized iommu,
the VFIO PCI driver needs to be loaded with a special flag.

This patch aims to do it by default in the virtual_plugin, since this
plugin is only used by OpenStack for now.

Note: it also changes `utils.LoadKernelModule` function to support
kernel module arguments. It also adds a note in `load-kmod.sh` about the
fact that a module won't be reloaded with potential new options if the
module is already loaded on the system.