### PR TITLE
Fix deadcode and goimports issues

### DIFF
--- a/cmd/webhook/start.go
+++ b/cmd/webhook/start.go
@@ -10,7 +10,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/golang/glog"
 	"github.com/spf13/cobra"
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/webhook"

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -57,7 +57,6 @@ const (
 	testNamespace = "openshift-sriov-network-operator"
 
 	timeout  = time.Second * 10
-	duration = time.Second * 100
 	interval = time.Millisecond * 250
 )
 

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -40,7 +40,6 @@ const (
 	filesDir          = "files"
 	ovsUnitsDir       = "ovs-units"
 	switchdevUnitsDir = "switchdev-units"
-	platformBase      = "bindata/manifests/machine-config"
 )
 
 func MakeRenderData() RenderData {

--- a/pkg/utils/shutdown.go
+++ b/pkg/utils/shutdown.go
@@ -6,7 +6,6 @@ import (
 	snclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned"
 	admv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -16,12 +15,6 @@ import (
 )
 
 var shutdownLog = ctrl.Log.WithName("shutdown")
-
-var sriovnetworksGVR = schema.GroupVersionResource{
-	Group:    "sriovnetwork.openshift.io",
-	Version:  "v1",
-	Resource: "sriovnetworks",
-}
 
 var failurePolicyIgnore = admv1.Ignore
 

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/golang/glog"
-	"k8s.io/api/admission/v1"
+	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"

--- a/test/e2e/e2e_tests_suite_test.go
+++ b/test/e2e/e2e_tests_suite_test.go
@@ -40,7 +40,6 @@ var doneNetNsSet chan error
 // Define utility constants for object names and testing timeouts/durations and intervals.
 const (
 	timeout         = time.Second * 30
-	duration        = time.Second * 300
 	interval        = time.Second * 1
 	devPollInterval = time.Millisecond * 400
 )


### PR DESCRIPTION
This commit fix the issues found by:
`golangci-lint run --disable-all -E deadcode`
and `golangci-lint run --disable-all -E goimports`

Signed-off-by: Fred Rolland <frolland@nvidia.com>