### PR TITLE
Fix mispell and staticchek issues

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -847,8 +847,7 @@ func (dn *Daemon) pauseMCP() error {
 			return
 		}
 		// Always get the latest object
-		newMcp := &mcfgv1.MachineConfigPool{}
-		newMcp, err = dn.mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, dn.mcpName, metav1.GetOptions{})
+		newMcp, err := dn.mcClient.MachineconfigurationV1().MachineConfigPools().Get(ctx, dn.mcpName, metav1.GetOptions{})
 		if err != nil {
 			glog.V(2).Infof("pauseMCP(): Failed to get MCP %s: %v", dn.mcpName, err)
 			return

--- a/test/conformance/tests/sriov_operator.go
+++ b/test/conformance/tests/sriov_operator.go
@@ -113,7 +113,7 @@ var _ = Describe("[sriov] operator", func() {
 					return daemonsScheduledOnNodes("node-role.kubernetes.io/worker=")
 				}, 3*time.Minute, 1*time.Second).Should(Equal(true))
 
-				By("Labelling one worker node with the label needed for the daemon")
+				By("Labeling one worker node with the label needed for the daemon")
 				allNodes, err := clients.Nodes().List(context.Background(), metav1.ListOptions{
 					LabelSelector: "node-role.kubernetes.io/worker",
 				})
@@ -1810,7 +1810,7 @@ func findMainSriovDevice(executorPod *corev1.Pod, sriovDevices []*sriovv1.Interf
 
 	for _, device := range sriovDevices {
 		if isDefaultRouteInterface(device.Name, routes) {
-			fmt.Println("Choosen ", device.Name, " as it is the default gw")
+			fmt.Println("Chosen ", device.Name, " as it is the default gw")
 			return device
 		}
 		stdout, _, err = pod.ExecCommand(clients, executorPod, "ip", "link", "show", device.Name)
@@ -1820,7 +1820,7 @@ func findMainSriovDevice(executorPod *corev1.Pod, sriovDevices []*sriovv1.Interf
 			continue // The interface is not active
 		}
 		if strings.Contains(stdout, "master ovs-system") {
-			fmt.Println("Choosen ", device.Name, " as it is used by ovs")
+			fmt.Println("Chosen ", device.Name, " as it is used by ovs")
 			return device
 		}
 	}

--- a/test/util/pod/pod.go
+++ b/test/util/pod/pod.go
@@ -82,14 +82,14 @@ func RedefineWithMount(pod *corev1.Pod, volume corev1.Volume, mount corev1.Volum
 	return pod
 }
 
-// RedefineWithCommand updates the pod defintion with a different command
+// RedefineWithCommand updates the pod definition with a different command
 func RedefineWithCommand(pod *corev1.Pod, command []string, args []string) *corev1.Pod {
 	pod.Spec.Containers[0].Command = command
 	pod.Spec.Containers[0].Args = args
 	return pod
 }
 
-// RedefineWithRestartPolicy updates the pod defintion with a restart policy
+// RedefineWithRestartPolicy updates the pod definition with a restart policy
 func RedefineWithRestartPolicy(pod *corev1.Pod, restartPolicy corev1.RestartPolicy) *corev1.Pod {
 	pod.Spec.RestartPolicy = restartPolicy
 	return pod


### PR DESCRIPTION
This commit fixes issues found by
`golangci-lint run --disable-all -E misspell`
and `golangci-lint run --disable-all -E staticcheck`

Signed-off-by: Fred Rolland <frolland@nvidia.com>