### PR TITLE
Fix Config Daemon node selector

### DIFF
--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -151,7 +151,7 @@ var _ = Describe("Operator", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		PIt("should be able to update the node selector of sriov-network-config-daemon", func() {
+		It("should be able to update the node selector of sriov-network-config-daemon", func() {
 			By("specify the configDaemonNodeSelector")
 			config := &sriovnetworkv1.SriovOperatorConfig{}
 			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", interval, timeout)

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -90,11 +90,11 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 	if err := MergeObjectForUpdate(existing, obj); err != nil {
 		return errors.Wrapf(err, "could not merge object %s with existing", objDesc)
 	}
-	if !equality.Semantic.DeepDerivative(obj, existing) {
+	if !equality.Semantic.DeepEqual(existing, obj) {
 		if err := client.Update(ctx, obj); err != nil {
 			return errors.Wrapf(err, "could not update object %s", objDesc)
 		} else {
-			log.Printf("update was successful")
+			log.Printf("update was successful %s", objDesc)
 		}
 	}
 


### PR DESCRIPTION
When node selectors are added then removed via "configDaemonNodeSelector" via the sriovoperatorconfigs CRD, certain combinations will not trigger an update due to the ordering of arguments into "DeepDerivative" from the reflect library.

This is an example combination of setting "configDaemonNodeSelector" that would make it such that the sriov-config-daemon daemon set's nodeSelector to become out of sync with the original "DeepDerivative" argument order:
```
Step 1) Create 3 labels in node selector:
configDaemonNodeSelector = {"labelA": "", "labelB": "", "labelC": ""}
config-daemon DS NodeSelector = {"labelA": "", "labelB": "", "labelC": ""}

Step 2) Remove 1 label in node selector without making changes to the other labels:
configDaemonNodeSelector = {"labelA": "", "labelB": ""}
config-daemon DS NodeSelector = {"labelA": "", "labelB": "", "labelC": ""} (Out of Sync)
```
"DeepDerivative" assumes that the left argument is the original (v1) and the right argument is the updated (v2). For maps it only checks if v1 > v2 in length:
```
    case reflect.Map:
        ...
        if v1.Len() > v2.Len() {
            return false
        }
        ...
```
This commit just reverts changes from commit:
"661a65b8e1aee6339037948732f75d06ceb91611"
Use DeepDerivative to compare the kube object content
Such that we react to changes to node selectors properly.