### PR TITLE
Sync SriovNetworkNodeState CRD into helm chart

### DIFF
--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -59,6 +59,8 @@ spec:
                         properties:
                           deviceType:
                             type: string
+                          isRdma:
+                            type: boolean
                           mtu:
                             type: integer
                           policyName:


### PR DESCRIPTION
SriovNetworkNodeState is outdated. IsRdma field was introduced
in the PR #207.

This patch syncs CRDs between config/crd/bases and helm chart.