### PR TITLE
external control plane

### DIFF
--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -28,6 +28,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       affinity:
+        {{ if not .ExternalControlPlane }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -37,7 +38,9 @@ spec:
             - matchExpressions:
                 - key: node-role.kubernetes.io/control-plane
                   operator: Exists
+        {{ end }}
       tolerations:
+      {{ if not .ExternalControlPlane }}
       - key: "node-role.kubernetes.io/master"
         operator: Exists
         effect: NoSchedule
@@ -47,6 +50,7 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: Exists
         effect: NoSchedule
+      {{ end }}
       {{- if .ImagePullSecrets }}
       imagePullSecrets:
       {{- range .ImagePullSecrets }}

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{.Namespace}}
   annotations:
     kubernetes.io/description: |
-      This daemon set launches the network resource injector component on master nodes.
+      This daemon set launches the network resource injector component on master or worker nodes.
     release.openshift.io/version: "{{.ReleaseVersion}}"
 spec:
   selector:
@@ -31,6 +31,7 @@ spec:
       nodeSelector:
         beta.kubernetes.io/os: linux
       affinity:
+        {{ if not .ExternalControlPlane }}
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
@@ -40,7 +41,9 @@ spec:
             - matchExpressions:
                 - key: node-role.kubernetes.io/control-plane
                   operator: Exists
+        {{ end }}
       tolerations:
+      {{ if not .ExternalControlPlane }}
       - key: "node-role.kubernetes.io/master"
         operator: Exists
         effect: NoSchedule
@@ -50,6 +53,7 @@ spec:
       - key: "node.kubernetes.io/not-ready"
         operator: Exists
         effect: NoSchedule
+      {{ end }}
       {{- if .ImagePullSecrets }}
       imagePullSecrets:
       {{- range .ImagePullSecrets }}

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -229,6 +229,12 @@ func (r *SriovOperatorConfigReconciler) syncWebhookObjs(dc *sriovnetworkv1.Sriov
 		data.Data["CaBundle"] = os.Getenv("WEBHOOK_CA_BUNDLE")
 		data.Data["DevMode"] = os.Getenv("DEV_MODE")
 		data.Data["ImagePullSecrets"] = GetImagePullSecrets()
+		external, err := utils.IsExternalControlPlaneCluster(r.Client)
+		if err != nil {
+			logger.Error(err, "Fail to get control plane topology")
+			return err
+		}
+		data.Data["ExternalControlPlane"] = external
 		objs, err := render.RenderDir(path, &data)
 		if err != nil {
 			logger.Error(err, "Fail to render webhook manifests")

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
+	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -84,6 +85,8 @@ var _ = BeforeSuite(func(done Done) {
 	err = netattdefv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 	err = mcfgv1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = openshiftconfigv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:scheme
@@ -164,6 +167,17 @@ var _ = BeforeSuite(func(done Done) {
 		LogLevel:                 2,
 	}
 	Expect(k8sClient.Create(context.TODO(), config)).Should(Succeed())
+
+	infra := &openshiftconfigv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: openshiftconfigv1.InfrastructureSpec{},
+		Status: openshiftconfigv1.InfrastructureStatus{
+			ControlPlaneTopology: openshiftconfigv1.HighlyAvailableTopologyMode,
+		},
+	}
+	Expect(k8sClient.Create(context.TODO(), infra)).Should(Succeed())
 
 	poolConfig := &sriovnetworkv1.SriovNetworkPoolConfig{}
 	poolConfig.SetNamespace(testNamespace)

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -79,6 +79,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: RELEASE_VERSION
               value: 4.3.0
             - name: SRIOV_CNI_BIN_PATH

--- a/deployment/sriov-network-operator/templates/operator.yaml
+++ b/deployment/sriov-network-operator/templates/operator.yaml
@@ -81,6 +81,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
             - name: RELEASE_VERSION
               value: {{ .Release.AppVersion }}
             - name: SRIOV_CNI_BIN_PATH

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -15,39 +15,99 @@ import (
 
 const (
 	// default Infrastructure resource name for Openshift
-	infraResourceName = "cluster"
+	infraResourceName        = "cluster"
+	workerRoleName           = "worker"
+	masterRoleName           = "master"
+	workerNodeLabelKey       = "node-role.kubernetes.io/worker"
+	masterNodeLabelKey       = "node-role.kubernetes.io/master"
+	controlPlaneNodeLabelKey = "node-role.kubernetes.io/control-plane"
 )
+
+func getNodeRole(node corev1.Node) string {
+	for k := range node.Labels {
+		if k == workerNodeLabelKey {
+			return workerRoleName
+		} else if k == masterNodeLabelKey || k == controlPlaneNodeLabelKey {
+			return masterRoleName
+		}
+	}
+	return ""
+}
 
 func IsSingleNodeCluster(c client.Client) (bool, error) {
 	if os.Getenv("CLUSTER_TYPE") == ClusterTypeOpenshift {
-		return openshiftSingleNodeClusterStatus(c)
+		topo, err := openshiftControlPlaneTopologyStatus(c)
+		if err != nil {
+			return false, err
+		}
+		if topo == configv1.SingleReplicaTopologyMode {
+			return true, nil
+		}
+		return false, nil
 	}
 	return k8sSingleNodeClusterStatus(c)
+}
+
+// IsExternalControlPlaneCluster detects control plane location of the cluster.
+// On OpenShift, the control plane topology is configured in configv1.Infrastucture struct.
+// On kubernetes, it is determined by which node the sriov operator is scheduled on. If operator
+// pod is schedule on worker node, it is considered as external control plane.
+func IsExternalControlPlaneCluster(c client.Client) (bool, error) {
+	if os.Getenv("CLUSTER_TYPE") == ClusterTypeOpenshift {
+		topo, err := openshiftControlPlaneTopologyStatus(c)
+		if err != nil {
+			return false, err
+		}
+		if topo == "External" {
+			return true, nil
+		}
+	} else if os.Getenv("CLUSTER_TYPE") == ClusterTypeKubernetes {
+		role, err := operatorNodeRole(c)
+		if err != nil {
+			return false, err
+		}
+		if role == workerRoleName {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func k8sSingleNodeClusterStatus(c client.Client) (bool, error) {
 	nodeList := &corev1.NodeList{}
 	err := c.List(context.TODO(), nodeList)
 	if err != nil {
-		glog.Errorf("IsSingleNodeCluster(): Failed to list nodes: %v", err)
+		glog.Errorf("k8sSingleNodeClusterStatus(): Failed to list nodes: %v", err)
 		return false, err
 	}
 
 	if len(nodeList.Items) == 1 {
-		glog.Infof("IsSingleNodeCluster(): one node found in the cluster")
+		glog.Infof("k8sSingleNodeClusterStatus(): one node found in the cluster")
 		return true, nil
 	}
 	return false, nil
 }
 
-func openshiftSingleNodeClusterStatus(c client.Client) (bool, error) {
+// operatorNodeRole returns role of the node where operator is scheduled on
+func operatorNodeRole(c client.Client) (string, error) {
+	node := corev1.Node{}
+	err := c.Get(context.TODO(), types.NamespacedName{Name: os.Getenv("NODE_NAME")}, &node)
+	if err != nil {
+		glog.Errorf("k8sIsExternalTopologyMode(): Failed to get node: %v", err)
+		return "", err
+	}
+
+	return getNodeRole(node), nil
+}
+
+func openshiftControlPlaneTopologyStatus(c client.Client) (configv1.TopologyMode, error) {
 	infra := &configv1.Infrastructure{}
 	err := c.Get(context.TODO(), types.NamespacedName{Name: infraResourceName}, infra)
 	if err != nil {
-		return false, err
+		return "", fmt.Errorf("openshiftControlPlaneTopologyStatus(): Failed to get Infrastructure (name: %s): %v", infraResourceName, err)
 	}
 	if infra == nil {
-		return false, fmt.Errorf("getting resource Infrastructure (name: %s) succeeded but object was nil", infraResourceName)
+		return "", fmt.Errorf("openshiftControlPlaneTopologyStatus(): getting resource Infrastructure (name: %s) succeeded but object was nil", infraResourceName)
 	}
-	return infra.Status.ControlPlaneTopology == configv1.SingleReplicaTopologyMode, nil
+	return infra.Status.ControlPlaneTopology, nil
 }

--- a/test/util/crds/config.openshift.io_infrastructures_crd.yaml
+++ b/test/util/crds/config.openshift.io_infrastructures_crd.yaml
@@ -1,0 +1,461 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.openshift.io: https://github.com/openshift/api/pull/470
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+  name: infrastructures.config.openshift.io
+spec:
+  group: config.openshift.io
+  names:
+    kind: Infrastructure
+    listKind: InfrastructureList
+    plural: infrastructures
+    singular: infrastructure
+  scope: Cluster
+  versions:
+    - name: v1
+      schema:
+        openAPIV3Schema:
+          description: "Infrastructure holds cluster-wide information about Infrastructure.  The canonical name is `cluster` \n Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer)."
+          type: object
+          required:
+            - spec
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec holds user settable values for configuration
+              type: object
+              properties:
+                cloudConfig:
+                  description: "cloudConfig is a reference to a ConfigMap containing the cloud provider configuration file. This configuration file is used to configure the Kubernetes cloud provider integration when using the built-in cloud provider integration or the external cloud controller manager. The namespace for this config map is openshift-config. \n cloudConfig should only be consumed by the kube_cloud_config controller. The controller is responsible for using the user configuration in the spec for various platforms and combining that with the user provided ConfigMap in this field to create a stitched kube cloud config. The controller generates a ConfigMap `kube-cloud-config` in `openshift-config-managed` namespace with the kube cloud config is stored in `cloud.conf` key. All the clients are expected to use the generated ConfigMap only."
+                  type: object
+                  properties:
+                    key:
+                      description: Key allows pointing to a specific key/value inside of the configmap.  This is useful for logical file references.
+                      type: string
+                    name:
+                      type: string
+                platformSpec:
+                  description: platformSpec holds desired information specific to the underlying infrastructure provider.
+                  type: object
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      type: object
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      type: object
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          type: array
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            type: object
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                type: string
+                                pattern: ^[a-z0-9-]+$
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                type: string
+                                pattern: ^https://
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      type: object
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      type: object
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      type: object
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      type: object
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      type: object
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      type: object
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      type: object
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      type: object
+                    powervs:
+                      description: PowerVS contains settings specific to the IBM Power Systems Virtual Servers infrastructure provider.
+                      type: object
+                      properties:
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          type: array
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            type: object
+                            required:
+                              - name
+                              - url
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                type: string
+                                pattern: ^[a-z0-9-]+$
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                type: string
+                                format: uri
+                                pattern: ^https://
+                          x-kubernetes-list-map-keys:
+                            - name
+                          x-kubernetes-list-type: map
+                    type:
+                      description: type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are "AWS", "Azure", "BareMetal", "GCP", "Libvirt", "OpenStack", "VSphere", "oVirt", "KubeVirt", "EquinixMetal", "PowerVS", "AlibabaCloud" and "None". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform.
+                      type: string
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      type: object
+            status:
+              description: status holds observed values from the cluster. They may not be overridden.
+              type: object
+              properties:
+                apiServerInternalURI:
+                  description: apiServerInternalURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerInternalURL can be used by components like kubelets, to contact the Kubernetes API server using the infrastructure provider rather than Kubernetes networking.
+                  type: string
+                apiServerURL:
+                  description: apiServerURL is a valid URI with scheme 'https', address and optionally a port (defaulting to 443).  apiServerURL can be used by components like the web console to tell users where to find the Kubernetes API.
+                  type: string
+                controlPlaneTopology:
+                  description: controlPlaneTopology expresses the expectations for operands that normally run on control nodes. The default is 'HighlyAvailable', which represents the behavior operators have in a "normal" cluster. The 'SingleReplica' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation The 'External' mode indicates that the control plane is hosted externally to the cluster and that its components are not visible within the cluster.
+                  type: string
+                  default: HighlyAvailable
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                    - External
+                etcdDiscoveryDomain:
+                  description: 'etcdDiscoveryDomain is the domain used to fetch the SRV records for discovering etcd servers and clients. For more info: https://github.com/etcd-io/etcd/blob/329be66e8b3f9e2e6af83c123ff89297e49ebd15/Documentation/op-guide/clustering.md#dns-discovery deprecated: as of 4.7, this field is no longer set or honored.  It will be removed in a future release.'
+                  type: string
+                infrastructureName:
+                  description: infrastructureName uniquely identifies a cluster with a human friendly name. Once set it should not be changed. Must be of max length 27 and must have only alphanumeric or hyphen characters.
+                  type: string
+                infrastructureTopology:
+                  description: 'infrastructureTopology expresses the expectations for infrastructure services that do not run on control plane nodes, usually indicated by a node selector for a `role` value other than `master`. The default is ''HighlyAvailable'', which represents the behavior operators have in a "normal" cluster. The ''SingleReplica'' mode will be used in single-node deployments and the operators should not configure the operand for highly-available operation NOTE: External topology mode is not applicable for this field.'
+                  type: string
+                  default: HighlyAvailable
+                  enum:
+                    - HighlyAvailable
+                    - SingleReplica
+                platform:
+                  description: "platform is the underlying infrastructure provider for the cluster. \n Deprecated: Use platformStatus.type instead."
+                  type: string
+                  enum:
+                    - ""
+                    - AWS
+                    - Azure
+                    - BareMetal
+                    - GCP
+                    - Libvirt
+                    - OpenStack
+                    - None
+                    - VSphere
+                    - oVirt
+                    - IBMCloud
+                    - KubeVirt
+                    - EquinixMetal
+                    - PowerVS
+                    - AlibabaCloud
+                platformStatus:
+                  description: platformStatus holds status information specific to the underlying infrastructure provider.
+                  type: object
+                  properties:
+                    alibabaCloud:
+                      description: AlibabaCloud contains settings specific to the Alibaba Cloud infrastructure provider.
+                      type: object
+                      required:
+                        - region
+                      properties:
+                        region:
+                          description: region specifies the region for Alibaba Cloud resources created for the cluster.
+                          type: string
+                          pattern: ^[0-9A-Za-z-]+$
+                        resourceGroupID:
+                          description: resourceGroupID is the ID of the resource group for the cluster.
+                          type: string
+                          pattern: ^(rg-[0-9A-Za-z]+)?$
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to Alibaba Cloud resources created for the cluster.
+                          type: array
+                          maxItems: 20
+                          items:
+                            description: AlibabaCloudResourceTag is the set of tags to add to apply to resources.
+                            type: object
+                            required:
+                              - key
+                              - value
+                            properties:
+                              key:
+                                description: key is the key of the tag.
+                                type: string
+                                maxLength: 128
+                                minLength: 1
+                              value:
+                                description: value is the value of the tag.
+                                type: string
+                                maxLength: 128
+                                minLength: 1
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                    aws:
+                      description: AWS contains settings specific to the Amazon Web Services infrastructure provider.
+                      type: object
+                      properties:
+                        region:
+                          description: region holds the default AWS region for new AWS resources created by the cluster.
+                          type: string
+                        resourceTags:
+                          description: resourceTags is a list of additional tags to apply to AWS resources created for the cluster. See https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html for information on tagging AWS resources. AWS supports a maximum of 50 tags per resource. OpenShift reserves 25 tags for its use, leaving 25 tags available for the user.
+                          type: array
+                          maxItems: 25
+                          items:
+                            description: AWSResourceTag is a tag to apply to AWS resources created for the cluster.
+                            type: object
+                            required:
+                              - key
+                              - value
+                            properties:
+                              key:
+                                description: key is the key of the tag
+                                type: string
+                                maxLength: 128
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                              value:
+                                description: value is the value of the tag. Some AWS service do not support empty values. Since tags are added to resources in many services, the length of the tag value must meet the requirements of all services.
+                                type: string
+                                maxLength: 256
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.:/=+-@]+$
+                        serviceEndpoints:
+                          description: ServiceEndpoints list contains custom endpoints which will override default service endpoint of AWS Services. There must be only one ServiceEndpoint for a service.
+                          type: array
+                          items:
+                            description: AWSServiceEndpoint store the configuration of a custom url to override existing defaults of AWS Services.
+                            type: object
+                            properties:
+                              name:
+                                description: name is the name of the AWS service. The list of all the service names can be found at https://docs.aws.amazon.com/general/latest/gr/aws-service-information.html This must be provided and cannot be empty.
+                                type: string
+                                pattern: ^[a-z0-9-]+$
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                type: string
+                                pattern: ^https://
+                    azure:
+                      description: Azure contains settings specific to the Azure infrastructure provider.
+                      type: object
+                      properties:
+                        armEndpoint:
+                          description: armEndpoint specifies a URL to use for resource management in non-soverign clouds such as Azure Stack.
+                          type: string
+                        cloudName:
+                          description: cloudName is the name of the Azure cloud environment which can be used to configure the Azure SDK with the appropriate Azure API endpoints. If empty, the value is equal to `AzurePublicCloud`.
+                          type: string
+                          enum:
+                            - ""
+                            - AzurePublicCloud
+                            - AzureUSGovernmentCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureStackCloud
+                        networkResourceGroupName:
+                          description: networkResourceGroupName is the Resource Group for network resources like the Virtual Network and Subnets used by the cluster. If empty, the value is same as ResourceGroupName.
+                          type: string
+                        resourceGroupName:
+                          description: resourceGroupName is the Resource Group for new Azure resources created for the cluster.
+                          type: string
+                    baremetal:
+                      description: BareMetal contains settings specific to the BareMetal platform.
+                      type: object
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for BareMetal deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                    equinixMetal:
+                      description: EquinixMetal contains settings specific to the Equinix Metal infrastructure provider.
+                      type: object
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                    gcp:
+                      description: GCP contains settings specific to the Google Cloud Platform infrastructure provider.
+                      type: object
+                      properties:
+                        projectID:
+                          description: resourceGroupName is the Project ID for new GCP resources created for the cluster.
+                          type: string
+                        region:
+                          description: region holds the region for new GCP resources created for the cluster.
+                          type: string
+                    ibmcloud:
+                      description: IBMCloud contains settings specific to the IBMCloud infrastructure provider.
+                      type: object
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        location:
+                          description: Location is where the cluster has been deployed
+                          type: string
+                        providerType:
+                          description: ProviderType indicates the type of cluster that was created
+                          type: string
+                        resourceGroupName:
+                          description: ResourceGroupName is the Resource Group for new IBMCloud resources created for the cluster.
+                          type: string
+                    kubevirt:
+                      description: Kubevirt contains settings specific to the kubevirt infrastructure provider.
+                      type: object
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                    openstack:
+                      description: OpenStack contains settings specific to the OpenStack infrastructure provider.
+                      type: object
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        cloudName:
+                          description: cloudName is the name of the desired OpenStack cloud in the client configuration file (`clouds.yaml`).
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for OpenStack deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+                    ovirt:
+                      description: Ovirt contains settings specific to the oVirt infrastructure provider.
+                      type: object
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                        nodeDNSIP:
+                          description: 'deprecated: as of 4.6, this field is no longer set or honored.  It will be removed in a future release.'
+                          type: string
+                    powervs:
+                      description: PowerVS contains settings specific to the Power Systems Virtual Servers infrastructure provider.
+                      type: object
+                      properties:
+                        cisInstanceCRN:
+                          description: CISInstanceCRN is the CRN of the Cloud Internet Services instance managing the DNS zone for the cluster's base domain
+                          type: string
+                        region:
+                          description: region holds the default Power VS region for new Power VS resources created by the cluster.
+                          type: string
+                        serviceEndpoints:
+                          description: serviceEndpoints is a list of custom endpoints which will override the default service endpoints of a Power VS service.
+                          type: array
+                          items:
+                            description: PowervsServiceEndpoint stores the configuration of a custom url to override existing defaults of PowerVS Services.
+                            type: object
+                            required:
+                              - name
+                              - url
+                            properties:
+                              name:
+                                description: name is the name of the Power VS service. Few of the services are IAM - https://cloud.ibm.com/apidocs/iam-identity-token-api ResourceController - https://cloud.ibm.com/apidocs/resource-controller/resource-controller Power Cloud - https://cloud.ibm.com/apidocs/power-cloud
+                                type: string
+                                pattern: ^[a-z0-9-]+$
+                              url:
+                                description: url is fully qualified URI with scheme https, that overrides the default generated endpoint for a client. This must be provided and cannot be empty.
+                                type: string
+                                format: uri
+                                pattern: ^https://
+                        zone:
+                          description: 'zone holds the default zone for the new Power VS resources created by the cluster. Note: Currently only single-zone OCP clusters are supported'
+                          type: string
+                    type:
+                      description: "type is the underlying infrastructure provider for the cluster. This value controls whether infrastructure automation such as service load balancers, dynamic volume provisioning, machine creation and deletion, and other integrations are enabled. If None, no infrastructure automation is enabled. Allowed values are \"AWS\", \"Azure\", \"BareMetal\", \"GCP\", \"Libvirt\", \"OpenStack\", \"VSphere\", \"oVirt\", \"EquinixMetal\", \"PowerVS\", \"AlibabaCloud\" and \"None\". Individual components may not support all platforms, and must handle unrecognized platforms as None if they do not support that platform. \n This value will be synced with to the `status.platform` and `status.platformStatus.type`. Currently this value cannot be changed once set."
+                      type: string
+                      enum:
+                        - ""
+                        - AWS
+                        - Azure
+                        - BareMetal
+                        - GCP
+                        - Libvirt
+                        - OpenStack
+                        - None
+                        - VSphere
+                        - oVirt
+                        - IBMCloud
+                        - KubeVirt
+                        - EquinixMetal
+                        - PowerVS
+                        - AlibabaCloud
+                    vsphere:
+                      description: VSphere contains settings specific to the VSphere infrastructure provider.
+                      type: object
+                      properties:
+                        apiServerInternalIP:
+                          description: apiServerInternalIP is an IP address to contact the Kubernetes API server that can be used by components inside the cluster, like kubelets using the infrastructure rather than Kubernetes networking. It is the IP that the Infrastructure.status.apiServerInternalURI points to. It is the IP for a self-hosted load balancer in front of the API servers.
+                          type: string
+                        ingressIP:
+                          description: ingressIP is an external IP which routes to the default ingress controller. The IP is a suitable target of a wildcard DNS record used to resolve default route host names.
+                          type: string
+                        nodeDNSIP:
+                          description: nodeDNSIP is the IP address for the internal DNS used by the nodes. Unlike the one managed by the DNS operator, `NodeDNSIP` provides name resolution for the nodes themselves. There is no DNS-as-a-service for vSphere deployments. In order to minimize necessary changes to the datacenter DNS, a DNS service is hosted as a static pod to serve those hostnames to the nodes in the cluster.
+                          type: string
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
Enable sriov operator in the cluster w/o master nodes (k8s apiserver and other control plane components are managed externally).