### PR TITLE
Render SriovNetworkNodeState before Device Plugin ConfigMap

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -132,16 +132,16 @@ func (r *SriovNetworkNodePolicyReconciler) Reconcile(ctx context.Context, req ct
 
 	// Sort the policies with priority, higher priority ones is applied later
 	sort.Sort(sriovnetworkv1.ByPriority(policyList.Items))
+	// Sync SriovNetworkNodeState objects
+	if err = r.syncAllSriovNetworkNodeStates(ctx, defaultPolicy, policyList, nodeList); err != nil {
+		return reconcile.Result{}, err
+	}
 	// Sync Sriov device plugin ConfigMap object
 	if err = r.syncDevicePluginConfigMap(ctx, policyList, nodeList); err != nil {
 		return reconcile.Result{}, err
 	}
 	// Render and sync Daemon objects
 	if err = r.syncPluginDaemonObjs(ctx, defaultPolicy, policyList); err != nil {
-		return reconcile.Result{}, err
-	}
-	// Sync SriovNetworkNodeState objects
-	if err = r.syncAllSriovNetworkNodeStates(ctx, defaultPolicy, policyList, nodeList); err != nil {
 		return reconcile.Result{}, err
 	}
 


### PR DESCRIPTION
Device Plugin ConfigMap relies on SriovNetworkNodeState object, so we need to render it earlier.

The issue is occured only if node stops to correspond to configDaemonNodeSelector during SR-IOV configuration, so controller will delete SriovNetworkNodeState and won't re-create it again once node starts correspond to configDaemonNodeSelector again.