### PR TITLE
ci: Stick with Go 1.17

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.17+
+    - name: Set up Go 1.17
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: 1.17.8
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Set up Go 1.17+
+    - name: Set up Go 1.17
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.17
+        go-version: 1.17.8
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2


### PR DESCRIPTION
As the Makefile uses deprecated Go features, GH actions should use a fixed 1.17.* version of Golang.
This is intended as a temporary fix for https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/231

