### PR TITLE
Adding support for Octeon DPU family

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -24,3 +24,8 @@ data:
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"
+  Marvell_OCTEON_TX2_CN98XX: "177d b100 b103"
+  Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"
+  Marvell_OCTEON10_CN10XXX: "177d b900 b903"
+  Marvell_OCTEON_Fusion_CNF105XX: "177d ba00 ba03"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -24,3 +24,8 @@ data:
   Broadcom_bnxt_BCM75508_2x100G: "14e4 1750 1806"
   Qlogic_qede_QL45000_50G: "1077 1654 1664"
   Red_Hat_Virtio_network_device: "1af4 1000 1000"
+  Marvell_OCTEON_TX2_CN96XX: "177d b200 b203"
+  Marvell_OCTEON_TX2_CN98XX: "177d b100 b103"
+  Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"
+  Marvell_OCTEON10_CN10XXX: "177d b900 b903"
+  Marvell_OCTEON_Fusion_CNF105XX: "177d ba00 ba03"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -18,6 +18,11 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Mellanox MT28908 Family [ConnectX-6 Dx] | 15b3 | 101d |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | 15b3 | a2d6 |
 | Qlogic QL45000 Series 50GbE Controller | 1077 | 1654 |
+| Marvell OCTEON TX2 CN96XX | 177d | b200 |
+| Marvell OCTEON TX2 CN98XX | 177d | b100 |
+| Marvell OCTEON Fusion CNF95XX | 177d | b600 |
+| Marvell OCTEON 10 CN10XXX | 177d | b900 |
+| Marvell OCTEON Fusion CNF105XX | 177d | ba00 |
 
 > **Note:** sriov-network-operator maintains a list of supported NICs which it supports.
 > These are stored in supported-nic-ids [configMap](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/deployment/sriov-network-operator/templates/configmap.yaml).
@@ -46,6 +51,11 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Mellanox MT28908 Family [ConnectX-6 Dx] | V | V | V |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | V | V | V |
 | Qlogic QL45000 Series 50GbE Controller | V | X | X |
+| Marvell OCTEON TX2 CN96XX | V | V | X |
+| Marvell OCTEON TX2 CN98XX | V | V | X |
+| Marvell OCTEON Fusion CNF95XX | V | V | X |
+| Marvell OCTEON 10 CN10XXX | V | V | X |
+| Marvell OCTEON Fusion CNF105XX | V | V | X |
 
 # Adding new Hardware
 

--- a/doc/vendor-support.md
+++ b/doc/vendor-support.md
@@ -12,4 +12,4 @@ as `active-in-project` in the table below.
 | Nvidia(Mellanox) | active-in-project |
 | Intel | active-in-project |
 | HPE(Marvell Qlogic) | BSN_dev_support@hpe.com |
-
+| Marvell | navadiaev@marvell.com |


### PR DESCRIPTION
Issue was opened per instructions:

https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/355