### PR TITLE
[Helm] Dont force deployment on control nodes

### DIFF
--- a/deployment/sriov-network-operator/values.yaml
+++ b/deployment/sriov-network-operator/values.yaml
@@ -9,13 +9,16 @@ operator:
   nodeSelector: {}
   affinity:
     nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-            - key: "node-role.kubernetes.io/master"
-              operator: In
-              values: [ "" ]
-          - matchExpressions:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/master"
+                operator: In
+                values: [""]
+        - weight: 1
+          preference:
+            matchExpressions:
               - key: "node-role.kubernetes.io/control-plane"
                 operator: In
                 values: [ "" ]


### PR DESCRIPTION
use preferred scheduling instead.

This is desired for a better user experience
on managed k8s clusters where control plane nodes
are not part of the cluster