### PR TITLE
Improve operator logging

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -236,7 +236,6 @@ func (p *SriovNetworkNodePolicy) Selected(node *corev1.Node) bool {
 		}
 		return false
 	}
-	log.Info("Selected():", "node", node.Name)
 	return true
 }
 

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -576,7 +576,7 @@ func renderDsForCR(path string, data *render.RenderData) ([]*uns.Unstructured, e
 
 func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(ctx context.Context, pl *sriovnetworkv1.SriovNetworkNodePolicyList, node *corev1.Node) (dptypes.ResourceConfList, error) {
 	logger := log.Log.WithName("renderDevicePluginConfigData")
-	logger.Info("Start to render device plugin config data")
+	logger.Info("Start to render device plugin config data", "node", node.Name)
 	rcl := dptypes.ResourceConfList{}
 	for _, p := range pl.Items {
 		if p.Name == constants.DefaultPolicyName {
@@ -608,7 +608,7 @@ func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(ctx cont
 				return rcl, err
 			}
 			rcl.ResourceList = append(rcl.ResourceList, *rc)
-			logger.Info("Add resource", "Resource", *rc, "Resource list", rcl.ResourceList)
+			logger.Info("Add resource", "Resource", *rc)
 		}
 	}
 	return rcl, nil

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -77,6 +78,7 @@ func main() {
 			"Enabling this will ensure there is only one active controller manager.")
 	opts := zap.Options{
 		Development: true,
+		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()


### PR DESCRIPTION
This PR improves the logging system of the operator:

a. `sigs.k8s.io/controller-runtime/pkg/log/zap` logging system needs a TimeEncoder to be set, so log lines change from:

```
1.6893201843653495e+09	INFO	Starting EventSource	{"controller": "sriovibnetwork"...
```
to 
```
2023-07-14T09:49:58.358957635Z	INFO	Starting EventSource	{"controller":  ...
```

b. Avoid logging in helper functions
c. `renderDevicePluginConfigData()` was logging a growing ResourceList array in a loop, leading to excessive logging when the cluster has 20+ policies.