### PR TITLE
improve the isdraning check for openshift

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -580,6 +580,14 @@ func (dn *Daemon) nodeHasAnnotation(annoKey string, value string) bool {
 
 func (dn *Daemon) isNodeDraining() bool {
 	if anno, ok := dn.node.Annotations[annoKey]; ok && (anno == annoDraining || anno == annoMcpPaused) {
+		// for openshift cluster draining should be true only if the annotation has MCP paused
+		if dn.openshiftContext.IsOpenshiftCluster() && !dn.openshiftContext.IsHypershift() {
+			if anno == annoMcpPaused {
+				return true
+			} else {
+				return false
+			}
+		}
 		return true
 	}
 	return false


### PR DESCRIPTION
there is a case where we annotate the node as draning because we took the leader but on OCP the machine config pool was doing some work so we wait for it. if in the specific stage that we wait for the MCP we reset the daemon the new pod will say that it doesn't need to pause the pool and just start a drain

and we will stuck the cluster if we have some PDB blocking for more then 1 node to drain