### PR TITLE
config-daemon: fix NM udev path

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -1026,8 +1026,8 @@ func tryCreateSwitchdevUdevRule(nodeState *sriovnetworkv1.SriovNetworkNodeState)
 
 func tryCreateNMUdevRule() error {
 	glog.V(2).Infof("tryCreateNMUdevRule()")
-	dirPath := path.Join(filesystemRoot, "/host/etc/udev/rules.d/")
-	filePath := dirPath + "10-nm-unmanaged.rules"
+	dirPath := path.Join(filesystemRoot, "/host/etc/udev/rules.d")
+	filePath := path.Join(dirPath, "10-nm-unmanaged.rules")
 
 	newContent := fmt.Sprintf("ACTION==\"add|change|move\", ATTRS{device}==\"%s\", ENV{NM_UNMANAGED}=\"1\"\n", strings.Join(sriovnetworkv1.GetSupportedVfIds(), "|"))
 


### PR DESCRIPTION
Function `tryCreateNMUdevRule()` was wrongly
concatenating path components, as `path.Join(...)`
removes every trailing slashes to the output string.

This regression has been introduced by
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/273

Error showed up in logs with:

```
I1007 12:20:21.325679 10055 daemon.go:1026] tryCreateNMUdevRule()
I1007 12:20:21.325740 10055 daemon.go:1041] Old udev content '' and new content 'ACTION=="add|change|move", ATTRS

{device}=="0x1000|0x1003|0x1004|0x1014|0x1016|0x1018|0x101a|0x101c|0x101e|0x10ed|0x1515|0x154c|0x1565|0x1664|0x16c1|0x1806|0x1889|0x8090", ENV{NM_UNMANAGED}="1"
SUBSYSTEM=="net", ACTION=="add|move", ATTRS{phys_switch_id}!="", ATTR{phys_port_name}=="pf*vf*", ENV{NM_UNMANAGED}="1"' differ. Writing to file /host/etc/udev/rules.d10-nm-unmanaged.rules.
E1007 12:20:21.325772 10055 daemon.go:1048] tryCreateNMUdevRule(): failed to create dir /host/etc/udev/rules.d: mkdir /host: operation not permitted
I1007 12:20:21.325793 10055 daemon.go:294] Could not create udev rule: mkdir /host: operation not permitted
```