### PR TITLE
Add support for Intel E823C NICs

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -17,6 +17,7 @@ data:
   Intel_ice_Columbiaville_E810-XXVDA4: "8086 1593 1889"
   Intel_ice_Columbiaville_E810-XXVDA2: "8086 159b 1889"
   Intel_ice_Columbiaville_E810: "8086 1591 1889"
+  Intel_ice_Columbiapark_E823C: "8086 188a 1889"
   Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
   Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
   Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -17,6 +17,7 @@ data:
   Intel_ice_Columbiaville_E810-XXVDA4: "8086 1593 1889"
   Intel_ice_Columbiaville_E810-XXVDA2: "8086 159b 1889"
   Intel_ice_Columbiaville_E810: "8086 1591 1889"
+  Intel_ice_Columbiapark_E823C: "8086 188a 1889"
   Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
   Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
   Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -13,6 +13,7 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Intel E810-CQDA2/2CQDA2 Family | 8086  | 1592 |
 | Intel E810-XXVDA4 Family | 8086  | 1593 |
 | Intel E810-XXVDA2 Family | 8086  | 159b |
+| Intel E823-C Family | 8086  | 188a |
 | Mellanox MT27700 Family [ConnectX-4] | 15b3 | 1013 |
 | Mellanox MT27710 Family [ConnectX-4 Lx] | 15b3 | 1015 |
 | Mellanox MT27800 Family [ConnectX-5] | 15b3 | 1017 |
@@ -52,6 +53,7 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Intel E810-CQDA2/2CQDA2 Family | V | V | X |
 | Intel E810-XXVDA4 Family | V | V | X |
 | Intel E810-XXVDA2 Family | V | V | X |
+| Intel E823-C Family | V | V | X |
 | Mellanox MT27700 Family [ConnectX-4] | V | V | V |
 | Mellanox MT27710 Family [ConnectX-4 Lx] | V | V | V |
 | Mellanox MT27800 Family [ConnectX-5] | V | V | V |


### PR DESCRIPTION
We use Kontron ME1310 Edge Servers which has built in E823C NICs. We create VFs using these NICs. We are able to create SriovNetworkNodePolicy and create the VFs after adding it under supported-nic-ids config map