### PR TITLE
Use the OPERATOR_NAMESPACE var in the k8sreporter

### DIFF
--- a/test/util/k8sreporter/reporter.go
+++ b/test/util/k8sreporter/reporter.go
@@ -21,11 +21,16 @@ func New(reportPath string) (*kniK8sReporter.KubernetesReporter, error) {
 		return nil
 	}
 
+	operatorNamespace := os.Getenv("OPERATOR_NAMESPACE")
+	if operatorNamespace == "" {
+		operatorNamespace = "openshift-sriov-network-operator"
+	}
+
 	dumpNamespace := func(ns string) bool {
 		switch {
 		case ns == namespaces.Test:
 			return true
-		case ns == "openshift-sriov-network-operator":
+		case ns == operatorNamespace:
 			return true
 		case strings.HasPrefix(ns, "sriov-"):
 			return true


### PR DESCRIPTION
This commit modifies the k8s reporter to fetch the namesapce from the env var OPERATOR_NAMESPACE.