### PR TITLE
Add the OvS max revalidator time to the ovs-vswitchd service

### DIFF
--- a/bindata/manifests/switchdev-config/ovs-units/ovs-vswitchd.service.yaml
+++ b/bindata/manifests/switchdev-config/ovs-units/ovs-vswitchd.service.yaml
@@ -3,4 +3,8 @@ dropins:
 - name: 10-hw-offload.conf
   contents: |
     [Service]
-    ExecStartPre=/bin/ovs-vsctl set Open_vSwitch . other_config:hw-offload=true
+    # Enable HW offload and set the max revalidator time.
+    # Workaround for Mellanox NICs, the max revalidator time needs to be extended to allow for higher than expected
+    # dump durations during the OvS revalidator sweep. This will prevent the flows from being deleted due to these unexpected
+    # delays.
+    ExecStartPre=/bin/ovs-vsctl set Open_vSwitch . other_config:hw-offload=true other_config:max-revalidator=1000


### PR DESCRIPTION
The OvS default max revalidator time is not enough for OvS Mellanox NICs. This is presumably only on the Mellanox NICs, however Mellanox NICs are the only NICs that currently support OvS HWOL with the SRIOV network operator. With the default OvS 500ms max revalidator time, it was observed during long duration traffic tests that the flows were removed momentarily then added back immediately. The max revalidator time needs to be extended to allow for higher than expected dump durations during the OvS revalidator sweep. This will prevent the flows from being deleted due to these unexpected delays.