### PR TITLE
Remove imagePullPolicy alltogether and use k8s defaults

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -42,7 +42,6 @@ spec:
         image: {{.Image}}
         command:
           - sriov-network-config-daemon
-        imagePullPolicy: IfNotPresent
         securityContext:
           privileged: true
         args:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -41,7 +41,6 @@ spec:
           image: $SRIOV_NETWORK_OPERATOR_IMAGE
           command:
           - sriov-network-operator
-          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 100m

--- a/deployment/sriov-network-operator/templates/operator.yaml
+++ b/deployment/sriov-network-operator/templates/operator.yaml
@@ -43,7 +43,6 @@ spec:
           image: {{ .Values.images.operator }}
           command:
             - sriov-network-operator
-          imagePullPolicy: IfNotPresent
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
Change sriov-device-plugin DaemonSet ImagePullPolicy to IfNotPresent
  
I find sriov-device-plugin DaemonSet ImagePullPolicy doesn't set, while imagePullPolicy for sriov-network-operator is `IfNotPresent`.  So it makes sense to set sriov-device-plugin DaemonSet ImagePullPolicy as `IfNotPresent`.