### PR TITLE
Remove unused code

### DIFF
--- a/cmd/webhook/start.go
+++ b/cmd/webhook/start.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/webhook"
@@ -28,11 +28,6 @@ var (
 		Short: "Starts Webhook Daemon",
 		Long:  "Starts Webhook Daemon",
 		Run:   runStartCmd,
-	}
-
-	startOpts struct {
-		kubeconfig string
-		nodeName   string
 	}
 )
 

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -48,9 +48,6 @@ type SriovOperatorConfigReconciler struct {
 	Scheme *runtime.Scheme
 }
 
-var injectorServiceCaCmVersion = ""
-var webhookServiceCaCmVersion = ""
-
 //+kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovoperatorconfigs,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovoperatorconfigs/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovoperatorconfigs/finalizers,verbs=update

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -32,7 +32,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -48,7 +47,6 @@ import (
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
 var k8sClient client.Client
 var testEnv *envtest.Environment
 

--- a/pkg/plugins/virtual/virtual_plugin.go
+++ b/pkg/plugins/virtual/virtual_plugin.go
@@ -1,9 +1,7 @@
 package main
 
 import (
-	"os/exec"
 	"reflect"
-	"syscall"
 
 	"github.com/golang/glog"
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
@@ -128,15 +126,6 @@ func needVfioDriver(state *sriovnetworkv1.SriovNetworkNodeState) bool {
 			if iface.VfGroups[i].DeviceType == "vfio-pci" {
 				return true
 			}
-		}
-	}
-	return false
-}
-
-func isCommandNotFound(err error) bool {
-	if exitErr, ok := err.(*exec.ExitError); ok {
-		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.ExitStatus() == 127 {
-			return true
 		}
 	}
 	return false

--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -257,16 +257,6 @@ func validatePolicyForNodePolicy(
 	return true, nil
 }
 
-func keys(m map[string]([]string)) []string {
-	keys := make([]string, len(m))
-	i := 0
-	for k := range m {
-		keys[i] = k
-		i++
-	}
-	return keys
-}
-
 func validateNicModel(selector *sriovnetworkv1.SriovNetworkNicSelector, iface *sriovnetworkv1.InterfaceExt, node *corev1.Node) bool {
 	if selector.Vendor != "" && selector.Vendor != iface.Vendor {
 		return false

--- a/test/e2e/e2e_tests_suite_test.go
+++ b/test/e2e/e2e_tests_suite_test.go
@@ -23,7 +23,6 @@ import (
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	// +kubebuilder:scaffold:imports
 
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/netns"
 )
 
@@ -56,7 +55,6 @@ func TestSriovTests(t *testing.T) {
 		[]Reporter{printer.NewlineReporter{}})
 }
 
-var sriovInfos *cluster.EnabledNodes
 var sriovIface *sriovnetworkv1.InterfaceExt
 
 var _ = BeforeSuite(func(done Done) {

--- a/test/util/discovery/discovery.go
+++ b/test/util/discovery/discovery.go
@@ -70,12 +70,3 @@ func getSriovNodes(clients *client.ClientSet, sriovNodeNames []string) ([]corev1
 	}
 	return nodes, nil
 }
-
-func containsNode(name string, sriovNodes []string) bool {
-	for _, node := range sriovNodes {
-		if node == name {
-			return true
-		}
-	}
-	return false
-}

--- a/test/util/k8sreporter/reporter.go
+++ b/test/util/k8sreporter/reporter.go
@@ -149,26 +149,6 @@ func (r *KubernetesReporter) logNetworkPolicies() {
 	}
 	fmt.Fprintln(r.dumpOutput, string(j))
 }
-func (r *KubernetesReporter) logNetworks() {
-	fmt.Fprintf(r.dumpOutput, "Logging networks")
-
-	networks := sriovv1.SriovNetworkList{}
-	err := r.clients.List(context.Background(),
-		&networks,
-		runtimeclient.InNamespace("openshift-sriov-network-operator"))
-
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to fetch network policies: %v\n", err)
-		return
-	}
-
-	j, err := json.MarshalIndent(networks, "", "    ")
-	if err != nil {
-		fmt.Println("Failed to marshal networks")
-		return
-	}
-	fmt.Fprintln(r.dumpOutput, string(j))
-}
 
 func (r *KubernetesReporter) logSriovNodeState() {
 	fmt.Fprintf(r.dumpOutput, "Logging node states")

--- a/test/validation/tests/validation.go
+++ b/test/validation/tests/validation.go
@@ -20,10 +20,6 @@ import (
 )
 
 var (
-	machineConfigPoolNodeSelector string
-)
-
-var (
 	clients           *testclient.ClientSet
 	operatorNamespace string
 )
@@ -54,8 +50,6 @@ func init() {
 	if roleWorkerCNF == "" {
 		roleWorkerCNF = "worker-cnf"
 	}
-
-	machineConfigPoolNodeSelector = fmt.Sprintf("node-role.kubernetes.io/%s", roleWorkerCNF)
 }
 
 var _ = Describe("validation", func() {


### PR DESCRIPTION
This PR fix issues found with:
`golangci-lint run --disable-all -E unused`

```bash
$ golangci-lint run --disable-all -E unused
test/util/k8sreporter/reporter.go:152:30: func `(*KubernetesReporter).logNetworks` is unused (unused)
controllers/suite_test.go:51:5: var `cfg` is unused (unused)
cmd/webhook/start.go:33:2: var `startOpts` is unused (unused)
controllers/sriovoperatorconfig_controller.go:51:5: var `injectorServiceCaCmVersion` is unused (unused)
controllers/sriovoperatorconfig_controller.go:52:5: var `webhookServiceCaCmVersion` is unused (unused)
pkg/plugins/virtual/virtual_plugin.go:136:6: func `isCommandNotFound` is unused (unused)
test/conformance/tests/sriov_operator.go:2002:6: func `isPodConditionUnschedulable` is unused (unused)
test/conformance/tests/sriov_operator.go:1981:6: func `createUnschedulableTestPod` is unused (unused)
pkg/daemon/daemon.go:91:2: field `dpReboot` is unused (unused)
pkg/daemon/daemon.go:110:6: type `workItem` is unused (unused)
pkg/daemon/daemon.go:182:19: func `(*Daemon).annotateUnsupportedNicIdConfigMap` is unused (unused)
pkg/daemon/daemon.go:67:2: field `namespace` is unused (unused)
test/e2e/e2e_tests_suite_test.go:59:5: var `sriovInfos` is unused (unused)
pkg/webhook/validate.go:260:6: func `keys` is unused (unused)
test/util/discovery/discovery.go:74:6: func `containsNode` is unused (unused)
test/validation/tests/validation.go:23:2: var `machineConfigPoolNodeSelector` is unused (unused)
```

Signed-off-by: Fred Rolland <frolland@nvidia.com>