### PR TITLE
Use `e2e-test` tag for images built in e2e CI

### DIFF
--- a/hack/run-e2e-test-kind.sh
+++ b/hack/run-e2e-test-kind.sh
@@ -2,8 +2,8 @@
 set -eo pipefail
 here="$(dirname "$(readlink --canonicalize "${BASH_SOURCE[0]}")")"
 root="$(readlink --canonicalize "$here/..")"
-export SRIOV_NETWORK_OPERATOR_IMAGE="${SRIOV_NETWORK_OPERATOR_IMAGE:-sriov-network-operator:latest}"
-export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE="${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE:-origin-sriov-network-config-daemon:latest}"
+export SRIOV_NETWORK_OPERATOR_IMAGE="${SRIOV_NETWORK_OPERATOR_IMAGE:-sriov-network-operator:e2e-test}"
+export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE="${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE:-origin-sriov-network-config-daemon:e2e-test}"
 export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
 INTERFACES_SWITCHER="${INTERFACES_SWITCHER:-"test-suite"}"
 SUPPORTED_INTERFACE_SWTICHER_MODES=("test-suite", "system-service")


### PR DESCRIPTION
Currently for the kind CI, Kind deploys Kubernetes version v1.27.3, in this version the `ImagePullpolicy` of containers follow the procedures in [1], this breaks the CI, since the CI uses the `latest` tag when building the images, and Kubernetes tries to pull the images always instead of using the built image.

This patch changes the tag of the image built by CI to `e2e-test`, so that K8S will set the image policy to be `IfNotPresent`.

[1] https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting