### PR TITLE
Remove "yum update" command from config-daemon Dockerfile

### DIFF
--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -6,7 +6,7 @@ RUN make plugins BIN_PATH=build/_output/pkg
 
 FROM quay.io/centos/centos:stream8
 ARG MSTFLINT=mstflint
-RUN yum -y update && ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && yum -y install hwdata $ARCH_DEP_PKGS && yum clean all
+RUN ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && yum -y install hwdata $ARCH_DEP_PKGS && yum clean all
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/


### PR DESCRIPTION
Remove "yum update" command from Dockerfile.sriov-network-config-daemon.

For config-daemon, centos:stream8 is used as a base image.
This image is actively maintained and should include available security updates with minimal delay.

The reason for this change is that latest(current) version of centos:stream8 image has following problem:

```
sudo docker run -ti --rm quay.io/centos/centos:stream8
[root@08c3ef94d916 /]# yum update
CentOS Stream 8 - AppStream                                                                                                                                                    7.8 MB/s |  21 MB     00:02    
CentOS Stream 8 - BaseOS                                                                                                                                                       8.0 MB/s |  20 MB     00:02    
CentOS Stream 8 - Extras                                                                                                                                                        26 kB/s |  18 kB     00:00    
Error: 
 Problem: package centos-stream-repos-8-4.el8.noarch requires centos-gpg-keys = 1:8-4.el8, but none of the providers can be installed
  - cannot install both centos-gpg-keys-1:8-5.el8.noarch and centos-gpg-keys-1:8-4.el8.noarch
  - cannot install the best update candidate for package centos-stream-repos-8-4.el8.noarch
  - cannot install the best update candidate for package centos-gpg-keys-1:8-4.el8.noarch
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
``` 
So, this change is a workaround to fix the problem above, but this change can be safely persist while centos:stream8 image
is maintained and keep receiving updates. 