### PR TITLE
Generic Plugin Reset interface on error

### DIFF
--- a/pkg/utils/driver.go
+++ b/pkg/utils/driver.go
@@ -96,7 +96,7 @@ func BindDefaultDriver(pciAddr string) error {
 	}
 	err = ioutil.WriteFile(sysBusPciDriversProbe, []byte(pciAddr), os.ModeAppend)
 	if err != nil {
-		glog.Errorf("BindDpdkDriver(): fail to bind driver for device %s: %s", pciAddr, err)
+		glog.Errorf("BindDefaultDriver(): fail to bind driver for device %s: %s", pciAddr, err)
 		return err
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -165,7 +165,10 @@ func SyncNodeState(newState *sriovnetworkv1.SriovNetworkNodeState) error {
 					break
 				}
 				if err = configSriovDevice(&iface, &ifaceStatus); err != nil {
-					glog.Errorf("SyncNodeState(): fail to config sriov interface %s: %v", iface.PciAddress, err)
+					glog.Errorf("SyncNodeState(): fail to configure sriov interface %s: %v. resetting interface.", iface.PciAddress, err)
+					if resetErr := resetSriovDevice(ifaceStatus); resetErr != nil {
+						glog.Errorf("SyncNodeState(): fail to reset on error SR-IOV interface: %s", resetErr)
+					}
 					return err
 				}
 				break

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -272,7 +272,7 @@ func configSriovDevice(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetwor
 		}
 		pfLink, err := netlink.LinkByName(iface.Name)
 		if err != nil {
-			glog.Errorf("setVfGuid(): unable to get PF link for device %+v %q", iface, err)
+			glog.Errorf("configSriovDevice(): unable to get PF link for device %+v %q", iface, err)
 			return err
 		}
 


### PR DESCRIPTION
If error occures during sriov configuration in
generic plugin, config daemon will log the error
and requeue the request to reconcile the node.

On the next run, when generic plugin Apply() method
is called, interface configuration may be skipped,
leaving the interface partially configured.

To ensure generic plugin re-configures the interface
on the next iteration, we reset the interface
before returning an error.