### PR TITLE
Set `mod=readonly` when installing binaries

### DIFF
--- a/hack/run-e2e-conformance.sh
+++ b/hack/run-e2e-conformance.sh
@@ -8,7 +8,7 @@ if [ $? -ne 0 ]; then
 	GINKGO_TMP_DIR=$(mktemp -d)
 	cd $GINKGO_TMP_DIR
 	go mod init tmp
-	go install github.com/onsi/ginkgo/ginkgo@v1.16.5
+	go install -mod=readonly github.com/onsi/ginkgo/ginkgo@v1.16.5
 	rm -rf $GINKGO_TMP_DIR	
 	echo "Downloading ginkgo tool"
 	cd -


### PR DESCRIPTION
If no `-mod` argument is specified, GOLFAGS environment
variable takes place. If it contains `mod=vendor` (like Makefile
actually does), goinstall can fail with:

```
go install: github.com/onsi/ginkgo/ginkgo@v1.16.5: cannot query module due to -mod=vendor
```

Signed-off-by: Andrea Panattoni <apanatto@redhat.com>