### PR TITLE
Return reconcile error if node state is not updated

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -711,6 +711,9 @@ func createDevicePluginResource(
 	// Enable the selection of devices using NetFilter
 	if p.Spec.NicSelector.NetFilter != "" {
 		// Loop through interfaces status to find a match for NetworkID or NetworkTag
+		if len(nodeState.Status.Interfaces) == 0 {
+			return nil, fmt.Errorf("node state %s doesn't contain interfaces data", nodeState.Name)
+		}
 		for _, intf := range nodeState.Status.Interfaces {
 			if sriovnetworkv1.NetFilterMatch(p.Spec.NicSelector.NetFilter, intf.NetFilter) {
 				// Found a match add the Interfaces PciAddress


### PR DESCRIPTION
NetFilter selector depends on PCI address of NICs from the node state. After PR #487 is merged we need to check if node state is updated or return an reconcile error to render device plugin config faster.