### PR TITLE
OpenStack: Support generic virtio device for DPDK

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -21,4 +21,4 @@ data:
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
-  
+  Red_Hat_Virtio_network_device: "1af4" "1000" "0000"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -21,4 +21,4 @@ data:
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
-  
+  Red_Hat_Virtio_network_device: "1af4" "1000" "0000"


### PR DESCRIPTION
This commit includes device with vendor 1af4, PF device 1000
and VF device 0000 to the supported NICs config-map to ensure
the webhook allows creation of SriovNetworkNodePolicy for DPDK
in the OpenStack CI.