### PR TITLE
Add e0ne user to CI admins list

### DIFF
--- a/ci/admin-list.yaml
+++ b/ci/admin-list.yaml
@@ -1,5 +1,6 @@
 admin-list:
   - adrianchiris
+  - e0ne
   - pliurh
   - zshi-redhat
 #org-list:


### PR DESCRIPTION
As a maintainer of Mellanox Plugin I would like to have permissions
to run e2e vendor CI tests.