### PR TITLE
Fix Plugin Config Daemon node selector

### DIFF
--- a/bindata/manifests/plugins/sriov-device-plugin.yaml
+++ b/bindata/manifests/plugins/sriov-device-plugin.yaml
@@ -26,8 +26,9 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        kubernetes.io/os: linux
-        node-role.kubernetes.io/worker:
+        {{- range $key, $value := .NodeSelectorField }}
+          {{ $key }}: {{ $value }}
+        {{- end }}
       tolerations:
       - operator: Exists
       serviceAccountName: sriov-device-plugin
@@ -70,7 +71,7 @@ spec:
           hostPath:
             path: /var/lib/kubelet/
         - name: config-volume
-          configMap: 
+          configMap:
             name: device-plugin-config
         - name: device-info
           hostPath:

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -56,3 +56,8 @@ func formatJSON(str string) (string, error) {
 	}
 	return prettyJSON.String(), nil
 }
+
+func GetDefaultNodeSelector() map[string]string {
+	return map[string]string{"node-role.kubernetes.io/worker": "",
+		"kubernetes.io/os": "linux"}
+}

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -335,6 +335,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncPluginDaemonObjs(ctx context.Cont
 	data.Data["ReleaseVersion"] = os.Getenv("RELEASEVERSION")
 	data.Data["ResourcePrefix"] = os.Getenv("RESOURCE_PREFIX")
 	data.Data["ImagePullSecrets"] = GetImagePullSecrets()
+	data.Data["NodeSelectorField"] = GetDefaultNodeSelector()
 
 	objs, err := renderDsForCR(constants.PluginPath, &data)
 	if err != nil {

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -154,9 +154,6 @@ func (r *SriovOperatorConfigReconciler) syncPluginDaemonSet(ctx context.Context,
 
 	names := []string{"sriov-cni", "sriov-device-plugin"}
 
-	if len(dc.Spec.ConfigDaemonNodeSelector) == 0 {
-		return nil
-	}
 	for _, name := range names {
 		err := r.Client.Get(ctx, types.NamespacedName{Name: name, Namespace: namespace}, ds)
 		if err != nil {
@@ -166,7 +163,11 @@ func (r *SriovOperatorConfigReconciler) syncPluginDaemonSet(ctx context.Context,
 			logger.Error(err, "Couldn't get daemonset", "name", name)
 			return err
 		}
-		ds.Spec.Template.Spec.NodeSelector = dc.Spec.ConfigDaemonNodeSelector
+		if len(dc.Spec.ConfigDaemonNodeSelector) == 0 {
+			ds.Spec.Template.Spec.NodeSelector = GetDefaultNodeSelector()
+		} else {
+			ds.Spec.Template.Spec.NodeSelector = dc.Spec.ConfigDaemonNodeSelector
+		}
 		err = r.Client.Update(ctx, ds)
 		if err != nil {
 			logger.Error(err, "Couldn't update daemonset", "name", name)


### PR DESCRIPTION
When node selectors are added via "configDaemonNodeSelector" via the sriovoperatorconfigs CRD then completely removed, the previous node selectors would remain for the plugin config daemons (sriov-device-plugin). This was not cleaned up, because the function "syncPluginDaemonSet" bails out when "configDaemonNodeSelector" is empty. For example:

```
Step 1) Create 3 labels in node selector:
configDaemonNodeSelector = {"labelA": "", "labelB": "", "labelC": ""}
device-plugin DS NodeSelector = {"labelA": "", "labelB": "", "labelC": ""} 

Step 2) Remove all labels in node selector:
configDaemonNodeSelector = {}
device-plugin DS NodeSelector = {"labelA": "", "labelB": "", "labelC": ""}
```

The expectation is that the device plugin will revert to the default node selectors (e.g. {"node-role.kubernetes.io/worker": "", "kubernetes.io/os": "linux"})

This change will make the node selector field in the sriov-device-plugin to take in a variable. This default node selector value is then shared with the code that updates the node selector.