### PR TITLE
Add options to CreateSriovPolicy

### DIFF
--- a/test/util/network/network.go
+++ b/test/util/network/network.go
@@ -49,7 +49,7 @@ func CreateSriovNetwork(clientSet *testclient.ClientSet, intf *sriovv1.Interface
 	return err
 }
 
-func defineSriovPolicy(generatedName string, operatorNamespace string, sriovDevice string, testNode string, numVfs int, resourceName string, deviceType string) *sriovv1.SriovNetworkNodePolicy {
+func defineSriovPolicy(generatedName string, operatorNamespace string, sriovDevice string, testNode string, numVfs int, resourceName string, deviceType string, options ...func(*sriovv1.SriovNetworkNodePolicy)) *sriovv1.SriovNetworkNodePolicy {
 	nodePolicy := &sriovv1.SriovNetworkNodePolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: generatedName,
@@ -68,12 +68,15 @@ func defineSriovPolicy(generatedName string, operatorNamespace string, sriovDevi
 			DeviceType: deviceType,
 		},
 	}
+	for _, o := range options {
+		o(nodePolicy)
+	}
 	return nodePolicy
 }
 
 // CreateSriovPolicy creates a SriovNetworkNodePolicy and returns it
-func CreateSriovPolicy(clientSet *testclient.ClientSet, generatedName string, operatorNamespace string, sriovDevice string, testNode string, numVfs int, resourceName string, deviceType string) (*sriovv1.SriovNetworkNodePolicy, error) {
-	nodePolicy := defineSriovPolicy(generatedName, operatorNamespace, sriovDevice, testNode, numVfs, resourceName, deviceType)
+func CreateSriovPolicy(clientSet *testclient.ClientSet, generatedName string, operatorNamespace string, sriovDevice string, testNode string, numVfs int, resourceName string, deviceType string, options ...func(*sriovv1.SriovNetworkNodePolicy)) (*sriovv1.SriovNetworkNodePolicy, error) {
+	nodePolicy := defineSriovPolicy(generatedName, operatorNamespace, sriovDevice, testNode, numVfs, resourceName, deviceType, options...)
 	err := clientSet.Create(context.Background(), nodePolicy)
 	return nodePolicy, err
 }


### PR DESCRIPTION
This code is reused in other repos which rely on sriov. One of those repos is the [CNF repo](https://github.com/openshift-kni/cnf-features-deploy) which provides a suite to check a cluster.

In this repo the CreateSriovPolicy function is used, but if a custom parameter (like NeedVhostNet) is needed, the function is just inlined: [here](https://github.com/openshift-kni/cnf-features-deploy/blob/008eac84ecb05bf2b3c0fcabb08f98f6ae78d2f6/cnf-tests/testsuites/e2esuite/dpdk/dpdk.go#L1005)

To avoid this, a tweaking function is added to parameters.