### PR TITLE
Update support for operator deployment on PSA

### DIFF
--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -4,3 +4,6 @@ metadata:
   name: $NAMESPACE
   labels:
     name: $NAMESPACE
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/deployment/sriov-network-operator/README.md
+++ b/deployment/sriov-network-operator/README.md
@@ -46,6 +46,11 @@ $ helm install -n sriov-network-operator --create-namespace --wait sriov-network
 $ kubectl -n sriov-network-operator get pods
 ```
 
+In the case that [Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) is enabled, the sriov network operator namespace will require a security level of 'privileged'
+```
+$ kubectl label ns sriov-network-operator pod-security.kubernetes.io/enforce=privileged
+```
+
 ## Chart parameters
 
 In order to tailor the deployment of the network operator to your cluster needs


### PR DESCRIPTION
PR #371 provided changes to allow the deployment of the operator when PSA is enabled.

https://kubernetes.io/docs/concepts/security/pod-security-admission/

This commit provides minor updates to address comments on the previous PR.

Signed-off-by: Salvatore Daniele <sdaniele@redhat.com>
Co-authored-by: Sebastian Sch <sebassch@gmail.com>