### PR TITLE
Wait for writer response on Refresh

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -413,6 +413,8 @@ func (dn *Daemon) nodeStateSyncHandler(generation int64) error {
 				syncStatus:    "Succeeded",
 				lastSyncError: "",
 			}
+			// wait for writer to refresh the status
+			<-dn.syncCh
 		}
 
 		return nil


### PR DESCRIPTION
When sending a Refresh message to Writer's refresh channel,
if the state is "Succeeded" or "Failed", the Writer will update
the sync channel when finished.

Therefore there is a need to wait on sync channel on the Daemon side
when sending "Succeeded" or "Failed".

Signed-off-by: Fred Rolland <frolland@nvidia.com>