### PR TITLE
add printercolumn for syncStatus in SriovNetworkNodeState

### DIFF
--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -91,6 +91,7 @@ type SriovNetworkNodeStateStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Sync Status",type=string,JSONPath=`.status.syncStatus`
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // SriovNetworkNodeState is the Schema for the sriovnetworknodestates API
 type SriovNetworkNodeState struct {

--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -90,6 +90,7 @@ type SriovNetworkNodeStateStatus struct {
 
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="Sync Status",type=string,JSONPath=`.status.syncStatus`
 
 // SriovNetworkNodeState is the Schema for the sriovnetworknodestates API
 type SriovNetworkNodeState struct {

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .status.syncStatus
       name: Sync Status
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -15,7 +15,11 @@ spec:
     singular: sriovnetworknodestate
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.syncStatus
+      name: Sync Status
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -19,6 +19,9 @@ spec:
     - jsonPath: .status.syncStatus
       name: Sync Status
       type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1
     schema:
       openAPIV3Schema:

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -15,7 +15,11 @@ spec:
     singular: sriovnetworknodestate
   scope: Namespaced
   versions:
-  - name: v1
+  - additionalPrinterColumns:
+    - jsonPath: .status.syncStatus
+      name: Sync Status
+      type: string
+    name: v1
     schema:
       openAPIV3Schema:
         description: SriovNetworkNodeState is the Schema for the sriovnetworknodestates

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -103,14 +103,15 @@ type Daemon struct {
 }
 
 const (
-	rdmaScriptsPath     = "/bindata/scripts/enable-rdma.sh"
-	udevScriptsPath     = "/bindata/scripts/load-udev.sh"
-	annoKey             = "sriovnetwork.openshift.io/state"
-	annoIdle            = "Idle"
-	annoDraining        = "Draining"
-	annoMcpPaused       = "Draining_MCP_Paused"
-	syncStatusSucceeded = "Succeeded"
-	syncStatusFailed    = "Failed"
+	rdmaScriptsPath      = "/bindata/scripts/enable-rdma.sh"
+	udevScriptsPath      = "/bindata/scripts/load-udev.sh"
+	annoKey              = "sriovnetwork.openshift.io/state"
+	annoIdle             = "Idle"
+	annoDraining         = "Draining"
+	annoMcpPaused        = "Draining_MCP_Paused"
+	syncStatusSucceeded  = "Succeeded"
+	syncStatusFailed     = "Failed"
+	syncStatusInProgress = "InProgress"
 )
 
 var namespace = os.Getenv("NAMESPACE")
@@ -448,7 +449,7 @@ func (dn *Daemon) nodeStateSyncHandler() error {
 	}
 
 	dn.refreshCh <- Message{
-		syncStatus:    "InProgress",
+		syncStatus:    syncStatusInProgress,
 		lastSyncError: "",
 	}
 


### PR DESCRIPTION
It would be useful to see the status of all nodes when querying through `SriovNetworkNodeStates`

