### PR TITLE
Remove `go get <binary>` instances

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ ENVTEST = $(shell pwd)/bin/setup-envtest
 envtest: ## Download envtest-setup locally if necessary.
 	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
-# go-get-tool will 'go get' any package $2 and install it to $1.
+# go-get-tool will 'go install' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
 @[ -f $(1) ] || { \

--- a/hack/run-e2e-conformance.sh
+++ b/hack/run-e2e-conformance.sh
@@ -8,7 +8,7 @@ if [ $? -ne 0 ]; then
 	GINKGO_TMP_DIR=$(mktemp -d)
 	cd $GINKGO_TMP_DIR
 	go mod init tmp
-	go get github.com/onsi/ginkgo/ginkgo@v1.12.0 
+	go install github.com/onsi/ginkgo/ginkgo@v1.16.5
 	rm -rf $GINKGO_TMP_DIR	
 	echo "Downloading ginkgo tool"
 	cd -


### PR DESCRIPTION
Go getting bninaries has been deprecated in go1.17 and not supported
in go1.18.

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>