### PR TITLE
Add support for BF2 in connectX mode

### DIFF
--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -88,12 +88,21 @@ func (p *GenericPlugin) Apply() error {
 			return nil
 		}
 	}
+
+	// Create a map with all the PFs we will need to configure
+	// we need to create it here before we access the host file system using the chroot function
+	// because the skipConfigVf needs the mstconfig package that exist only inside the sriov-config-daemon file system
+	pfsToSkip, err := utils.GetPfsToSkip(p.DesireState)
+	if err != nil {
+		return err
+	}
+
 	exit, err := utils.Chroot("/host")
 	if err != nil {
 		return err
 	}
 	defer exit()
-	if err := utils.SyncNodeState(p.DesireState); err != nil {
+	if err := utils.SyncNodeState(p.DesireState, pfsToSkip); err != nil {
 		return err
 	}
 	p.LastState = &sriovnetworkv1.SriovNetworkNodeState{}

--- a/pkg/utils/utils_mlx.go
+++ b/pkg/utils/utils_mlx.go
@@ -1,0 +1,117 @@
+package utils
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/golang/glog"
+)
+
+//BlueField mode representation
+type BlueFieldMode int
+
+const (
+	bluefieldDpu BlueFieldMode = iota
+	bluefieldConnectXMode
+
+	internalCPUPageSupplier   = "INTERNAL_CPU_PAGE_SUPPLIER"
+	internalCPUEswitchManager = "INTERNAL_CPU_ESWITCH_MANAGER"
+	internalCPUIbVporto       = "INTERNAL_CPU_IB_VPORT0"
+	internalCPUOffloadEngine  = "INTERNAL_CPU_OFFLOAD_ENGINE"
+	internalCPUModel          = "INTERNAL_CPU_MODEL"
+
+	ecpf        = "ECPF"
+	extHostPf   = "EXT_HOST_PF"
+	embeddedCPU = "EMBEDDED_CPU"
+
+	disabled = "DISABLED"
+	enabled  = "ENABLED"
+)
+
+func MstConfigReadData(pciAddress string) (string, error) {
+	glog.Infof("MstConfigReadData(): device %s", pciAddress)
+	args := []string{"-e", "-d", pciAddress, "q"}
+	out, err := RunCommand("mstconfig", args...)
+	return out, err
+}
+
+func ParseMstconfigOutput(mstOutput string, attributes []string) (fwCurrent, fwNext map[string]string) {
+	glog.Infof("ParseMstconfigOutput(): Attributes %v", attributes)
+	fwCurrent = map[string]string{}
+	fwNext = map[string]string{}
+	formatRegex := regexp.MustCompile(`(?P<Attribute>\w+)\s+(?P<Default>\S+)\s+(?P<Current>\S+)\s+(?P<Next>\S+)`)
+	mstOutputLines := strings.Split(mstOutput, "\n")
+	for _, attr := range attributes {
+		for _, line := range mstOutputLines {
+			if strings.Contains(line, attr) {
+				regexResult := formatRegex.FindStringSubmatch(line)
+				fwCurrent[attr] = regexResult[3]
+				fwNext[attr] = regexResult[4]
+				break
+			}
+		}
+	}
+	return
+}
+
+func mellanoxBlueFieldMode(PciAddress string) (BlueFieldMode, error) {
+	glog.V(2).Infof("MellanoxBlueFieldMode():checking mode for card %s", PciAddress)
+	out, err := MstConfigReadData(PciAddress)
+	if err != nil {
+		glog.Errorf("MellanoxBlueFieldMode(): failed to get mlx nic fw data %v", err)
+		return -1, fmt.Errorf("failed to get mlx nic fw data %v", err)
+	}
+
+	attrs := []string{internalCPUPageSupplier,
+		internalCPUEswitchManager,
+		internalCPUIbVporto,
+		internalCPUOffloadEngine,
+		internalCPUModel}
+	mstCurrentData, _ := ParseMstconfigOutput(out, attrs)
+
+	internalCPUPageSupplierstatus, exist := mstCurrentData[internalCPUPageSupplier]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUPageSupplier)
+	}
+
+	internalCPUEswitchManagerStatus, exist := mstCurrentData[internalCPUEswitchManager]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUEswitchManager)
+	}
+
+	internalCPUIbVportoStatus, exist := mstCurrentData[internalCPUIbVporto]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUIbVporto)
+	}
+
+	internalCPUOffloadEngineStatus, exist := mstCurrentData[internalCPUOffloadEngine]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUOffloadEngine)
+	}
+
+	internalCPUModelStatus, exist := mstCurrentData[internalCPUModel]
+	if !exist {
+		return 0, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUModel)
+	}
+
+	// check for DPU
+	if strings.Contains(internalCPUPageSupplierstatus, ecpf) &&
+		strings.Contains(internalCPUEswitchManagerStatus, ecpf) &&
+		strings.Contains(internalCPUIbVportoStatus, ecpf) &&
+		strings.Contains(internalCPUOffloadEngineStatus, enabled) &&
+		strings.Contains(internalCPUModelStatus, embeddedCPU) {
+		glog.V(2).Infof("MellanoxBlueFieldMode():card %s in DPU mode", PciAddress)
+		return bluefieldDpu, nil
+	} else if strings.Contains(internalCPUPageSupplierstatus, extHostPf) &&
+		strings.Contains(internalCPUEswitchManagerStatus, extHostPf) &&
+		strings.Contains(internalCPUIbVportoStatus, extHostPf) &&
+		strings.Contains(internalCPUOffloadEngineStatus, disabled) &&
+		strings.Contains(internalCPUModelStatus, embeddedCPU) {
+		glog.V(2).Infof("MellanoxBlueFieldMode():card %s in ConnectX mode", PciAddress)
+		return bluefieldConnectXMode, nil
+	}
+
+	glog.Errorf("MellanoxBlueFieldMode(): unknown card status for %s mstconfig output \n %s", PciAddress, out)
+	return -1, fmt.Errorf("MellanoxBlueFieldMode(): unknown card status for %s", PciAddress)
+}


### PR DESCRIPTION
Fix the issue introduced in https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/240/files#r808624002

Allow to use BF in connectX mode also for OCP platform.
This is needed until we support the systemd configuration

Signed-off-by: Sebastian Sch <sebassch@gmail.com>