### PR TITLE
Replace daemonset security context from privileged to runnning as roo…

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
       - name: sriov-cni
         image: {{.SRIOVCNIImage}}
         securityContext:
-          privileged: true
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m
@@ -52,7 +52,7 @@ spec:
       - name: sriov-infiniband-cni
         image: {{.SRIOVInfiniBandCNIImage}}
         securityContext:
-          privileged: true
+          runAsUser: 0
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
The deamonset needs to copy the plugin binaries to root owned filesystem.
Running as root should be enought for this.