### PR TITLE
Move logger initialization before k8s client creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -78,6 +78,7 @@ func main() {
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
 	restConfig := ctrl.GetConfigOrDie()
 	kubeClient, err := client.New(restConfig, client.Options{Scheme: scheme})
@@ -88,7 +89,6 @@ func main() {
 
 	le := leaderelection.GetLeaderElectionConfig(kubeClient, enableLeaderElection)
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	namespace := os.Getenv("NAMESPACE")
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 scheme,


### PR DESCRIPTION
ctrl.Log var contains noop logger until logger instance is
explicitly set with ctrl.SetLogger function

If error happen during k8s client creation it will be not logged
because ctrl.SetLogger is called after.

Move logger initialization step before k8s client
creation to be able to log client initialization errors.

Log messages when kubecofig unavailable
Before patch:
```
go run main.go                                                                                
exit status 1  
```
After patch:
```
go run main.go 
2022-03-09T18:40:27.941+0300    ERROR   controller-runtime.client.config        unable to get kubeconfig        {"error": "invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable", "errorCauses": [{"error": "no configuration has been provided, try setting KUBERNETES_MASTER environment variable"}]}
github.com/go-logr/zapr.(*zapLogger).Error
        /home/user/go/code/sriov-network-operator/vendor/github.com/go-logr/zapr/zapr.go:132
sigs.k8s.io/controller-runtime/pkg/log.(*DelegatingLogger).Error
        /home/user/go/code/sriov-network-operator/vendor/sigs.k8s.io/controller-runtime/pkg/log/deleg.go:144
sigs.k8s.io/controller-runtime/pkg/client/config.GetConfigOrDie
        /home/user/go/code/sriov-network-operator/vendor/sigs.k8s.io/controller-runtime/pkg/client/config/config.go:154
main.main
        /home/user/go/code/sriov-network-operator/main.go:83
runtime.main
        /usr/local/go/src/runtime/proc.go:255
exit status 1
```
