### PR TITLE
Make sriov-network-config-daemon crash when configmap cannot be obtained

### DIFF
--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -184,6 +184,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	var namespace = os.Getenv("NAMESPACE")
 	if err := sriovnetworkv1.InitNicIDMap(kubeclient, namespace); err != nil {
 		glog.Errorf("failed to run init NicIdMap: %v", err)
+		panic(err.Error())
 	}
 
 	// block the deamon process until nodeWriter finish first its run


### PR DESCRIPTION
This PR adds a line to crash sriov-network-config-daemon if it can't access the configmap with NIC interfaces. 
Fixes #390