### PR TITLE
SriovNetwork: react on namespace creation

### DIFF
--- a/controllers/sriovibnetwork_controller.go
+++ b/controllers/sriovibnetwork_controller.go
@@ -21,12 +21,15 @@ import (
 	"reflect"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -136,10 +139,16 @@ func (r *SriovIBNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	// Check if this NetworkAttachmentDefinition already exists
 	found := &netattdefv1.NetworkAttachmentDefinition{}
-
 	err = r.Get(ctx, types.NamespacedName{Name: netAttDef.Name, Namespace: netAttDef.Namespace}, found)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			targetNamespace := &corev1.Namespace{}
+			err = r.Get(ctx, types.NamespacedName{Name: netAttDef.Namespace}, targetNamespace)
+			if errors.IsNotFound(err) {
+				reqLogger.Info("Target namespace doesn't exist, NetworkAttachmentDefinition will be created when namespace is available", "Namespace", netAttDef.Namespace, "Name", netAttDef.Name)
+				return reconcile.Result{}, nil
+			}
+
 			reqLogger.Info("NetworkAttachmentDefinition CR not exist, creating")
 			err = r.Create(ctx, netAttDef)
 			if err != nil {
@@ -172,8 +181,30 @@ func (r *SriovIBNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SriovIBNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Reconcile when the target namespace is created after the SriovNetwork object.
+	namespaceHandler := handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
+			ibNetworkList := sriovnetworkv1.SriovIBNetworkList{}
+			err := r.List(ctx,
+				&ibNetworkList,
+				client.MatchingFields{"spec.networkNamespace": e.Object.GetName()},
+			)
+			if err != nil {
+				log.Log.WithName("SriovIBNetworkReconciler").
+					Info("Can't list SriovIBNetworkReconciler for namespace", "resource", e.Object.GetName(), "error", err)
+			}
+
+			for _, network := range ibNetworkList.Items {
+				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: network.Namespace,
+					Name:      network.Name,
+				}})
+			}
+		},
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sriovnetworkv1.SriovIBNetwork{}).
 		Watches(&netattdefv1.NetworkAttachmentDefinition{}, &handler.EnqueueRequestForObject{}).
+		Watches(&corev1.Namespace{}, &namespaceHandler).
 		Complete(r)
 }

--- a/controllers/sriovibnetwork_controller_test.go
+++ b/controllers/sriovibnetwork_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -187,6 +188,52 @@ var _ = Describe("SriovIBNetwork Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = k8sClient.Delete(goctx.TODO(), found, []dynclient.DeleteOption{}...)
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When the target NetworkNamespace doesn't exists", func() {
+		It("should create the NetAttachDef when the namespace is created", func() {
+			cr := sriovnetworkv1.SriovIBNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-missing-namespace",
+					Namespace: testNamespace,
+				},
+				Spec: sriovnetworkv1.SriovIBNetworkSpec{
+					NetworkNamespace: "ib-ns-xxx",
+					ResourceName:     "resource_missing_namespace",
+					IPAM:             `{"type":"dhcp"}`,
+				},
+			}
+			var err error
+			expect := generateExpectedIBNetConfig(&cr)
+
+			err = k8sClient.Create(goctx.TODO(), &cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			DeferCleanup(func() {
+				err = k8sClient.Delete(goctx.TODO(), &cr)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			// Sleep 3 seconds to be sure the Reconcile loop has been invoked. This can be improved by exposing some information (e.g. the error)
+			// in the SriovIBNetwork.Status field.
+			time.Sleep(3 * time.Second)
+
+			netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
+			err = k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetName(), Namespace: "ib-ns-xxx"}, netAttDef)
+			Expect(err).To(HaveOccurred())
+
+			err = k8sClient.Create(goctx.TODO(), &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{Name: "ib-ns-xxx"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = util.WaitForNamespacedObject(netAttDef, k8sClient, "ib-ns-xxx", cr.GetName(), util.RetryInterval, util.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+
+			anno := netAttDef.GetAnnotations()
+			Expect(anno["k8s.v1.cni.cncf.io/resourceName"]).To(Equal("openshift.io/" + cr.Spec.ResourceName))
+			Expect(strings.TrimSpace(netAttDef.Spec.Config)).To(Equal(expect))
 		})
 	})
 })

--- a/controllers/sriovnetwork_controller.go
+++ b/controllers/sriovnetwork_controller.go
@@ -21,13 +21,15 @@ import (
 	"reflect"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-
+	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -140,6 +142,13 @@ func (r *SriovNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	err = r.Get(ctx, types.NamespacedName{Name: netAttDef.Name, Namespace: netAttDef.Namespace}, found)
 	if err != nil {
 		if errors.IsNotFound(err) {
+			targetNamespace := &corev1.Namespace{}
+			err = r.Get(ctx, types.NamespacedName{Name: netAttDef.Namespace}, targetNamespace)
+			if errors.IsNotFound(err) {
+				reqLogger.Info("Target namespace doesn't exist, NetworkAttachmentDefinition will be created when namespace is available", "Namespace", netAttDef.Namespace, "Name", netAttDef.Name)
+				return reconcile.Result{}, nil
+			}
+
 			reqLogger.Info("NetworkAttachmentDefinition CR not exist, creating")
 			err = r.Create(ctx, netAttDef)
 			if err != nil {
@@ -173,8 +182,31 @@ func (r *SriovNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *SriovNetworkReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	// Reconcile when the target namespace is created after the SriovNetwork object.
+	namespaceHandler := handler.Funcs{
+		CreateFunc: func(ctx context.Context, e event.CreateEvent, q workqueue.RateLimitingInterface) {
+			networkList := sriovnetworkv1.SriovNetworkList{}
+			err := r.List(ctx,
+				&networkList,
+				client.MatchingFields{"spec.networkNamespace": e.Object.GetName()},
+			)
+			if err != nil {
+				log.Log.WithName("SriovNetworkReconciler").
+					Info("Can't list SriovNetworks for namespace", "resource", e.Object.GetName(), "error", err)
+			}
+
+			for _, network := range networkList.Items {
+				q.Add(reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: network.Namespace,
+					Name:      network.Name,
+				}})
+			}
+		},
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&sriovnetworkv1.SriovNetwork{}).
 		Watches(&netattdefv1.NetworkAttachmentDefinition{}, &handler.EnqueueRequestForObject{}).
+		Watches(&corev1.Namespace{}, &namespaceHandler).
 		Complete(r)
 }

--- a/controllers/sriovnetwork_controller_test.go
+++ b/controllers/sriovnetwork_controller_test.go
@@ -8,7 +8,9 @@ import (
 	"time"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -214,6 +216,54 @@ var _ = Describe("SriovNetwork Controller", func() {
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
+
+		Context("When the target NetworkNamespace doesn't exists", func() {
+			It("should create the NetAttachDef when the namespace is created", func() {
+				cr := sriovnetworkv1.SriovNetwork{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-missing-namespace",
+						Namespace: testNamespace,
+					},
+					Spec: sriovnetworkv1.SriovNetworkSpec{
+						NetworkNamespace: "ns-xxx",
+						ResourceName:     "resource_missing_namespace",
+						IPAM:             `{"type":"dhcp"}`,
+						Vlan:             200,
+					},
+				}
+				var err error
+				expect := generateExpectedNetConfig(&cr)
+
+				err = k8sClient.Create(goctx.TODO(), &cr)
+				Expect(err).NotTo(HaveOccurred())
+
+				DeferCleanup(func() {
+					err = k8sClient.Delete(goctx.TODO(), &cr)
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				// Sleep 3 seconds to be sure the Reconcile loop has been invoked. This can be improved by exposing some information (e.g. the error)
+				// in the SriovNetwork.Status field.
+				time.Sleep(3 * time.Second)
+
+				netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
+				err = k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetName(), Namespace: "ns-xxx"}, netAttDef)
+				Expect(err).To(HaveOccurred())
+
+				err = k8sClient.Create(goctx.TODO(), &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: "ns-xxx"},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				err = util.WaitForNamespacedObject(netAttDef, k8sClient, "ns-xxx", cr.GetName(), util.RetryInterval, util.Timeout)
+				Expect(err).NotTo(HaveOccurred())
+
+				anno := netAttDef.GetAnnotations()
+				Expect(anno["k8s.v1.cni.cncf.io/resourceName"]).To(Equal("openshift.io/" + cr.Spec.ResourceName))
+				Expect(strings.TrimSpace(netAttDef.Spec.Config)).To(Equal(expect))
+			})
+		})
+
 	})
 })
 

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -113,6 +113,10 @@ var _ = BeforeSuite(func(done Done) {
 		return []string{o.(*sriovnetworkv1.SriovNetwork).Spec.NetworkNamespace}
 	})
 
+	k8sManager.GetCache().IndexField(context.Background(), &sriovnetworkv1.SriovIBNetwork{}, "spec.networkNamespace", func(o client.Object) []string {
+		return []string{o.(*sriovnetworkv1.SriovIBNetwork).Spec.NetworkNamespace}
+	})
+
 	err = (&SriovNetworkReconciler{
 		Client: k8sManager.GetClient(),
 		Scheme: k8sManager.GetScheme(),

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/gomega"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
+	"go.uber.org/zap/zapcore"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -64,7 +65,12 @@ const (
 )
 
 var _ = BeforeSuite(func(done Done) {
-	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	logf.SetLogger(zap.New(
+		zap.WriteTo(GinkgoWriter),
+		zap.UseDevMode(true),
+		func(o *zap.Options) {
+			o.TimeEncoder = zapcore.RFC3339NanoTimeEncoder
+		}))
 
 	// Go to project root directory
 	os.Chdir("..")
@@ -102,6 +108,10 @@ var _ = BeforeSuite(func(done Done) {
 		Scheme: scheme.Scheme,
 	})
 	Expect(err).ToNot(HaveOccurred())
+
+	k8sManager.GetCache().IndexField(context.Background(), &sriovnetworkv1.SriovNetwork{}, "spec.networkNamespace", func(o client.Object) []string {
+		return []string{o.(*sriovnetworkv1.SriovNetwork).Spec.NetworkNamespace}
+	})
 
 	err = (&SriovNetworkReconciler{
 		Client: k8sManager.GetClient(),

--- a/main.go
+++ b/main.go
@@ -130,6 +130,10 @@ func main() {
 		return []string{o.(*sriovnetworkv1.SriovNetwork).Spec.NetworkNamespace}
 	})
 
+	mgrGlobal.GetCache().IndexField(context.Background(), &sriovnetworkv1.SriovIBNetwork{}, "spec.networkNamespace", func(o client.Object) []string {
+		return []string{o.(*sriovnetworkv1.SriovIBNetwork).Spec.NetworkNamespace}
+	})
+
 	if err := initNicIDMap(); err != nil {
 		setupLog.Error(err, "unable to init NicIdMap")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -126,6 +126,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	mgrGlobal.GetCache().IndexField(context.Background(), &sriovnetworkv1.SriovNetwork{}, "spec.networkNamespace", func(o client.Object) []string {
+		return []string{o.(*sriovnetworkv1.SriovNetwork).Spec.NetworkNamespace}
+	})
+
 	if err := initNicIDMap(); err != nil {
 		setupLog.Error(err, "unable to init NicIdMap")
 		os.Exit(1)


### PR DESCRIPTION
If a user creates an SriovNetwork with a network namespace that doesn't exist, retrying reconciling with an exponential backoff is not efficient, as the routing will fail until the namespace is created.

This patch makes the controller watch Namespace resource creation and reconcile the related SriovNetworks if needed.

Before this PR, the SriovNetwork reconcile function returned an error, triggering the exponential back-off retry system:

```
2023-08-11T16:14:18.839626394Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "9783b6b4-b193-4d78-9371-be4f3487d68b", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:18.905244077Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "fccf9f74-f963-47f4-b672-d5099eb40484", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:18.970988294Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "5c790fc5-ca13-4283-b0a8-22753d0ccb89", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:19.047349515Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "388e00a0-dfe3-4b01-afef-b2ec0b62a675", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:19.142652361Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "dd8a06d4-08d8-479f-b5c4-b29e2d07a6b9", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:19.278729554Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "8267549b-ec6c-4370-a162-c4b88987c2aa", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:19.496675162Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "7764a8ea-fd2e-4704-82b1-902f066e2cda", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:19.87228528Z   ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "5c111316-1313-470c-9e95-3637f5386bd1", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:20.569108499Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "ac4bfd17-af0e-4421-8ec7-b583ce7c2831", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
2023-08-11T16:14:21.905604308Z  ERROR   Couldn't create NetworkAttachmentDefinition CR  {"controller": "sriovnetwork", "controllerGroup": "sriovnetwork.openshift.io", "controllerKind": "SriovNetwork", "SriovNetwork": {"name":"test-missing-ns","namespace":"openshift-sriov-network-operator"}, "namespace": "openshift-sriov-network-operator", "name": "test-missing-ns", "reconcileID": "c63c700a-537d-4fc4-b64d-6b4dba8f7a4e", "sriovnetwork": "openshift-sriov-network-operator/test-missing-ns", "Namespace": "ns-xxx", "Name": "test-missing-ns", "error": "namespaces \"ns-xxx\" not found"}
```