### PR TITLE
Make sriov-network-config-daemon crash when nodeInfo cannot be obtained

### DIFF
--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -161,7 +161,7 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 			}
 		}
 	} else {
-		glog.Warningf("Failed to fetch node state %s, %v!", startOpts.nodeName, err)
+		glog.Fatalf("Failed to fetch node state %s, %v!", startOpts.nodeName, err)
 	}
 	glog.V(0).Infof("Running on platform: %s", platformType.String())
 


### PR DESCRIPTION
Change the error level of nodeinfo from warning to fatal. If error is not empty, config-daemon crash. #414 