### PR TITLE
Stick with go <1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Set up Go 1.18
       uses: actions/setup-go@v3
       with:
-        go-version: '>=1.18.2'
+        go-version: '>=1.18.2 <1.19'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
     - name: Set up Go 1.18
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.2
+        go-version: '>=1.18.2 <1.19'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go 1.18
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.2
+        go-version: '>=1.18.2 <1.19'
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
     - name: golangci-lint
@@ -69,7 +69,7 @@ jobs:
     - name: Set up Go 1.18
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.2
+        go-version: '>=1.18.2 <1.19'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,6 @@
 # Tested with golangci-lint ver. 1.37
 run:
-  timeout: 3m
+  timeout: 10m
   skip-dirs:
     - vendor/
     - .github/


### PR DESCRIPTION
Using a dynamic version like '>=1.18.2' may lead to unexpected
build results, with new go tools in place.

This PR should fix [errors like this](https://github.com/k8snetworkplumbingwg/sriov-network-operator/runs/7875123215?check_suite_focus=true), as they occur due to go 1.19

```
Run actions/setup-go@v3
Setup go version spec >=1.18.2
Found in cache @ /opt/hostedtoolcache/go/1.19.0/x64
Added go to the path
Successfully set up Go version >=1.1[8](https://github.com/k8snetworkplumbingwg/sriov-network-operator/runs/7839168685?check_suite_focus=true#step:2:9).2
go version go1.1[9](https://github.com/k8snetworkplumbingwg/sriov-network-operator/runs/7839168685?check_suite_focus=true#step:2:10) linux/amd64
```
