### PR TITLE
Set Open_vSwitch hardware offload in config daemon

### DIFF
--- a/bindata/manifests/switchdev-config/ovs-units/ovs-vswitchd.service.yaml
+++ b/bindata/manifests/switchdev-config/ovs-units/ovs-vswitchd.service.yaml
@@ -1,6 +1,0 @@
-name: ovs-vswitchd.service
-dropins:
-- name: 10-hw-offload.conf
-  contents: |
-    [Service]
-    ExecStartPre=/bin/ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true

--- a/controllers/sriovnetworkpoolconfig_controller.go
+++ b/controllers/sriovnetworkpoolconfig_controller.go
@@ -148,7 +148,7 @@ func (r *SriovNetworkPoolConfigReconciler) syncOvsHardwareOffloadMachineConfigs(
 	}
 
 	data := render.MakeRenderData()
-	mc, err := render.GenerateMachineConfig("bindata/manifests/switchdev-config", mcName, mcpName, true, &data)
+	mc, err := render.GenerateMachineConfig("bindata/manifests/switchdev-config", mcName, mcpName, &data)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugins/k8s/k8s_plugin.go
+++ b/pkg/plugins/k8s/k8s_plugin.go
@@ -27,7 +27,6 @@ type K8sPlugin struct {
 	switchdevUdevScript        *service.ScriptManifestFile
 	switchdevBeforeNMService   *service.Service
 	switchdevAfterNMService    *service.Service
-	openVSwitchService         *service.Service
 	networkManagerService      *service.Service
 	updateTarget               *k8sUpdateTarget
 }
@@ -81,7 +80,6 @@ const (
 	switchdevBeforeNMUnitFile         = switchdevUnits + "switchdev-configuration-before-nm.yaml"
 	switchdevAfterNMUnitFile          = switchdevUnits + "switchdev-configuration-after-nm.yaml"
 	networkManagerUnitFile            = switchdevUnits + "NetworkManager.service.yaml"
-	ovsUnitFile                       = switchdevManifestPath + "ovs-units/ovs-vswitchd.service.yaml"
 	configuresSwitchdevBeforeNMScript = switchdevManifestPath + "files/switchdev-configuration-before-nm.sh.yaml"
 	configuresSwitchdevAfterNMScript  = switchdevManifestPath + "files/switchdev-configuration-after-nm.sh.yaml"
 	switchdevRenamingUdevScript       = switchdevManifestPath + "files/switchdev-vf-link-name.sh.yaml"
@@ -220,26 +218,12 @@ func (p *K8sPlugin) readNetworkManagerManifest() error {
 	return nil
 }
 
-func (p *K8sPlugin) readOpenVSwitchdManifest() error {
-	openVSwitchService, err := service.ReadServiceInjectionManifestFile(ovsUnitFile)
-	if err != nil {
-		return err
-	}
-
-	p.openVSwitchService = openVSwitchService
-	return nil
-}
-
 func (p *K8sPlugin) readManifestFiles() error {
 	if err := p.readSwitchdevManifest(); err != nil {
 		return err
 	}
 
 	if err := p.readNetworkManagerManifest(); err != nil {
-		return err
-	}
-
-	if err := p.readOpenVSwitchdManifest(); err != nil {
 		return err
 	}
 
@@ -282,7 +266,7 @@ func (p *K8sPlugin) switchdevServiceStateUpdate() error {
 }
 
 func (p *K8sPlugin) getSystemServices() []*service.Service {
-	return []*service.Service{p.networkManagerService, p.openVSwitchService}
+	return []*service.Service{p.networkManagerService}
 }
 
 func (p *K8sPlugin) isSwitchdevScriptNeedUpdate(scriptObj *service.ScriptManifestFile) (needUpdate bool, err error) {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -38,7 +38,6 @@ type DeviceInfo struct {
 
 const (
 	filesDir          = "files"
-	ovsUnitsDir       = "ovs-units"
 	switchdevUnitsDir = "switchdev-units"
 )
 
@@ -145,7 +144,7 @@ func formateDeviceList(devs []DeviceInfo) string {
 	return out
 }
 
-func GenerateMachineConfig(path, name, mcRole string, ovsOffload bool, d *RenderData) (*mcfgv1.MachineConfig, error) {
+func GenerateMachineConfig(path, name, mcRole string, d *RenderData) (*mcfgv1.MachineConfig, error) {
 	d.Funcs["formateDeviceList"] = formateDeviceList
 
 	exists, err := existsDir(path)
@@ -170,19 +169,6 @@ func GenerateMachineConfig(path, name, mcRole string, ovsOffload bool, d *Render
 	if exists {
 		if err := filterTemplates(files, p, d); err != nil {
 			return nil, err
-		}
-	}
-
-	if ovsOffload {
-		p = filepath.Join(path, ovsUnitsDir)
-		exists, err = existsDir(p)
-		if err != nil {
-			return nil, err
-		}
-		if exists {
-			if err := filterTemplates(units, p, d); err != nil {
-				return nil, err
-			}
 		}
 	}
 

--- a/pkg/render/testdata/machineconfig/units/ovs-vswitchd.service.yaml
+++ b/pkg/render/testdata/machineconfig/units/ovs-vswitchd.service.yaml
@@ -1,6 +1,0 @@
-name: ovs-vswitchd.service
-dropins:
-- name: 10-hw-offload.conf
-  contents: |
-    [Service]
-    ExecStartPre=/bin/ovs-vsctl --no-wait set Open_vSwitch . other_config:hw-offload=true

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -788,6 +788,22 @@ func RunCommand(command string, args ...string) (string, error) {
 	return stdout.String(), err
 }
 
+func RunOVSvsctl(args ...string) (string, error) {
+	glog.Infof("runOVSvsctl(): ovs-vsctl %v", args)
+	var output bytes.Buffer
+	cmd := exec.Command("ovs-vsctl", args...)
+	cmd.Stdout = &output
+	err := cmd.Run()
+
+	return output.String(), err
+}
+
+func RestartOVS() error {
+	glog.Infof("RestartOVS(): restarting openvswitch.service")
+	cmd := exec.Command("systemctl", "restart", "openvswitch.service")
+	return cmd.Run()
+}
+
 func hasMellanoxInterfacesInSpec(newState *sriovnetworkv1.SriovNetworkNodeState) bool {
 	for _, ifaceStatus := range newState.Status.Interfaces {
 		if ifaceStatus.Vendor == VendorMellanox {


### PR DESCRIPTION
Previously, we have set ovs hardware offload via the service applied by the Machine Config Operator
(bindata/manifests/switchdev-config/ovs-units.ovs-vswitchd.service).

However, the issue with this approach is that after the user has removed the MachineConfigPool or removed SRIOV all together, ovs hw-offload remains enabled.

This change will instead handle configuring ovs hardware offloading in the config daemon by checking for switchdev devices, and enabling ovs hardware offload only while such devices are detected. We will remove the serviced file responsible for setting ovs-hwol to true on boot. Upon detecting a change in the sriov node policy, we will check for any switchdev devices and set ovs-hwol accordingly. Changes to ovs will result in drain and reboot of the node to ensure changes are applied