### PR TITLE
Init NicIdMap on the config daemon startup

### DIFF
--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -160,6 +160,11 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	}
 	glog.V(0).Infof("Running on platform: %s", platformType.String())
 
+	var namespace = os.Getenv("NAMESPACE")
+	if err := sriovnetworkv1.InitNicIdMap(kubeclient, namespace); err != nil {
+		glog.Errorf("failed to run init NicIdMap: %v", err)
+	}
+
 	// block the deamon process until nodeWriter finish first its run
 	nodeWriter.Run(stopCh, refreshCh, syncCh, destdir, true, platformType)
 	go nodeWriter.Run(stopCh, refreshCh, syncCh, "", false, platformType)

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -233,10 +233,6 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 	tryEnableRdma()
 	tryEnableTun()
 
-	if err := sriovnetworkv1.InitNicIdMap(dn.kubeClient, namespace); err != nil {
-		return err
-	}
-
 	if err := dn.tryCreateUdevRuleWrapper(); err != nil {
 		return err
 	}


### PR DESCRIPTION
After PR #252 is merged there is a race condition between NicIdMap
init and accec to it.
This patch moves InitNicIdMap function call before NicIdMap will be
used in node writer and config daemon run function.

Closes-Bug: #279