### PR TITLE
Update device plugins volumes mounts

### DIFF
--- a/bindata/manifests/plugins/sriov-device-plugin.yaml
+++ b/bindata/manifests/plugins/sriov-device-plugin.yaml
@@ -58,7 +58,10 @@ spec:
             memory: 50Mi
         volumeMounts:
         - name: devicesock
-          mountPath: /var/lib/kubelet/
+          mountPath: /var/lib/kubelet/device-plugins
+          readOnly: false
+        - name: plugins-registry
+          mountPath: /var/lib/kubelet/plugins_registry
           readOnly: false
         - name: config-volume
           mountPath: /etc/pcidp/
@@ -68,7 +71,10 @@ spec:
       volumes:
         - name: devicesock
           hostPath:
-            path: /var/lib/kubelet/
+            path: /var/lib/kubelet/device-plugins
+        - name: plugins-registry
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
         - name: config-volume
           configMap: 
             name: device-plugin-config


### PR DESCRIPTION
There is no need to mount the whole '/var/lib/kubelet/' directory into a pod. It's enough to mount only '/var/lib/kubelet/device-plugins' and '/var/lib/kubelet/plugins_registry' directories.