### PR TITLE
Skip config if policy not applied yet

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -278,6 +278,12 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(np *sriovne
 			return fmt.Errorf("failed to get SriovNetworkNodeState: %v", err)
 		}
 	} else {
+		if len(found.Status.Interfaces) == 0 {
+			logger.Info("SriovNetworkNodeState Status Interfaces are empty. Skip update of policies in spec",
+				"namespace", ns.Namespace, "name", ns.Name)
+			return nil
+		}
+
 		logger.Info("SriovNetworkNodeState already exists, updating")
 		newVersion := found.DeepCopy()
 		newVersion.Spec = ns.Spec

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -418,6 +418,19 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 		return nil
 	}
 
+	if latestState.GetGeneration() == 1 && len(latestState.Spec.Interfaces) == 0 {
+		glog.V(0).Infof("nodeStateSyncHandler(): Name: %s, Interface policy spec not yet set by controller", latestState.Name)
+		if latestState.Status.SyncStatus != "Succeeded" {
+			dn.refreshCh <- Message{
+				syncStatus:    "Succeeded",
+				lastSyncError: "",
+			}
+			// wait for writer to refresh status
+			<-dn.syncCh
+		}
+		return nil
+	}
+
 	dn.refreshCh <- Message{
 		syncStatus:    "InProgress",
 		lastSyncError: "",


### PR DESCRIPTION
There is a stage when the SriovNetworkNodeState is initializing
where the spec is empty because the SriovNetworkNodePolicyReconciler
did not yet applied the policies.

It can cause a non required action by the plugins,
that will try to apply the empty spec by resetting the NIC for example.

The config daemon will not run the plugins if the generation is 1
and the Spec.Interfaces is empty.

Solves issue #283

For e2e tests, the wait timeout to get to initial Sync state has been
increased.
This change is needed as now the config daemon will not apply on "empty"
spec until the SriovNetworkNodePolicyReconciler will iterate on the Interfaces.
The reconcile loop interval is 5 minutes, so the test timeout needed to be increased.

Signed-off-by: Fred Rolland <frolland@nvidia.com>