### PR TITLE
Add sriovoperatorconfigs resource to webhook

### DIFF
--- a/bindata/manifests/operator-webhook/003-webhook.yaml
+++ b/bindata/manifests/operator-webhook/003-webhook.yaml
@@ -57,3 +57,7 @@ webhooks:
         apiGroups: ["sriovnetwork.openshift.io"]
         apiVersions: ["v1"]
         resources: ["sriovnetworknodepolicies"]
+      - operations: [ "CREATE", "UPDATE", "DELETE" ]
+        apiGroups: [ "sriovnetwork.openshift.io" ]
+        apiVersions: [ "v1" ]
+        resources: [ "sriovoperatorconfigs" ]

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -75,6 +75,8 @@ var _ = BeforeSuite(func(done Done) {
 		ErrorIfCRDPathMissing: true,
 	}
 
+	testEnv.ControlPlane.GetAPIServer().Configure().Set("disable-admission-plugins", "MutatingAdmissionWebhook", "ValidatingAdmissionWebhook")
+
 	cfg, err := testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())


### PR DESCRIPTION
The sriovoperatorconfigs resource was not present in the validating webhook configuration. The logic to validate this object was not triggered.