### PR TITLE
add support for mellanox/rdma-cni

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -38,6 +38,17 @@ spec:
       {{- end }}
       {{- end }}
       containers:
+      - name: rdma-cni
+        image: {{.RDMACNIImage}}
+        securityContext:
+          privileged: true
+        resources:
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+          - name: cnibin
+            mountPath: /host/opt/cni/bin
       - name: sriov-cni
         image: {{.SRIOVCNIImage}}
         securityContext:

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -171,6 +171,7 @@ func (r *SriovOperatorConfigReconciler) syncConfigDaemonSet(dc *sriovnetworkv1.S
 	data.Data["Namespace"] = namespace
 	data.Data["SRIOVCNIImage"] = os.Getenv("SRIOV_CNI_IMAGE")
 	data.Data["SRIOVInfiniBandCNIImage"] = os.Getenv("SRIOV_INFINIBAND_CNI_IMAGE")
+	data.Data["RDMACNIImage"] = os.Getenv("RDMA_CNI_IMAGE")
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASEVERSION")
 	data.Data["ClusterType"] = utils.ClusterType
 	data.Data["DevMode"] = os.Getenv("DEV_MODE")

--- a/deployment/sriov-network-operator/templates/operator.yaml
+++ b/deployment/sriov-network-operator/templates/operator.yaml
@@ -53,6 +53,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: RDMA_CNI_IMAGE
+              value: {{ .Values.images.rdmaCni }}
             - name: SRIOV_CNI_IMAGE
               value: {{ .Values.images.sriovCni }}
             - name: SRIOV_INFINIBAND_CNI_IMAGE

--- a/deployment/sriov-network-operator/values.yaml
+++ b/deployment/sriov-network-operator/values.yaml
@@ -35,5 +35,6 @@ images:
   sriovDevicePlugin: ghcr.io/k8snetworkplumbingwg/sriov-network-device-plugin
   resourcesInjector: ghcr.io/k8snetworkplumbingwg/network-resources-injector
   webhook: ghcr.io/k8snetworkplumbingwg/sriov-network-operator-webhook
+  rdmaCni: mellanox/rdma-cni
 
 imagePullSecrets: []

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -244,8 +244,6 @@ github.com/imdario/mergo
 # github.com/inconshreveable/mousetrap v1.0.0
 ## explicit
 github.com/inconshreveable/mousetrap
-# github.com/intel/sriov-network-device-plugin v3.0.0+incompatible
-## explicit
 # github.com/jaypipes/ghw v0.6.1
 ## explicit; go 1.12
 github.com/jaypipes/ghw


### PR DESCRIPTION
In addition to `sriov-cni`, we need to deploy `rdma-cni`. It would be great if we can add this as a component to the sriov-config-daemon DS