### PR TITLE
e2e: Allow testing custom cni and dp image

### DIFF
--- a/hack/run-e2e-conformance-common
+++ b/hack/run-e2e-conformance-common
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+podman_tag_and_push() {
+  local_image=$1
+  cluster_image=$2
+
+  echo "## Pushing ${local_image} to cluster registry ${cluster_image}"
+  podman tag ${local_image} ${cluster_image}
+  podman push --tls-verify=false ${cluster_image}
+}

--- a/hack/run-e2e-conformance-virtual-cluster.sh
+++ b/hack/run-e2e-conformance-virtual-cluster.sh
@@ -19,6 +19,8 @@ if [ "$NUM_OF_WORKERS" -lt 2 ]; then
     exit 1
 fi
 
+source $here/run-e2e-conformance-common
+
 check_requirements() {
   for cmd in kcli virsh virt-edit podman make go; do
     if ! command -v "$cmd" &> /dev/null; then
@@ -293,6 +295,23 @@ podman push --tls-verify=false "${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}"
 podman rmi -fi ${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE}
 podman push --tls-verify=false "${SRIOV_NETWORK_WEBHOOK_IMAGE}"
 podman rmi -fi ${SRIOV_NETWORK_WEBHOOK_IMAGE}
+
+
+if [[ -v LOCAL_SRIOV_CNI_IMAGE ]]; then
+  export SRIOV_CNI_IMAGE="$controller_ip:5000/sriov-cni:latest"
+  podman_tag_and_push ${LOCAL_SRIOV_CNI_IMAGE} ${SRIOV_CNI_IMAGE}
+fi
+
+if [[ -v LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE ]]; then
+  export SRIOV_DEVICE_PLUGIN_IMAGE="$controller_ip:5000/sriov-network-device-plugin:latest"
+  podman_tag_and_push ${LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE} ${SRIOV_DEVICE_PLUGIN_IMAGE}
+fi
+
+if [[ -v LOCAL_NETWORK_RESOURCES_INJECTOR_IMAGE ]]; then
+  export NETWORK_RESOURCES_INJECTOR_IMAGE="$controller_ip:5000/network-resources-injector:latest"
+  podman_tag_and_push ${LOCAL_NETWORK_RESOURCES_INJECTOR_IMAGE} ${NETWORK_RESOURCES_INJECTOR_IMAGE}
+fi
+
 
 # remove the crio bridge and let flannel to recreate
 kcli ssh $cluster_name-ctlplane-0 << EOF

--- a/hack/run-e2e-conformance-virtual-cluster.sh
+++ b/hack/run-e2e-conformance-virtual-cluster.sh
@@ -426,9 +426,17 @@ if [ -z $SKIP_TEST ]; then
     export JUNIT_OUTPUT="${root}/${TEST_REPORT_PATH}/conformance-test-report"
   fi
 
+  # Disable exit on error temporarily to gather cluster information
+  set +e
   SUITE=./test/conformance hack/run-e2e-conformance.sh
+  TEST_EXITE_CODE=$?
+  set -e
 
   if [[ -v TEST_REPORT_PATH ]]; then
     kubectl cluster-info dump --namespaces ${NAMESPACE} --output-directory "${root}/${TEST_REPORT_PATH}/cluster-info"
+  fi
+
+  if [[ $TEST_EXITE_CODE -ne 0 ]]; then
+    exit $TEST_EXITE_CODE
   fi
 fi

--- a/hack/run-e2e-conformance-virtual-ocp.sh
+++ b/hack/run-e2e-conformance-virtual-ocp.sh
@@ -21,6 +21,8 @@ fi
 here="$(dirname "$(readlink --canonicalize "${BASH_SOURCE[0]}")")"
 root="$(readlink --canonicalize "$here/..")"
 
+source $here/run-e2e-conformance-common
+
 check_requirements() {
   for cmd in kcli virsh podman make go jq base64 tar; do
     if ! command -v "$cmd" &> /dev/null; then
@@ -262,6 +264,21 @@ EOF
 export SRIOV_NETWORK_OPERATOR_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-network-operator:latest"
 export SRIOV_NETWORK_CONFIG_DAEMON_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-network-config-daemon:latest"
 export SRIOV_NETWORK_WEBHOOK_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-network-operator-webhook:latest"
+
+if [[ -v LOCAL_SRIOV_CNI_IMAGE ]]; then
+  podman_tag_and_push ${LOCAL_SRIOV_CNI_IMAGE} "$registry/$NAMESPACE/sriov-cni:latest"
+  export SRIOV_CNI_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-cni:latest"
+fi
+
+if [[ -v LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE ]]; then
+  podman_tag_and_push ${LOCAL_SRIOV_DEVICE_PLUGIN_IMAGE} "$registry/$NAMESPACE/sriov-network-device-plugin:latest"
+  export SRIOV_DEVICE_PLUGIN_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/sriov-network-device-plugin:latest"
+fi
+
+if [[ -v LOCAL_NETWORK_RESOURCES_INJECTOR_IMAGE ]]; then
+  podman_tag_and_push ${LOCAL_NETWORK_RESOURCES_INJECTOR_IMAGE} "$registry/$NAMESPACE/network-resources-injector:latest"
+  export NETWORK_RESOURCES_INJECTOR_IMAGE="image-registry.openshift-image-registry.svc:5000/$NAMESPACE/network-resources-injector:latest"
+fi
 
 echo "## deploying SRIOV Network Operator"
 hack/deploy-setup.sh $NAMESPACE

--- a/hack/run-e2e-conformance-virtual-ocp.sh
+++ b/hack/run-e2e-conformance-virtual-ocp.sh
@@ -293,9 +293,17 @@ if [ -z $SKIP_TEST ]; then
     export JUNIT_OUTPUT="${root}/${TEST_REPORT_PATH}/conformance-test-report"
   fi
 
+  # Disable exit on error temporarily to gather cluster information
+  set +e
   SUITE=./test/conformance hack/run-e2e-conformance.sh
+  TEST_EXITE_CODE=$?
+  set -e
 
   if [[ -v TEST_REPORT_PATH ]]; then
     kubectl cluster-info dump --namespaces ${NAMESPACE} --output-directory "${root}/${TEST_REPORT_PATH}/cluster-info"
+  fi
+
+  if [[ $TEST_EXITE_CODE -ne 0 ]]; then
+    exit $TEST_EXITE_CODE
   fi
 fi


### PR DESCRIPTION
Let `run-e2e-conformance-virtual-ocp.sh` and
`run-e2e-conformance-virtual-cluster.sh` deploy clusters with specific SRIOV CNI and Device Plugin images. This will enable other projects to have full end-to-end test CI with the operator's suite.

Ref:
- https://github.com/k8snetworkplumbingwg/sriov-cni/pull/282

cc @adrianchiris @e0ne 