### PR TITLE
Add coverage evidence to the project

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -49,10 +49,10 @@ jobs:
     name: Golangci-lint
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.17
+    - name: Set up Go 1.18
       uses: actions/setup-go@v2
       with:
-        go-version: 1.17.8
+        go-version: 1.18.2
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: golangci-lint
@@ -60,3 +60,31 @@ jobs:
       with:
         # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
         version: v1.46
+
+  test-coverage:
+    name: test-coverage
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.18
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.2
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: test pkg
+      run: make test-pkg
+
+    - name: test controllers on opensfhit
+      run: CLUSTER_TYPE=openshift make test-controllers
+
+    - name: merge test coverage
+      run: make merge-test-coverage
+
+    - name: Coveralls
+      uses: coverallsapp/github-action@1.1.3
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: lcov.out


### PR DESCRIPTION
In order to increase project quality, it would be useful to monitor unit test code coverage and try to not decrease it with PRs.
Besides this commit, an admin is needed to link the repository to https://coveralls.io/ to enable it.

> Configure CI to collect coverage and integrate with coveralls.io
> service.
> 
> Move plugin packages out of `pkg` package, as they aren't
> exportable as library and their presence conflicts with
> `-coverpkg=./...` cover parameter.
> 
> Add Makefile rules for merging coverage profiles from multiple
> sources, as tests are usually run by `make test-pkg` and
> `make test-controllers`.
> 
> Signed-off-by: Andrea Panattoni <apanatto@redhat.com>

