### PR TITLE
Don't start config daemon on unsupported platforms

### DIFF
--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -162,6 +162,10 @@ func runStartCmd(cmd *cobra.Command, args []string) {
 	} else {
 		glog.Fatalf("Failed to fetch node state %s, %v!", startOpts.nodeName, err)
 	}
+	// Return an error if the platform is not Baremetal or OpenStack
+	if platformType != utils.Baremetal && platformType != utils.VirtualOpenStack {
+		glog.Fatalf("Unsupported platform type %s!", platformType.String())
+	}
 	glog.V(0).Infof("Running on platform: %s", platformType.String())
 
 	var namespace = os.Getenv("NAMESPACE")


### PR DESCRIPTION
The operator is only supported on Baremetal and OpenStack.
We should not start the config daemon elsewhere, as this is not
something we have tested.

On platform-agnostic deployments, there are a few unknowns that could
potentially be problematic especially for when running in virtualized
environments outside of the OpenStack platform type.
