### PR TITLE
Fix networks-status annotation in e2e tests

### DIFF
--- a/test/util/network/network.go
+++ b/test/util/network/network.go
@@ -86,7 +86,7 @@ func CreateSriovPolicy(clientSet *testclient.ClientSet, generatedName string, op
 func GetNicsByPrefix(pod *k8sv1.Pod, ifcPrefix string) ([]string, error) {
 	var nets []Network
 	nics := []string{}
-	err := json.Unmarshal([]byte(pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks-status"]), &nets)
+	err := json.Unmarshal([]byte(pod.ObjectMeta.Annotations[netattdefv1.NetworkStatusAnnot]), &nets)
 	if err != nil {
 		return nil, err
 	}
@@ -101,15 +101,15 @@ func GetNicsByPrefix(pod *k8sv1.Pod, ifcPrefix string) ([]string, error) {
 // GetSriovNicIPs returns the list of ip addresses related to the given
 // interface name for the given pod.
 func GetSriovNicIPs(pod *k8sv1.Pod, ifcName string) ([]string, error) {
-	networksStatus, ok := pod.ObjectMeta.Annotations["k8s.v1.cni.cncf.io/networks-status"]
+	networksStatus, ok := pod.ObjectMeta.Annotations[netattdefv1.NetworkStatusAnnot]
 	if !ok {
-		return nil, fmt.Errorf("pod [%s] has no annotation `k8s.v1.cni.cncf.io/networks-status`", pod.Name)
+		return nil, fmt.Errorf("pod [%s] has no annotation `%s`", netattdefv1.NetworkStatusAnnot, pod.Name)
 	}
 
 	var nets []Network
 	err := json.Unmarshal([]byte(networksStatus), &nets)
 	if err != nil {
-		return nil, fmt.Errorf("can't unmarshal annotation `k8s.v1.cni.cncf.io/networks-status`: %w", err)
+		return nil, fmt.Errorf("can't unmarshal annotation `%s`: %w", netattdefv1.NetworkStatusAnnot, err)
 	}
 	for _, net := range nets {
 		if net.Interface != ifcName {

--- a/test/util/network/network_test.go
+++ b/test/util/network/network_test.go
@@ -3,6 +3,7 @@ package network
 import (
 	"testing"
 
+	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/stretchr/testify/assert"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -10,7 +11,7 @@ import (
 )
 
 func TestGetSriovNicIPs(t *testing.T) {
-	networksStatus := `[{
+	networkStatus := `[{
 		"name": "network1",
 		    "interface": "eth0",
 		"ips": [
@@ -39,7 +40,7 @@ func TestGetSriovNicIPs(t *testing.T) {
 	p := &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"k8s.v1.cni.cncf.io/networks-status": networksStatus,
+				netattdefv1.NetworkStatusAnnot: networkStatus,
 			},
 		},
 	}
@@ -61,12 +62,12 @@ func TestGetSriovNicIPsErrors(t *testing.T) {
 	p := &k8sv1.Pod{}
 	_, err := GetSriovNicIPs(p, "eth0")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "has no annotation `k8s.v1.cni.cncf.io/networks-status`")
+	assert.Contains(t, err.Error(), "has no annotation `k8s.v1.cni.cncf.io/network-status`")
 
 	p = &k8sv1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"k8s.v1.cni.cncf.io/networks-status": "xxx",
+				"k8s.v1.cni.cncf.io/network-status": "xxx",
 			},
 		},
 	}


### PR DESCRIPTION
Annotation `k8s.v1.cni.cncf.io/networks-status` has been changed to `k8s.v1.cni.cncf.io/network-status` and the former is no longer supported. Use the new key in e2e tests utilities.

Refs:
- k8snetworkplumbingwg/network-attachment-definition-client/pull/45