### PR TITLE
CI scripts improvements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -119,6 +119,12 @@ jobs:
           name: k8s-artifact
           path: ./k8s-artifacts
 
+      - name: remove virtual cluster
+        if: always()
+        run: |
+          kcli delete cluster $CLUSTER_NAME -y
+          kcli delete network $CLUSTER_NAME -y
+
   virtual-ocp:
     name: ocp
     needs: [
@@ -145,3 +151,9 @@ jobs:
         with:
           name: ocp-artifact
           path: ./ocp-artifacts
+
+      - name: remove virtual cluster
+        if: always()
+        run: |
+          kcli delete cluster $CLUSTER_NAME -y
+          kcli delete network $CLUSTER_NAME -y

--- a/hack/run-e2e-conformance-virtual-cluster.sh
+++ b/hack/run-e2e-conformance-virtual-cluster.sh
@@ -120,6 +120,9 @@ controller_ip=`kubectl get node -o wide | grep ctlp | awk '{print $6}'`
 insecure_registry="[[registry]]
 location = \"$controller_ip:5000\"
 insecure = true
+
+[aliases]
+\"golang\" = \"docker.io/library/golang\"
 "
 
 cat << EOF > /etc/containers/registries.conf.d/003-${cluster_name}.conf
@@ -223,7 +226,7 @@ spec:
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
       containers:
-      - image: docker.io/registry:latest
+      - image: quay.io/libpod/registry:2.8.2
         imagePullPolicy: Always
         name: registry
         volumeMounts:

--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -143,8 +143,9 @@ var _ = Describe("[sriov] operator", func() {
 				cfg.Spec.ConfigDaemonNodeSelector = map[string]string{
 					"sriovenabled": "true",
 				}
-				err = clients.Update(context.TODO(), &cfg)
-				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() error {
+					return clients.Update(context.TODO(), &cfg)
+				}, 1*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 
 				By("Checking that a daemon is scheduled only on selected node")
 				Eventually(func() bool {
@@ -159,8 +160,9 @@ var _ = Describe("[sriov] operator", func() {
 				}, &cfg)
 				Expect(err).ToNot(HaveOccurred())
 				cfg.Spec.ConfigDaemonNodeSelector = map[string]string{}
-				err = clients.Update(context.TODO(), &cfg)
-				Expect(err).ToNot(HaveOccurred())
+				Eventually(func() error {
+					return clients.Update(context.TODO(), &cfg)
+				}, 1*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 
 				By("Checking that a daemon is scheduled on each worker node")
 				Eventually(func() bool {
@@ -2316,8 +2318,9 @@ func createVanillaNetworkPolicy(node string, sriovInfos *cluster.EnabledNodes, n
 			DeviceType: "netdevice",
 		},
 	}
-	err = clients.Create(context.Background(), config)
-	Expect(err).ToNot(HaveOccurred())
+	Eventually(func() error {
+		return clients.Create(context.Background(), config)
+	}, 1*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
 
 	Eventually(func() sriovv1.Interfaces {
 		nodeState, err := clients.SriovNetworkNodeStates(operatorNamespace).Get(context.Background(), node, metav1.GetOptions{})


### PR DESCRIPTION
Updates to OCP:
* add a retry to the policy create to fix OCP CI flake
* add more ram to the OCP master single node
* add a wait for registry to be available
* update the ocp version to latest 4.14 rc release
    
Updates for K8s:
* switch to not use dockerhub for the registry image to overcome the pull limit
    
github actions: 
* always remove the cluster


Signed-off-by: Sebastian Sch <sebassch@gmail.com>
