### PR TITLE
remove unused volume from sriov-device-plugin DS

### DIFF
--- a/bindata/manifests/plugins/sriov-device-plugin.yaml
+++ b/bindata/manifests/plugins/sriov-device-plugin.yaml
@@ -69,9 +69,6 @@ spec:
         - name: devicesock
           hostPath:
             path: /var/lib/kubelet/
-        - name: net
-          hostPath:
-            path: /sys/class/net
         - name: config-volume
           configMap: 
             name: device-plugin-config


### PR DESCRIPTION
`/sys/class/net` is not mounted, so we can just remove the volume ref