### PR TITLE
Pretty print CNI config when rendering NetAttachDefs

### DIFF
--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controllers
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
 	"strings"
 
@@ -37,4 +39,12 @@ func GetImagePullSecrets() []string {
 	} else {
 		return []string{}
 	}
+}
+
+func formatJSON(str string) (string, error) {
+	var prettyJSON bytes.Buffer
+	if err := json.Indent(&prettyJSON, []byte(str), "", "    "); err != nil {
+		return "", err
+	}
+	return prettyJSON.String(), nil
 }

--- a/controllers/sriovibnetwork_controller.go
+++ b/controllers/sriovibnetwork_controller.go
@@ -117,6 +117,12 @@ func (r *SriovIBNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	// format CNI config json in CR for easier readability
+	netAttDef.Spec.Config, err = formatJSON(netAttDef.Spec.Config)
+	if err != nil {
+		reqLogger.Error(err, "Couldn't process rendered NetworkAttachmentDefinition config", "Namespace", netAttDef.Namespace, "Name", netAttDef.Name)
+		return reconcile.Result{}, err
+	}
 	if lnns, ok := instance.GetAnnotations()[sriovnetworkv1.LASTNETWORKNAMESPACE]; ok && netAttDef.GetNamespace() != lnns {
 		err = r.Delete(ctx, &netattdefv1.NetworkAttachmentDefinition{
 			ObjectMeta: metav1.ObjectMeta{

--- a/controllers/sriovnetwork_controller.go
+++ b/controllers/sriovnetwork_controller.go
@@ -118,6 +118,12 @@ func (r *SriovNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	if err != nil {
 		return reconcile.Result{}, err
 	}
+	// format CNI config json in CR for easier readability
+	netAttDef.Spec.Config, err = formatJSON(netAttDef.Spec.Config)
+	if err != nil {
+		reqLogger.Error(err, "Couldn't process rendered NetworkAttachmentDefinition config", "Namespace", netAttDef.Namespace, "Name", netAttDef.Name)
+		return reconcile.Result{}, err
+	}
 	if lnns, ok := instance.GetAnnotations()[sriovnetworkv1.LASTNETWORKNAMESPACE]; ok && netAttDef.GetNamespace() != lnns {
 		err = r.Delete(ctx, &netattdefv1.NetworkAttachmentDefinition{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
When debugging CNI configs, it becomes a lot easier when we can see pretty-printed JSON in NetworkAttachmentDefinitions