### PR TITLE
Add support for operator deployment on PSA

### DIFF
--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: $NAMESPACE
   labels:
     name: $NAMESPACE
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: v1.24
+    security.openshift.io/scc.podSecurityLabelSync: "false"

--- a/deployment/sriov-network-operator/README.md
+++ b/deployment/sriov-network-operator/README.md
@@ -42,6 +42,9 @@ For additional information and methods for installing Helm, refer to the officia
 # Install Operator
 $ helm install -n sriov-network-operator --create-namespace --wait sriov-network-operator ./
 
+# Add PSA label for the sriov network operator namespace
+$ kubectl label ns sriov-network-operator pod-security.kubernetes.io/enforce=privileged
+
 # View deployed resources
 $ kubectl -n sriov-network-operator get pods
 ```


### PR DESCRIPTION
pod-security-admission is a new feature in k8s 1.25

https://kubernetes.io/docs/concepts/security/pod-security-admission/

This change allow to deploy the operator a k8s cluster with PSA enabled. This commit allow add the openshift label to allow the auto labeling

Signed-off-by: Sebastian Sch <sebassch@gmail.com>