### PR TITLE
Run mstfwreset when applying config changes

### DIFF
--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -5,7 +5,7 @@ RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM quay.io/centos/centos:stream9
 ARG MSTFLINT=mstflint
-RUN ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && yum -y install hwdata $ARCH_DEP_PKGS && yum clean all
+RUN ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && yum -y install hwdata pciutils $ARCH_DEP_PKGS && yum clean all
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -180,7 +180,13 @@ func (p *MellanoxPlugin) Apply() error {
 		return nil
 	}
 	glog.Info("mellanox-plugin Apply()")
-	return configFW()
+	if err := configFW(); err != nil {
+		return err
+	}
+	if err := resetFW(); err != nil {
+		return err
+	}
+	return nil
 }
 
 func configFW() error {
@@ -209,6 +215,21 @@ func configFW() error {
 		_, err := utils.RunCommand("mstconfig", cmdArgs...)
 		if err != nil {
 			glog.Errorf("mellanox-plugin configFW(): failed : %v", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func resetFW() error {
+	glog.Info("mellanox-plugin resetFW()")
+	for pciAddr := range attributesToChange {
+		cmdArgs := []string{"-d", pciAddr, "-y", "reset"}
+
+		glog.V(2).Infof("mellanox-plugin: resetFW(): %v", cmdArgs)
+		_, err := utils.RunCommand("mstfwreset", cmdArgs...)
+		if err != nil {
+			glog.Errorf("mellanox-plugin resetFW(): failed : %v", err)
 			return err
 		}
 	}


### PR DESCRIPTION
As of the most recent update to the Bluefield2 firmware (v24.37.1300)
configuration changes no longer are applied on node reboot without
running mstfwreset().

This can result in a node ending up in a bootloop when applying a new
configuration.

i.e. a sriov-workload-node-policy if applied to updated total vfs. This
change is applied via mstconfig, however the change is not reflected in
NUM_OF_VFS without running mstfwreset(). This resulted in a repeated
call to reboot.

```
    I0523 20:59:44.059046    7496 mellanox_plugin.go:335] Changing TotalVfs 16 to 12, needs reboot
    I0523 20:59:44.059057    7496 mellanox_plugin.go:172] mellanox-plugin needDrain true needReboot true
```
    
Signed-off-by: Salvatore Daniele <sdaniele@redhat.com>