### PR TITLE
Improve `config-daemon` logging

### DIFF
--- a/pkg/daemon/writer.go
+++ b/pkg/daemon/writer.go
@@ -73,7 +73,10 @@ func (w *NodeStateStatusWriter) RunOnce(destDir string, platformType utils.Platf
 		glog.Errorf("RunOnce(): first poll failed: %v", err)
 	}
 
-	ns, _ := w.setNodeStateStatus(msg)
+	ns, err := w.setNodeStateStatus(msg)
+	if err != nil {
+		glog.Errorf("RunOnce(): first writing to node status failed: %v", err)
+	}
 	return w.writeCheckpointFile(ns, destDir)
 }
 
@@ -93,7 +96,11 @@ func (w *NodeStateStatusWriter) Run(stop <-chan struct{}, refresh <-chan Message
 			if err := w.pollNicStatus(platformType); err != nil {
 				continue
 			}
-			w.setNodeStateStatus(msg)
+			_, err := w.setNodeStateStatus(msg)
+			if err != nil {
+				glog.Errorf("Run() refresh: writing to node status failed: %v", err)
+			}
+
 			if msg.syncStatus == syncStatusSucceeded || msg.syncStatus == syncStatusFailed {
 				syncCh <- struct{}{}
 			}
@@ -102,7 +109,10 @@ func (w *NodeStateStatusWriter) Run(stop <-chan struct{}, refresh <-chan Message
 			if err := w.pollNicStatus(platformType); err != nil {
 				continue
 			}
-			w.setNodeStateStatus(msg)
+			_, err := w.setNodeStateStatus(msg)
+			if err != nil {
+				glog.Errorf("Run() period: writing to node status failed: %v", err)
+			}
 		}
 	}
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -415,7 +415,7 @@ func configSriovDevice(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetwor
 }
 
 func setSriovNumVfs(pciAddr string, numVfs int) error {
-	glog.V(2).Infof("setSriovNumVfs(): set NumVfs for device %s", pciAddr)
+	glog.V(2).Infof("setSriovNumVfs(): set NumVfs for device %s to %d", pciAddr, numVfs)
 	numVfsFilePath := filepath.Join(sysBusPciDevices, pciAddr, numVfsFile)
 	bs := []byte(strconv.Itoa(numVfs))
 	err := ioutil.WriteFile(numVfsFilePath, []byte("0"), os.ModeAppend)
@@ -783,9 +783,8 @@ func RunCommand(command string, args ...string) (string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	glog.V(2).Infof("RunCommand(): %s, %v", command, args)
 	err := cmd.Run()
-	glog.V(2).Infof("RunCommand(): %s, %s", stdout.String(), err)
+	glog.V(2).Infof("RunCommand(): out:(%s), err:(%v)", stdout.String(), err)
 	return stdout.String(), err
 }
 


### PR DESCRIPTION
This PR aims to improve logs in `config-daemon` component, as:

- `utils.setSriovNumVfs(...)`: log  desired number of VF 
- `utils.RunCommand()`: avoid logging command twice, better print error.
- Log `daemon.setNodeStateStatus()` in case of errors