### PR TITLE
Support Graceful Shutdown

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -93,6 +93,7 @@ spec:
         volumeMounts:
         - name: cnibin
           mountPath: /host/opt/cni/bin
+      terminationGracePeriodSeconds: 900
       volumes:
       - name: host
         hostPath:


### PR DESCRIPTION
If the kubelet where the the sriov pod is running has gracefulShutdown configured, we'll delay in preStop for a while if and while /tmp/sriov-delay-shutdown exists, up to a maximum wait that's less than 15 minutes (which is now specified in the daemonset pod's terminationGracePeriodSeconds).

I wrote this as a possible alternative approach to the implementation [in this PR](https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/363), that [was reverted](https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/374) last year.