### PR TITLE
add support for Intel X557 Family

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -6,6 +6,7 @@ data:
   Intel_i40e_XXV710: "8086 158a 154c"
   Intel_i40e_25G_SFP28: "8086 158b 154c"
   Intel_i40e_10G_X710_SFP: "8086 1572 154c"
+  Intel_i40e_X710_X557_AT_10G: "8086 1589 154c"
   Intel_i40e_XXV710_N3000: "8086 0d58 154c"
   Intel_i40e_40G_XL710_QSFP: "8086 1583 154c"
   Intel_ice_Columbiaville_E810-CQDA2_2CQDA2: "8086 1592 1889"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -6,6 +6,7 @@ data:
   Intel_i40e_XXV710: "8086 158a 154c"
   Intel_i40e_25G_SFP28: "8086 158b 154c"
   Intel_i40e_10G_X710_SFP: "8086 1572 154c"
+  Intel_i40e_X710_X557_AT_10G: "8086 1589 154c"
   Intel_i40e_XXV710_N3000: "8086 0d58 154c"
   Intel_i40e_40G_XL710_QSFP: "8086 1583 154c"
   Intel_ice_Columbiaville_E810-CQDA2_2CQDA2: "8086 1592 1889"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -5,6 +5,7 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Model                    | Vendor ID | Device ID |
 | ------------------------ | --------- | --------- |
 | Intel XXV710 Family |  8086 | 158b |
+| Intel X557 Family |  8086 | 1589 |
 | Intel E810 Family | 8086  | 1591 |
 | Intel E810-CQDA2/2CQDA2 Family | 8086  | 1592 |
 | Intel E810-XXVDA4 Family | 8086  | 1593 |
@@ -32,6 +33,7 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Model                    | SR-IOV Kernel | SR-IOV DPDK | SR-IOV Hardware Offload (switchdev) |
 | ------------------------ | ------------- | ----------- |------------------------------------ |
 | Intel XXV710 Family | V | V | X |
+| Intel X557 Family | V | V | X |
 | Intel E810 Family | V | V | X |
 | Intel E810-CQDA2/2CQDA2 Family | V | V | X |
 | Intel E810-XXVDA4 Family | V | V | X |


### PR DESCRIPTION
The Intel Ethernet Connection X557 family is utilized in IBM Cloud bare metals. This adds support for being able to utilize SR-IOV in IBM Cloud when the bare metals have those ethernet cards.