### PR TITLE
config-daemon: Improve logging of draining state

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -217,6 +217,8 @@ func (dn *Daemon) tryCreateUdevRuleWrapper() error {
 
 // Run the config daemon
 func (dn *Daemon) Run(stopCh <-chan struct{}, exitCh <-chan error) error {
+	glog.V(0).Infof("Run(): node: %s", dn.name)
+
 	if utils.ClusterType == utils.ClusterTypeOpenshift {
 		glog.V(0).Infof("Run(): start daemon. openshiftFlavor: %s", dn.openshiftContext.OpenshiftFlavor)
 	} else {


### PR DESCRIPTION
Executions of `nodeUpdateHandler` are not tracked by logs,
that make debugging problems harder.

Also, adding a log line to write the node name the config-daemon is working on.

**Note**: part of this work will be superseded by
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/488

but it's still useful to deal with draining issue while waiting for that PR.

