### PR TITLE
Add `NUMANode` to node state

### DIFF
--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -65,6 +65,7 @@ type InterfaceExt struct {
 	LinkType    string            `json:"linkType,omitempty"`
 	EswitchMode string            `json:"eSwitchMode,omitempty"`
 	TotalVfs    int               `json:"totalvfs,omitempty"`
+	NUMANode    int               `json:"numaNode,omitempty"`
 	VFs         []VirtualFunction `json:"Vfs,omitempty"`
 }
 type InterfaceExts []InterfaceExt

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -139,6 +139,8 @@ spec:
                       type: string
                     numVfs:
                       type: integer
+                    numaNode:
+                      type: integer
                     pciAddress:
                       type: string
                     totalvfs:

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -139,6 +139,8 @@ spec:
                       type: string
                     numVfs:
                       type: integer
+                    numaNode:
+                      type: integer
                     pciAddress:
                       type: string
                     totalvfs:

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -125,6 +125,7 @@ func DiscoverSriovDevices(withUnsupported bool) ([]sriovnetworkv1.InterfaceExt, 
 		if dputils.IsSriovPF(device.Address) {
 			iface.TotalVfs = dputils.GetSriovVFcapacity(device.Address)
 			iface.NumVfs = dputils.GetVFconfigured(device.Address)
+			iface.NUMANode = dputils.GetDevNode(device.Address)
 			if iface.EswitchMode, err = GetNicSriovMode(device.Address); err != nil {
 				glog.Warningf("DiscoverSriovDevices(): unable to get device mode %+v %q", device.Address, err)
 			}


### PR DESCRIPTION
Add and populate the field
`SriovNetworkNodeState.Status.Interfaces[].NUMANode` so that the user knows which NUMA node every device is installed in.