### PR TITLE
Enable smfs flow steering by default in switchdev mode.

### DIFF
--- a/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
@@ -62,8 +62,8 @@ contents:
           echo $VfPciAddr > /sys/bus/pci/drivers/mlx5_core/unbind || true
         done
         # set flow steering mode before entering switchdev mode
-        echo "Set flow steering mode to dmfs"
-        devlink dev param set pci/${pci_addr} name flow_steering_mode value dmfs cmode runtime
+        echo "Set flow steering mode to smfs"
+        devlink dev param set pci/${pci_addr} name flow_steering_mode value smfs cmode runtime
 
         # set PF to switchdev mode
         echo "Set eswitch mode to switchdev"


### PR DESCRIPTION
It was found that dmfs is slower than smfs. This affects dump duration of flows in OvS. Since smfs should replace dmfs moving forward, we will set smfs to be used by default.

Signed-off-by: William Zhao <wizhao@redhat.com>