### PR TITLE
load vhost-net kernel module

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -206,6 +206,7 @@ func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
 
 	tryEnableRdma()
 	tryEnableTun()
+	tryEnableVhostNet()
 
 	if err := dn.tryCreateUdevRuleWrapper(); err != nil {
 		return err
@@ -902,6 +903,12 @@ func (dn *Daemon) drainNode() error {
 func tryEnableTun() {
 	if err := utils.LoadKernelModule("tun"); err != nil {
 		glog.Errorf("tryEnableTun(): TUN kernel module not loaded: %v", err)
+	}
+}
+
+func tryEnableVhostNet() {
+	if err := utils.LoadKernelModule("vhost_net"); err != nil {
+		glog.Errorf("tryEnableVhostNet(): VHOST_NET kernel module not loaded: %v", err)
 	}
 }
 


### PR DESCRIPTION
This commit is needed when using DPDK with vhost-net in virtio mode.
We must load the vhost-net kernel module if we don't want the dpdk
application to run with privilege

Signed-off-by: Sebastian Sch <sebassch@gmail.com>