### PR TITLE
e2e: Use `OPERATOR_NAMESPACE` in k8sreporter

### DIFF
--- a/test/util/k8sreporter/reporter.go
+++ b/test/util/k8sreporter/reporter.go
@@ -21,11 +21,16 @@ func New(reportPath string) (*kniK8sReporter.KubernetesReporter, error) {
 		return nil
 	}
 
+	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
+	if operatorNamespace == "" {
+		operatorNamespace = "openshift-sriov-network-operator"
+	}
+
 	dumpNamespace := func(ns string) bool {
 		switch {
 		case ns == namespaces.Test:
 			return true
-		case ns == "openshift-sriov-network-operator":
+		case ns == operatorNamespace:
 			return true
 		case strings.HasPrefix(ns, "sriov-"):
 			return true


### PR DESCRIPTION
The operator working namespace should be specified by the user when running conformance tests.

amends:
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/498

cc @liornoy 