### PR TITLE
Add Intel E810 PF 1591 Network Adapter

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -11,6 +11,7 @@ data:
   Intel_ice_Columbiaville_E810-CQDA2_2CQDA2: "8086 1592 1889"
   Intel_ice_Columbiaville_E810-XXVDA4: "8086 1593 1889"
   Intel_ice_Columbiaville_E810-XXVDA2: "8086 159b 1889"
+  Intel_ice_Columbiaville_E810: "8086 1591 1889"
   Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
   Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
   Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -11,6 +11,7 @@ data:
   Intel_ice_Columbiaville_E810-CQDA2_2CQDA2: "8086 1592 1889"
   Intel_ice_Columbiaville_E810-XXVDA4: "8086 1593 1889"
   Intel_ice_Columbiaville_E810-XXVDA2: "8086 159b 1889"
+  Intel_ice_Columbiaville_E810: "8086 1591 1889"
   Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
   Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
   Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -5,6 +5,7 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Model                    | Vendor ID | Device ID |
 | ------------------------ | --------- | --------- |
 | Intel XXV710 Family |  8086 | 158b |
+| Intel E810 Family | 8086  | 1591 |
 | Intel E810-CQDA2/2CQDA2 Family | 8086  | 1592 |
 | Intel E810-XXVDA4 Family | 8086  | 1593 |
 | Intel E810-XXVDA2 Family | 8086  | 159b |
@@ -31,6 +32,7 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Model                    | SR-IOV Kernel | SR-IOV DPDK | SR-IOV Hardware Offload (switchdev) |
 | ------------------------ | ------------- | ----------- |------------------------------------ |
 | Intel XXV710 Family | V | V | X |
+| Intel E810 Family | V | V | X |
 | Intel E810-CQDA2/2CQDA2 Family | V | V | X |
 | Intel E810-XXVDA4 Family | V | V | X |
 | Intel E810-XXVDA2 Family | V | V | X |
@@ -61,7 +63,7 @@ should follow the following procedure:
 * Add information of what was tested to the issue opened
 * Add contact point information to [vendor-support.md](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/vendor-support.md), so we know who to reach out if issues arise when running sriov-network-operator against the specified hardware.
 * Submit PR to add your device to this file as well as to supported-nic-ids configMap [here](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/deployment/sriov-network-operator/templates/configmap.yaml) and [here](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/deploy/configmap.yaml).
-  * The tables above should be updated according to what was tested 
+  * The tables above should be updated according to what was tested
 
 ## Continuous support
 To ensure sriov-network-operator continues to operate as expected on supported hardware it is recommended that hardware vendors (or another party)


### PR DESCRIPTION
The Intel series of E810 cards with a 1591 PF ID need to be added to the supported card listing in OpenShift.  This PCI ID belongs to [Intel.](https://www.pcilookup.com/?ven=8086&dev=1591&action=submit)

Cards have Vendor ID 8086, PF 1591, and VF of 1889.

Note: Silicom TimeSync cards (STS2, STS4, etc) contain this embedded E810 in those particular network adapters.

Cards were tested internally in Red Hat and found to be passing.  Request of this PR is to get them to the supported list of devices.

