### PR TITLE
virtual cluster e2e tests changes

### DIFF
--- a/.github/workflows/virtual-cluster.yml
+++ b/.github/workflows/virtual-cluster.yml
@@ -1,0 +1,45 @@
+name: sriov-operator-test
+on: [pull_request]
+
+jobs:
+  virtual-k8s-cluster:
+    name: k8s
+    runs-on: [sriov]
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - name: run test
+        run: make test-e2e-conformance-virtual-k8s-cluster-ci
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: artifact
+          path: ./artifacts.tar.gz
+
+  virtual-ocp:
+    name: ocp
+    runs-on: [ ocp ]
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Go 1.20
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.20.x
+
+      - name: run test
+        run: make test-e2e-conformance-virtual-ocp-cluster-ci
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: artifact
+          path: ./artifacts.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,18 @@ deploy-setup-k8s: deploy-setup
 test-e2e-conformance:
 	SUITE=./test/conformance ./hack/run-e2e-conformance.sh
 
+test-e2e-conformance-virtual-k8s-cluster-ci:
+	./hack/run-e2e-conformance-virtual-cluster.sh
+
+test-e2e-conformance-virtual-k8s-cluster:
+	SKIP_DELETE=TRUE ./hack/run-e2e-conformance-virtual-cluster.sh
+
+test-e2e-conformance-virtual-ocp-cluster-ci:
+	./hack/run-e2e-conformance-virtual-ocp.sh
+
+test-e2e-conformance-virtual-ocp-cluster:
+	SKIP_DELETE=TRUE ./hack/run-e2e-conformance-virtual-ocp.sh
+
 test-e2e-validation-only:
 	SUITE=./test/validation ./hack/run-e2e-conformance.sh	
 

--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -7,6 +7,7 @@ data:
   Intel_i40e_25G_SFP28: "8086 158b 154c"
   Intel_i40e_10G_X710_SFP: "8086 1572 154c"
   Intel_ixgbe_10G_X550: "8086 1563 1565"
+  Intel_ixgbe_82576: "8086 10c9 10ca"
   Intel_i40e_X710_X557_AT_10G: "8086 1589 154c"
   Intel_i40e_10G_X710_BACKPLANE: "8086 1581 154c"
   Intel_i40e_10G_X710_BASE_T: "8086 15ff 154c"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -7,6 +7,7 @@ data:
   Intel_i40e_25G_SFP28: "8086 158b 154c"
   Intel_i40e_10G_X710_SFP: "8086 1572 154c"
   Intel_ixgbe_10G_X550: "8086 1563 1565"
+  Intel_ixgbe_82576: "8086 10c9 10ca"
   Intel_i40e_X710_X557_AT_10G: "8086 1589 154c"
   Intel_i40e_10G_X710_BACKPLANE: "8086 1581 154c"
   Intel_i40e_10G_X710_BASE_T: "8086 15ff 154c"

--- a/doc/testing-virtual-machine.md
+++ b/doc/testing-virtual-machine.md
@@ -1,0 +1,58 @@
+## E2E conformance test
+
+It's possible to use QEMU to test the SR-IOV operator on a virtual kubernetes/openshift cluster.
+Using the IGB model network driver allow to create virtual functions on the virtual system
+
+## How to test
+
+First you will need to enable the `DEV_MODE` via the operator environment variable.
+Second step is to add the intel virtual nic to the supported nics configmap.
+
+Another requirement is to load the vfio kernel module with no_iommu configuration. Example systemd:
+
+```
+[Unit]
+Description=vfio no-iommu
+Before=kubelet.service crio.service node-valid-hostname.service
+
+[Service]
+# Need oneshot to delay kubelet
+Type=oneshot
+ExecStart=/usr/bin/bash -c "modprobe vfio enable_unsafe_noiommu_mode=1"
+StandardOutput=journal+console
+StandardError=journal+console
+
+[Install]
+WantedBy=network-online.target
+```
+
+### Prerequisites
+* kcli - deployment tool (https://github.com/karmab/kcli)
+* virsh 
+* qemu > 8.1
+* libvirt > 9
+* podman
+* make
+* go
+
+## Deploy the cluster
+
+use the deployment [script](../hack/run-e2e-conformance-virtual-cluster.sh), this will deploy a k8s cluster
+compile the operator images and run the e2e tests.
+
+example:
+```
+SKIP_DELETE=TRUE make test-e2e-conformance-virtual-k8s-cluster 
+```
+
+It's also possible to skip the tests and only deploy the cluster running
+
+```
+SKIP_TEST=TRUE SKIP_DELETE=TRUE make test-e2e-conformance-virtual-k8s-cluster
+```
+
+To use the cluster after the deployment you need to export the kubeconfig
+
+```
+export KUBECONFIG=$HOME/.kcli/clusters/virtual/auth/kubeconfig
+```

--- a/hack/run-e2e-conformance-virtual-cluster.sh
+++ b/hack/run-e2e-conformance-virtual-cluster.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+cluster_name=${CLUSTER_NAME:-virtual}
+domain_name=$cluster_name.lab
+
+api_ip=${API_IP:-192.168.124.250}
+virtual_router_id=${VIRTUAL_ROUTER_ID:-250}
+HOME="/root"
+
+here="$(dirname "$(readlink --canonicalize "${BASH_SOURCE[0]}")")"
+root="$(readlink --canonicalize "$here/..")"
+
+check_requirements() {
+  for cmd in kcli virsh virt-edit podman make go; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "$cmd is not available"
+      exit 1
+    fi
+  done
+  return 0
+}
+
+echo "## checking requirements"
+check_requirements
+echo "## delete existing cluster name $cluster_name"
+kcli delete cluster $cluster_name -y
+kcli delete network $cluster_name -y
+
+function cleanup {
+  kcli delete cluster $cluster_name -y
+  kcli delete network $cluster_name -y
+}
+
+if [ -z $SKIP_DELETE ]; then
+  trap cleanup EXIT
+fi
+
+kcli create network -c 192.168.124.0/24 k8s
+kcli create network -c 192.168.${virtual_router_id}.0/24 --nodhcp -i $cluster_name
+
+cat <<EOF > ./${cluster_name}-plan.yaml
+ctlplane_memory: 4096
+worker_memory: 4096
+pool: default
+disk_size: 50
+network: k8s
+api_ip: $api_ip
+virtual_router_id: $virtual_router_id
+domain: $domain_name
+ctlplanes: 1
+workers: 2
+ingress: false
+machine: q35
+engine: crio
+sdn: flannel
+autolabeller: false
+vmrules:
+  - $cluster_name-worker-.*:
+      nets:
+        - name: k8s
+          type: igb
+          vfio: true
+          noconf: true
+          numa: 0
+        - name: $cluster_name
+          type: igb
+          vfio: true
+          noconf: true
+          numa: 1
+      numcpus: 6
+      numa:
+        - id: 0
+          vcpus: 0,2,4
+          memory: 2048
+        - id: 1
+          vcpus: 1,3,5
+          memory: 2048
+
+EOF
+
+kcli create cluster generic --paramfile ./${cluster_name}-plan.yaml $cluster_name
+
+export KUBECONFIG=$HOME/.kcli/clusters/$cluster_name/auth/kubeconfig
+export PATH=$PWD:$PATH
+
+ATTEMPTS=0
+MAX_ATTEMPTS=72
+ready=false
+sleep_time=10
+
+until $ready || [ $ATTEMPTS -eq $MAX_ATTEMPTS ]
+do
+    echo "waiting for cluster to be ready"
+    if [ `kubectl get node | grep Ready | wc -l` == 3 ]; then
+        echo "cluster is ready"
+        ready=true
+    else
+        echo "cluster is not ready yet"
+        sleep $sleep_time
+    fi
+    ATTEMPTS=$((ATTEMPTS+1))
+done
+
+if ! $ready; then
+    echo "Timed out waiting for cluster to be ready"
+    kubectl get nodes
+    exit 1
+fi
+
+echo "## label cluster workers as sriov capable"
+kubectl label node $cluster_name-worker-0.$domain_name feature.node.kubernetes.io/network-sriov.capable=true --overwrite
+kubectl label node $cluster_name-worker-1.$domain_name feature.node.kubernetes.io/network-sriov.capable=true --overwrite
+
+echo "## label cluster worker as worker"
+kubectl label node $cluster_name-worker-0.$domain_name node-role.kubernetes.io/worker= --overwrite
+kubectl label node $cluster_name-worker-1.$domain_name node-role.kubernetes.io/worker= --overwrite
+
+controller_ip=`kubectl get node -o wide | grep ctlp | awk '{print $6}'`
+insecure_registry="[[registry]]
+location = \"$controller_ip:5000\"
+insecure = true
+"
+
+cat << EOF > /etc/containers/registries.conf.d/003-${cluster_name}.conf
+$insecure_registry
+EOF
+
+kcli ssh $cluster_name-ctlplane-0 << EOF
+sudo su
+echo '$insecure_registry' > /etc/containers/registries.conf.d/003-internal.conf
+systemctl restart crio
+EOF
+
+kcli ssh $cluster_name-worker-0 << EOF
+sudo su
+echo '$insecure_registry' > /etc/containers/registries.conf.d/003-internal.conf
+systemctl restart crio
+EOF
+
+kcli ssh $cluster_name-worker-1 << EOF
+sudo su
+echo '$insecure_registry' > /etc/containers/registries.conf.d/003-internal.conf
+systemctl restart crio
+EOF
+
+kubectl create namespace container-registry
+
+echo "## deploy internal registry"
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: registry-pv
+spec:
+  capacity:
+    storage: 60Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: registry-local-storage
+  local:
+    path: /mnt/
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ${cluster_name}-ctlplane-0.${domain_name}
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-pv-claim
+  namespace: container-registry
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 60Gi
+  storageClassName: registry-local-storage
+EOF
+
+cat <<EOF | kubectl apply -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: container-registry
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      hostNetwork: true
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      containers:
+      - image: docker.io/registry:latest
+        imagePullPolicy: Always
+        name: registry
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/registry
+      volumes:
+      - name: data
+        persistentVolumeClaim:
+          claimName: registry-pv-claim
+      terminationGracePeriodSeconds: 10
+EOF
+
+
+export SRIOV_NETWORK_OPERATOR_IMAGE="$controller_ip:5000/sriov-network-operator:latest"
+export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE="$controller_ip:5000/sriov-network-config-daemon:latest"
+export SRIOV_NETWORK_WEBHOOK_IMAGE="$controller_ip:5000/sriov-network-operator-webhook:latest"
+
+echo "## build operator image"
+podman build -t "${SRIOV_NETWORK_OPERATOR_IMAGE}" -f "${root}/Dockerfile" "${root}"
+
+echo "## build daemon image"
+podman build -t "${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}" -f "${root}/Dockerfile.sriov-network-config-daemon" "${root}"
+
+echo "## build webhook image"
+podman build -t "${SRIOV_NETWORK_WEBHOOK_IMAGE}" -f "${root}/Dockerfile.webhook" "${root}"
+
+podman push --tls-verify=false "${SRIOV_NETWORK_OPERATOR_IMAGE}"
+podman push --tls-verify=false "${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}"
+podman push --tls-verify=false "${SRIOV_NETWORK_WEBHOOK_IMAGE}"
+
+# remove the crio bridge and let flannel to recreate
+kcli ssh $cluster_name-ctlplane-0 << EOF
+sudo su
+if [ $(ip a | grep 10.85.0 | wc -l) -eq 0 ]; then ip link del cni0; fi
+EOF
+
+
+kubectl -n kube-system get po | grep multus | awk '{print "kubectl -n kube-system delete po",$1}' | sh
+kubectl -n kube-system get po | grep coredns | awk '{print "kubectl -n kube-system delete po",$1}' | sh
+
+TIMEOUT=400
+echo "## wait for coredns"
+kubectl -n kube-system wait --for=condition=available deploy/coredns --timeout=${TIMEOUT}s
+echo "## wait for multus"
+kubectl -n kube-system wait --for=condition=ready -l name=multus pod --timeout=${TIMEOUT}s
+
+echo "## deploy cert manager"
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.12.0/cert-manager.yaml
+
+echo "## wait for cert manager to be ready"
+
+ATTEMPTS=0
+MAX_ATTEMPTS=72
+ready=false
+sleep_time=5
+
+until $ready || [ $ATTEMPTS -eq $MAX_ATTEMPTS ]
+do
+    echo "waiting for cert manager webhook to be ready"
+    if [ `kubectl -n cert-manager get po | grep webhook | grep "1/1" | wc -l` == 1 ]; then
+        echo "cluster is ready"
+        ready=true
+    else
+        echo "cert manager webhook is not ready yet"
+        sleep $sleep_time
+    fi
+    ATTEMPTS=$((ATTEMPTS+1))
+done
+
+
+export ENABLE_ADMISSION_CONTROLLER=true
+export SKIP_VAR_SET=""
+export NAMESPACE="sriov-network-operator"
+export OPERATOR_NAMESPACE="sriov-network-operator"
+export CNI_BIN_PATH=/opt/cni/bin
+export OPERATOR_EXEC=kubectl
+export CLUSTER_TYPE=kubernetes
+export DEV_MODE=TRUE
+export CLUSTER_HAS_EMULATED_PF=TRUE
+
+echo "## deploy namespace"
+envsubst< $root/deploy/namespace.yaml | ${OPERATOR_EXEC} apply -f -
+
+echo "## create certificates for webhook"
+cat <<EOF | kubectl apply -f -
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: ${NAMESPACE}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: network-resources-injector-secret
+  namespace: ${NAMESPACE}
+spec:
+  commonName: network-resources-injector-service.svc
+  dnsNames:
+  - network-resources-injector-service.${NAMESPACE}.svc.cluster.local
+  - network-resources-injector-service.${NAMESPACE}.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: network-resources-injector-secret
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: operator-webhook-service
+  namespace: ${NAMESPACE}
+spec:
+  commonName: operator-webhook-service.svc
+  dnsNames:
+  - operator-webhook-service.${NAMESPACE}.svc.cluster.local
+  - operator-webhook-service.${NAMESPACE}.svc
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: operator-webhook-service
+EOF
+
+
+echo "## apply CRDs"
+kubectl apply -k $root/config/crd
+
+echo "## deploying SRIOV Network Operator"
+hack/deploy-setup.sh $NAMESPACE
+
+echo "## wait for sriov operator to be ready"
+hack/deploy-wait.sh
+
+if [ -z $SKIP_TEST ]; then
+  echo "## run sriov e2e conformance tests"
+  SUITE=./test/conformance JUNIT_OUTPUT=`pwd`/artifacts hack/run-e2e-conformance.sh
+  tar -zcvf artifacts.tar.gz ./artifacts
+fi

--- a/hack/run-e2e-conformance-virtual-ocp.sh
+++ b/hack/run-e2e-conformance-virtual-ocp.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+set -xeo pipefail
+
+cluster_name=${CLUSTER_NAME:-ocp-virt}
+domain_name=lab
+
+api_ip=${API_IP:-192.168.123.253}
+virtual_router_id=${VIRTUAL_ROUTER_ID:-253}
+registry="default-route-openshift-image-registry.apps.${cluster_name}.${domain_name}"
+HOME="/root"
+
+here="$(dirname "$(readlink --canonicalize "${BASH_SOURCE[0]}")")"
+root="$(readlink --canonicalize "$here/..")"
+
+check_requirements() {
+  for cmd in kcli virsh podman make go jq base64 tar; do
+    if ! command -v "$cmd" &> /dev/null; then
+      echo "$cmd is not available"
+      exit 1
+    fi
+  done
+  return 0
+}
+
+echo "## checking requirements"
+check_requirements
+echo "## delete existing cluster name $cluster_name"
+kcli delete cluster $cluster_name -y
+kcli delete network $cluster_name -y
+
+function cleanup {
+  kcli delete cluster $cluster_name -y
+  kcli delete network $cluster_name -y
+}
+
+if [ -z $SKIP_DELETE ]; then
+  trap cleanup EXIT
+fi
+
+kcli create network -c 192.168.123.0/24 ocp
+kcli create network -c 192.168.${virtual_router_id}.0/24 --nodhcp -i $cluster_name
+
+cat <<EOF > ./${cluster_name}-plan.yaml
+tag: 4.14.0-rc.1
+ctlplane_memory: 24576
+worker_memory: 8192
+pool: default
+disk_size: 50
+network: ocp
+api_ip: $api_ip
+virtual_router_id: $virtual_router_id
+domain: $domain_name
+ctlplanes: 1
+workers: 3
+machine: q35
+network_type: OVNKubernetes
+pull_secret: /root/openshift_pull.json
+vmrules:
+  - $cluster_name-worker-.*:
+      nets:
+        - name: ocp
+          numa: 0
+        - name: $cluster_name
+          type: igb
+          vfio: true
+          noconf: true
+          numa: 0
+        - name: $cluster_name
+          type: igb
+          vfio: true
+          noconf: true
+          numa: 1
+      numcpus: 6
+      numa:
+        - id: 0
+          vcpus: 0,2,4
+          memory: 4096
+        - id: 1
+          vcpus: 1,3,5
+          memory: 4096
+
+EOF
+
+kcli create cluster openshift --paramfile ./${cluster_name}-plan.yaml $cluster_name
+
+export KUBECONFIG=$HOME/.kcli/clusters/$cluster_name/auth/kubeconfig
+export PATH=$PWD:$PATH
+
+# w/a for the registry pull
+kubectl create clusterrolebinding authenticated-registry-viewer --clusterrole registry-viewer --group system:unauthenticated
+
+ATTEMPTS=0
+MAX_ATTEMPTS=72
+ready=false
+sleep_time=10
+
+until $ready || [ $ATTEMPTS -eq $MAX_ATTEMPTS ]
+do
+    echo "waiting for cluster to be ready"
+    if [ `kubectl get node | grep Ready | wc -l` == 4 ]; then
+        echo "cluster is ready"
+        ready=true
+    else
+        echo "cluster is not ready yet"
+        sleep $sleep_time
+    fi
+    ATTEMPTS=$((ATTEMPTS+1))
+done
+
+if ! $ready; then
+    echo "Timed out waiting for cluster to be ready"
+    kubectl get nodes
+    exit 1
+fi
+
+echo "## label cluster workers as sriov capable"
+kubectl label node $cluster_name-worker-0.$domain_name feature.node.kubernetes.io/network-sriov.capable=true --overwrite
+kubectl label node $cluster_name-worker-1.$domain_name feature.node.kubernetes.io/network-sriov.capable=true --overwrite
+kubectl label node $cluster_name-worker-2.$domain_name feature.node.kubernetes.io/network-sriov.capable=true --overwrite
+
+controller_ip=`kubectl get node -o wide | grep ctlp | awk '{print $6}'`
+
+if [ `cat /etc/hosts | grep ${api_ip} | grep "default-route-openshift-image-registry.apps.${cluster_name}.${domain_name}" | wc -l` == 0 ]; then
+  echo "adding registry to hosts"
+  sed -i "s/${api_ip}/${api_ip} default-route-openshift-image-registry.apps.${cluster_name}.${domain_name}/g" /etc/hosts
+fi
+
+
+cat <<EOF | oc apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: registry-pv
+spec:
+  capacity:
+    storage: 60Gi
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteMany
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: registry-local-storage
+  local:
+    path: /mnt/
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - ${cluster_name}-ctlplane-0.${domain_name}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-pv-claim
+  namespace: openshift-image-registry
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 60Gi
+  storageClassName: registry-local-storage
+EOF
+
+kubectl patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true,"storage":{"emptyDir": null,"pvc":{"claim":"registry-pv-claim"}},"topologySpreadConstraints":[],"rolloutStrategy":"Recreate","tolerations":[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"},{"effect":"NoSchedule","key":"node-role.kubernetes.io/control-plane","operator":"Exists"}]}}' --type=merge
+
+export ENABLE_ADMISSION_CONTROLLER=true
+export SKIP_VAR_SET=""
+export NAMESPACE="openshift-sriov-network-operator"
+export OPERATOR_NAMESPACE=$NAMESPACE
+export OPERATOR_EXEC=kubectl
+export CLUSTER_TYPE=openshift
+export DEV_MODE=TRUE
+export CLUSTER_HAS_EMULATED_PF=TRUE
+
+export SRIOV_NETWORK_OPERATOR_IMAGE="$registry/$NAMESPACE/sriov-network-operator:latest"
+export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE="$registry/$NAMESPACE/sriov-network-config-daemon:latest"
+export SRIOV_NETWORK_WEBHOOK_IMAGE="$registry/$NAMESPACE/sriov-network-operator-webhook:latest"
+
+envsubst< deploy/namespace.yaml | kubectl apply -f -
+
+echo "## build operator image"
+podman build -t "${SRIOV_NETWORK_OPERATOR_IMAGE}" -f "${root}/Dockerfile" "${root}"
+
+echo "## build daemon image"
+podman build -t "${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}" -f "${root}/Dockerfile.sriov-network-config-daemon" "${root}"
+
+echo "## build webhook image"
+podman build -t "${SRIOV_NETWORK_WEBHOOK_IMAGE}" -f "${root}/Dockerfile.webhook" "${root}"
+
+dockercgf=`kubectl -n ${NAMESPACE} get sa builder -oyaml | grep imagePullSecrets -A 1 | grep -o "builder-.*"`
+auth=`kubectl -n ${NAMESPACE} get secret ${dockercgf} -ojson | jq '.data.".dockercfg"'`
+auth="${auth:1:-1}"
+auth=`echo ${auth} | base64 -d`
+echo ${auth} > registry-login.conf
+
+pass=$( jq .\"$registry\".password registry-login.conf )
+podman login -u serviceaccount -p ${pass:1:-1} $registry --tls-verify=false
+
+podman push --tls-verify=false "${SRIOV_NETWORK_OPERATOR_IMAGE}"
+podman push --tls-verify=false "${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}"
+podman push --tls-verify=false "${SRIOV_NETWORK_WEBHOOK_IMAGE}"
+
+podman logout $registry
+
+echo "## apply CRDs"
+kubectl apply -k $root/config/crd
+
+
+cat <<EOF | kubectl apply -f -
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: ${NAMESPACE}
+spec:
+  disableDrain: false
+  enableInjector: true
+  enableOperatorWebhook: true
+  logLevel: 2
+EOF
+
+export SRIOV_NETWORK_OPERATOR_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-network-operator:latest"
+export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-network-config-daemon:latest"
+export SRIOV_NETWORK_WEBHOOK_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-network-operator-webhook:latest"
+
+echo "## deploying SRIOV Network Operator"
+hack/deploy-setup.sh $NAMESPACE
+
+echo "## wait for sriov operator to be ready"
+hack/deploy-wait.sh
+
+if [ -z $SKIP_TEST ]; then
+  echo "## run sriov e2e conformance tests"
+  SUITE=./test/conformance JUNIT_OUTPUT=`pwd`/artifacts hack/run-e2e-conformance.sh
+  tar -zcvf artifacts.tar.gz `pwd`/artifacts
+fi

--- a/hack/run-e2e-conformance.sh
+++ b/hack/run-e2e-conformance.sh
@@ -8,7 +8,7 @@ if [ $? -ne 0 ]; then
 	GINKGO_TMP_DIR=$(mktemp -d)
 	cd $GINKGO_TMP_DIR
 	go mod init tmp
-	go install -mod=readonly github.com/onsi/ginkgo/v2/ginkgo@v2.5.0
+	go install -mod=readonly github.com/onsi/ginkgo/v2/ginkgo@v2.9.5
 	rm -rf $GINKGO_TMP_DIR	
 	echo "Downloading ginkgo tool"
 	cd -
@@ -18,4 +18,4 @@ GOPATH="${GOPATH:-~/go}"
 JUNIT_OUTPUT="${JUNIT_OUTPUT:-/tmp/artifacts}"
 export PATH=$PATH:$GOPATH/bin
 
-GOFLAGS=-mod=vendor ginkgo -output-dir=$JUNIT_OUTPUT --junit-report "unit_report.xml" "$SUITE" -- -report=$JUNIT_OUTPUT
+GOFLAGS=-mod=vendor ginkgo -output-dir=$JUNIT_OUTPUT --junit-report "unit_report.xml" -v "$SUITE" -- -report=$JUNIT_OUTPUT

--- a/test/conformance/test_suite_test.go
+++ b/test/conformance/test_suite_test.go
@@ -11,6 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 
 	kniK8sReporter "github.com/openshift-kni/k8sreporter"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	// Test files in this package must not end with `_test.go` suffix, as they are imported as go package
 	_ "github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests"
@@ -53,6 +55,7 @@ func TestTest(t *testing.T) {
 		}
 	}
 
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 	RunSpecs(t, "SRIOV Operator conformance tests")
 }
 

--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -511,6 +511,11 @@ var _ = Describe("[sriov] operator", func() {
 
 			// 25961
 			It("Should configure the the link state variable", func() {
+				if cluster.VirtualCluster() {
+					// https://bugzilla.redhat.com/show_bug.cgi?id=2214976
+					Skip("Bug in IGB driver")
+				}
+
 				sriovNetwork := &sriovv1.SriovNetwork{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-statenetwork", Namespace: operatorNamespace},
 					Spec: sriovv1.SriovNetworkSpec{
@@ -1161,6 +1166,11 @@ var _ = Describe("[sriov] operator", func() {
 			Context("PF shutdown", func() {
 				// 29398
 				It("Should be able to create pods successfully if PF is down.Pods are able to communicate with each other on the same node", func() {
+					if cluster.VirtualCluster() {
+						// https://bugzilla.redhat.com/show_bug.cgi?id=2214976
+						Skip("Bug in IGB driver")
+					}
+
 					resourceName := testResourceName
 					var testNode string
 					var unusedSriovDevice *sriovv1.InterfaceExt
@@ -1210,6 +1220,11 @@ var _ = Describe("[sriov] operator", func() {
 
 			Context("MTU", func() {
 				BeforeEach(func() {
+					if cluster.VirtualCluster() {
+						// https://bugzilla.redhat.com/show_bug.cgi?id=2214977
+						Skip("Bug in IGB driver")
+					}
+
 					var node string
 					resourceName := "mturesource"
 					var numVfs int
@@ -1305,7 +1320,6 @@ var _ = Describe("[sriov] operator", func() {
 							ResourceName:     resourceName,
 							IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
 							NetworkNamespace: namespaces.Test,
-							LinkState:        "enable",
 						}}
 
 					// We need this to be able to run the connectivity checks on Mellanox cards
@@ -1395,11 +1409,11 @@ var _ = Describe("[sriov] operator", func() {
 						},
 
 						Spec: sriovv1.SriovNetworkNodePolicySpec{
-							NumVfs:       10,
+							NumVfs:       7,
 							ResourceName: "resourceXXX",
 							NodeSelector: map[string]string{"kubernetes.io/hostname": node},
 							NicSelector: sriovv1.SriovNetworkNicSelector{
-								PfNames: []string{intf.Name + "#0-4"},
+								PfNames: []string{intf.Name + "#0-3"},
 							},
 							ExcludeTopology: true,
 						},
@@ -1412,11 +1426,11 @@ var _ = Describe("[sriov] operator", func() {
 						},
 
 						Spec: sriovv1.SriovNetworkNodePolicySpec{
-							NumVfs:       10,
+							NumVfs:       7,
 							ResourceName: "resourceXXX",
 							NodeSelector: map[string]string{"kubernetes.io/hostname": node},
 							NicSelector: sriovv1.SriovNetworkNicSelector{
-								PfNames: []string{intf.Name + "#5-9"},
+								PfNames: []string{intf.Name + "#4-6"},
 							},
 							ExcludeTopology: false,
 						},
@@ -1429,11 +1443,11 @@ var _ = Describe("[sriov] operator", func() {
 						},
 
 						Spec: sriovv1.SriovNetworkNodePolicySpec{
-							NumVfs:       10,
+							NumVfs:       7,
 							ResourceName: "resourceYYY",
 							NodeSelector: map[string]string{"kubernetes.io/hostname": node},
 							NicSelector: sriovv1.SriovNetworkNicSelector{
-								PfNames: []string{intf.Name + "#5-9"},
+								PfNames: []string{intf.Name + "#4-6"},
 							},
 							ExcludeTopology: false,
 						},
@@ -1447,15 +1461,15 @@ var _ = Describe("[sriov] operator", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					assertDevicePluginConfigurationContains(node,
-						fmt.Sprintf(`{"resourceName":"resourceXXX","excludeTopology":true,"selectors":{"pfNames":["%s#0-4"],"IsRdma":false,"NeedVhostNet":false},"SelectorObj":null}`, intf.Name))
+						fmt.Sprintf(`{"resourceName":"resourceXXX","excludeTopology":true,"selectors":{"pfNames":["%s#0-3"],"IsRdma":false,"NeedVhostNet":false},"SelectorObj":null}`, intf.Name))
 
 					err = clients.Create(context.Background(), excludeTopologyFalseResourceYYY)
 					Expect(err).ToNot(HaveOccurred())
 
 					assertDevicePluginConfigurationContains(node,
-						fmt.Sprintf(`{"resourceName":"resourceXXX","excludeTopology":true,"selectors":{"pfNames":["%s#0-4"],"IsRdma":false,"NeedVhostNet":false},"SelectorObj":null}`, intf.Name))
+						fmt.Sprintf(`{"resourceName":"resourceXXX","excludeTopology":true,"selectors":{"pfNames":["%s#0-3"],"IsRdma":false,"NeedVhostNet":false},"SelectorObj":null}`, intf.Name))
 					assertDevicePluginConfigurationContains(node,
-						fmt.Sprintf(`{"resourceName":"resourceYYY","selectors":{"pfNames":["%s#5-9"],"IsRdma":false,"NeedVhostNet":false},"SelectorObj":null}`, intf.Name))
+						fmt.Sprintf(`{"resourceName":"resourceYYY","selectors":{"pfNames":["%s#4-6"],"IsRdma":false,"NeedVhostNet":false},"SelectorObj":null}`, intf.Name))
 				})
 
 				It("multiple values for the same resource should not be allowed", func() {
@@ -1729,7 +1743,6 @@ var _ = Describe("[sriov] operator", func() {
 						ResourceName:     resourceName,
 						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
 						NetworkNamespace: namespaces.Test,
-						LinkState:        "enable",
 					}}
 
 				// We need this to be able to run the connectivity checks on Mellanox cards
@@ -2084,9 +2097,9 @@ func createCustomTestPod(node string, networks []string, hostNetwork bool, podCa
 		Expect(err).ToNot(HaveOccurred())
 		return runningPod.Status.Phase
 	}, 5*time.Minute, 1*time.Second).Should(Equal(corev1.PodRunning))
-	pod, err := clients.Pods(namespaces.Test).Get(context.Background(), createdPod.Name, metav1.GetOptions{})
+	podObj, err := clients.Pods(namespaces.Test).Get(context.Background(), createdPod.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
-	return pod
+	return podObj
 }
 
 func pingPod(ip string, nodeSelector string, sriovNetworkAttachment string) {
@@ -2095,15 +2108,19 @@ func pingPod(ip string, nodeSelector string, sriovNetworkAttachment string) {
 		ipProtocolVersion = "4"
 	}
 	podDefinition := pod.RedefineWithNodeSelector(
-		pod.RedefineWithRestartPolicy(
-			pod.RedefineWithCommand(
-				pod.DefineWithNetworks([]string{sriovNetworkAttachment}),
-				[]string{"sh", "-c", fmt.Sprintf("ping -%s -c 3 %s", ipProtocolVersion, ip)}, []string{},
+		pod.RedefineWithCapabilities(
+			pod.RedefineWithRestartPolicy(
+				pod.RedefineWithCommand(
+					pod.DefineWithNetworks([]string{sriovNetworkAttachment}),
+					[]string{"sh", "-c", fmt.Sprintf("ping -%s -c 3 %s", ipProtocolVersion, ip)}, []string{},
+				),
+				corev1.RestartPolicyNever,
 			),
-			corev1.RestartPolicyNever,
+			[]corev1.Capability{"NET_RAW"},
 		),
 		nodeSelector,
 	)
+
 	createdPod, err := clients.Pods(namespaces.Test).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 

--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -28,8 +29,8 @@ type EnabledNodes struct {
 }
 
 var (
-	supportedPFDrivers = []string{"mlx5_core", "i40e", "ixgbe", "ice"}
-	supportedVFDrivers = []string{"iavf", "vfio-pci", "mlx5_core"}
+	supportedPFDrivers = []string{"mlx5_core", "i40e", "ixgbe", "ice", "igb"}
+	supportedVFDrivers = []string{"iavf", "vfio-pci", "mlx5_core", "igbvf"}
 	mlxVendorID        = "15b3"
 	intelVendorID      = "8086"
 )
@@ -330,4 +331,11 @@ func GetNodeSecureBootState(clients *testclient.ClientSet, nodeName, namespace s
 	}
 
 	return strings.Contains(stdout, "[integrity]") || strings.Contains(stdout, "[confidentiality]"), nil
+}
+
+func VirtualCluster() bool {
+	if v, exist := os.LookupEnv("CLUSTER_HAS_EMULATED_PF"); exist && v != "" {
+		return true
+	}
+	return false
 }

--- a/test/util/network/network.go
+++ b/test/util/network/network.go
@@ -12,6 +12,7 @@ import (
 
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	testclient "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
 )
 
 // Needed for parsing of podinfo
@@ -36,6 +37,11 @@ func CreateSriovNetwork(clientSet *testclient.ClientSet, intf *sriovv1.Interface
 			// for pod to pod connectivity tests in the same host
 			LinkState: "enable",
 		}}
+
+	// https://bugzilla.redhat.com/show_bug.cgi?id=2214976
+	if cluster.VirtualCluster() {
+		sriovNetwork.Spec.LinkState = ""
+	}
 
 	for _, o := range options {
 		o(sriovNetwork)

--- a/test/util/pod/pod.go
+++ b/test/util/pod/pod.go
@@ -95,6 +95,11 @@ func RedefineWithRestartPolicy(pod *corev1.Pod, restartPolicy corev1.RestartPoli
 	return pod
 }
 
+func RedefineWithCapabilities(pod *corev1.Pod, capabilitiesList []corev1.Capability) *corev1.Pod {
+	pod.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{Capabilities: &corev1.Capabilities{Add: capabilitiesList}}
+	return pod
+}
+
 // ExecCommand runs command in the pod and returns buffer output
 func ExecCommand(cs *testclient.ClientSet, pod *corev1.Pod, command ...string) (string, string, error) {
 	var buf, errbuf bytes.Buffer


### PR DESCRIPTION
Initial work to be able to run our conformance tests on a virtual cluster

Run output
```
=== RUN   TestTest
Running Suite: SRIOV Operator conformance tests - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance
=====================================================================================================================================================================
Random Seed: 1687262298

Will run 27 of 27 specs
------------------------------
[BeforeSuite] 
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/test_suite_test.go:80
[BeforeSuite] PASSED [0.308 seconds]
------------------------------
[sriov] operator No SriovNetworkNodePolicy SR-IOV network config daemon can be set by nodeselector Should schedule the config daemon on selected nodes
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:109
Waiting for the sriov state to stable
Sriov state is stable
  STEP: Checking that a daemon is scheduled on each worker node @ 06/20/23 14:58:33.937
  STEP: Labeling one worker node with the label needed for the daemon @ 06/20/23 14:58:34.098
  STEP: Setting the node selector for each daemon @ 06/20/23 14:58:34.276
  STEP: Checking that a daemon is scheduled only on selected node @ 06/20/23 14:58:34.392
  STEP: Restoring the node selector for daemons @ 06/20/23 14:58:36.228
  STEP: Checking that a daemon is scheduled on each worker node @ 06/20/23 14:58:36.38
• [17.335 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy Resource Injector Should inject downward api volume with no labels present
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:225
Waiting for the sriov state to stable
Sriov state is stable
• [72.291 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy Resource Injector Should inject downward api volume with labels present
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:287
• [2.479 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy VF flags Should configure the spoofChk boolean variable
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:424
  STEP: configuring spoofChk on @ 06/20/23 14:59:53.829
  STEP: removing sriov network @ 06/20/23 14:59:56.184
  STEP: configuring spoofChk off @ 06/20/23 14:59:56.305
• [8.653 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy VF flags Should configure the trust boolean variable
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:469
  STEP: configuring trust on @ 06/20/23 15:00:01.387
  STEP: removing sriov network @ 06/20/23 15:00:04.896
  STEP: configuring trust off @ 06/20/23 15:00:05.011
• [7.432 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy VF flags Should configure the the link state variable
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:513
  [SKIPPED] in [It] - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:516 @ 06/20/23 15:00:09.867
S [SKIPPED] [2.531 seconds]
[sriov] operator Generic SriovNetworkNodePolicy VF flags [It] Should configure the the link state variable
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:513

  [SKIPPED] Bug in IGB driver
  In [It] at: /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:516 @ 06/20/23 15:00:09.867
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy VF flags rate limit Should configure the requested rate limit flags under the vf
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:582
  [SKIPPED] in [It] - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:588 @ 06/20/23 15:00:12.198
S [SKIPPED] [2.331 seconds]
[sriov] operator Generic SriovNetworkNodePolicy VF flags rate limit [It] Should configure the requested rate limit flags under the vf
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:582

  [SKIPPED] Skip rate limit test no mellanox driver found
  In [It] at: /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:588 @ 06/20/23 15:00:12.198
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy VF flags vlan and Qos vlan Should configure the requested vlan and Qos vlan flags under the vf
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:628
• [4.808 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy Multiple sriov device and attachment Should configure multiple network attachments
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:665
• [3.531 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy IPv6 configured secondary interfaces on pods should be able to ping each other
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:683
• [14.095 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy NAD update NAD is updated when SriovNetwork spec/networkNamespace is changed
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:706
• [18.655 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy NAD update NAD default gateway is updated when SriovNetwork ipam is changed
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:744
• [0.595 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy SRIOV and macvlan Should be able to create a pod with both sriov and macvlan interfaces
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:780
• [2.532 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy Meta Plugin Configuration Should be able to configure a metaplugin
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:820
• [2.832 seconds]
------------------------------
[sriov] operator Generic SriovNetworkNodePolicy Virtual Functions should release the VFs once the pod deleted and same VFs can be used by the new created pods
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:842
  STEP: Create first Pod which consumes all available VFs @ 06/20/23 15:00:59.495
  STEP: Checking that first Pod is in Running state @ 06/20/23 15:00:59.688
  STEP: Create second Pod which consumes one more VF @ 06/20/23 15:01:10.378
  STEP: Checking second that pod is in Pending state @ 06/20/23 15:01:10.504
  STEP: Checking that relevant error event was originated @ 06/20/23 15:01:10.566
  STEP: Delete first pod and release all VFs @ 06/20/23 15:01:10.639
  STEP: Checking that second pod is able to use released VF @ 06/20/23 15:01:10.694
• [16.768 seconds]
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Configuration Create vfio-pci node policy Should be possible to create a vfio-pci resource
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:939
Waiting for the sriov state to stable
Sriov state is stable
  STEP: creating a vfio-pci node policy @ 06/20/23 15:02:11.355
  STEP: waiting for the node state to be updated @ 06/20/23 15:02:11.455
  STEP: waiting the sriov to be stable on the node @ 06/20/23 15:02:11.473
Waiting for the sriov state to stable
Sriov state is stable
  STEP: waiting for the resources to be available @ 06/20/23 15:03:11.262
• [115.318 seconds]
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Configuration PF Partitioning Should be possible to partition the pf's vfs
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:982
Waiting for the sriov state to stable
Sriov state is stable
Waiting for the sriov state to stable
Sriov state is stable
• [182.820 seconds]
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Configuration PF Partitioning Should not be possible to have overlapping pf ranges
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1073
Waiting for the sriov state to stable
Sriov state is stable
• [64.747 seconds]
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Configuration Main PF should work when vfs are used by pods
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1138
Waiting for the sriov state to stable
Sriov state is stable
  [SKIPPED] in [It] - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1147 @ 06/20/23 15:07:38.492
S [SKIPPED] [19.590 seconds]
[sriov] operator Custom SriovNetworkNodePolicy Configuration Main PF [It] should work when vfs are used by pods
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1138

  [SKIPPED] Could not find pf used as gateway
  In [It] at: /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1147 @ 06/20/23 15:07:38.492
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Configuration PF shutdown Should be able to create pods successfully if PF is down.Pods are able to communicate with each other on the same node
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1168
Waiting for the sriov state to stable
Sriov state is stable
  [SKIPPED] in [It] - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1171 @ 06/20/23 15:07:48.948
S [SKIPPED] [10.456 seconds]
[sriov] operator Custom SriovNetworkNodePolicy Configuration PF shutdown [It] Should be able to create pods successfully if PF is down.Pods are able to communicate with each other on the same node
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1168

  [SKIPPED] Bug in IGB driver
  In [It] at: /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1171 @ 06/20/23 15:07:48.948
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Configuration MTU Should support jumbo frames
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1342
Waiting for the sriov state to stable
Sriov state is stable
  [SKIPPED] in [BeforeEach] - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1225 @ 06/20/23 15:07:59.212
S [SKIPPED] [10.263 seconds]
[sriov] operator Custom SriovNetworkNodePolicy Configuration MTU [BeforeEach] Should support jumbo frames
  [BeforeEach] /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1222
  [It] /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1342

  [SKIPPED] Bug in IGB driver
  In [BeforeEach] at: /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1225 @ 06/20/23 15:07:59.212
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Nic Validation Test connectivity using the requested nic Intel Corporation Ethernet Controller XXV710 for 25GbE SFP28
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1486
Waiting for the sriov state to stable
Sriov state is stable
  STEP: searching for the requested network card @ 06/20/23 15:08:09.535
  [SKIPPED] in [It] - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1413 @ 06/20/23 15:08:09.536
S [SKIPPED] [10.324 seconds]
[sriov] operator Custom SriovNetworkNodePolicy Nic Validation Test connectivity using the requested nic [It] Intel Corporation Ethernet Controller XXV710 for 25GbE SFP28
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1486

  [SKIPPED] skip nic validate as wasn't able to find a nic with vendorID 8086 and deviceID 158b
  In [It] at: /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1413 @ 06/20/23 15:08:09.536
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Nic Validation Test connectivity using the requested nic Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1487
Waiting for the sriov state to stable
Sriov state is stable
  STEP: searching for the requested network card @ 06/20/23 15:08:19.948
  [SKIPPED] in [It] - /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1413 @ 06/20/23 15:08:19.949
S [SKIPPED] [10.413 seconds]
[sriov] operator Custom SriovNetworkNodePolicy Nic Validation Test connectivity using the requested nic [It] Ethernet Controller XXV710 Intel(R) FPGA Programmable Acceleration Card N3000 for Networking
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1487

  [SKIPPED] skip nic validate as wasn't able to find a nic with vendorID 8086 and deviceID 0d58
  In [It] at: /home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1413 @ 06/20/23 15:08:19.949
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Resource Injector SR-IOV Operator Config, disable Resource Injector
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1504
Waiting for the sriov state to stable
Sriov state is stable
• [31.044 seconds]
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Resource Injector SR-IOV Operator Config, disable Operator Webhook
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1525
Waiting for the sriov state to stable
Sriov state is stable
• [30.862 seconds]
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy Resource Injector SR-IOV Operator Config, disable Resource Injector and Operator Webhook
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1545
Waiting for the sriov state to stable
Sriov state is stable
• [41.146 seconds]
------------------------------
[sriov] operator Custom SriovNetworkNodePolicy vhost-net and tun devices Validation Should have the vhost-net device inside the container
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1661
Waiting for the sriov state to stable
Sriov state is stable
Waiting for the sriov state to stable
Sriov state is stable
  STEP: waiting for the resources to be available @ 06/20/23 15:11:12.666
  STEP: creating a pod @ 06/20/23 15:11:21.314
  STEP: checking the /dev/vhost device exist inside the container @ 06/20/23 15:11:22.491
  STEP: checking the /dev/vhost device exist inside the container @ 06/20/23 15:11:22.791
  STEP: creating a tap device inside the container @ 06/20/23 15:11:23.135
  STEP: checking the tap device was created inside the container @ 06/20/23 15:11:23.447
• [80.842 seconds]
------------------------------
[AfterSuite] 
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/test_suite_test.go:85
[AfterSuite] PASSED [8.489 seconds]
------------------------------
[ReportAfterSuite] conformance
/home/sscheink/Documents/GolangProjects/src/github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/test_suite_test.go:59
[ReportAfterSuite] PASSED [0.000 seconds]
------------------------------

Ran 20 of 27 Specs in 793.499 seconds
SUCCESS! -- 20 Passed | 0 Failed | 0 Pending | 7 Skipped
--- PASS: TestTest (793.65s)
PASS

```