### PR TITLE
Remove glog 

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -121,7 +121,7 @@ func IsSupportedModel(vendorID, deviceID string) bool {
 			return true
 		}
 	}
-	log.Info("IsSupportedModel():", "Unsupported model:", "vendorId:", vendorID, "deviceId:", deviceID)
+	log.Info("IsSupportedModel(): found unsupported model", "vendorId:", vendorID, "deviceId:", deviceID)
 	return false
 }
 

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -70,7 +70,6 @@ spec:
         - -port=6443
         - -tls-private-key-file=/etc/tls/tls.key
         - -tls-cert-file=/etc/tls/tls.crt
-        - -alsologtostderr=true
         - -insecure=true
         env:
         - name: NAMESPACE

--- a/cmd/sriov-network-config-daemon/main.go
+++ b/cmd/sriov-network-config-daemon/main.go
@@ -18,8 +18,10 @@ package main
 import (
 	"flag"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 )
 
 const (
@@ -35,11 +37,12 @@ var (
 )
 
 func init() {
+	snolog.BindFlags(flag.CommandLine)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 }
 
 func main() {
 	if err := rootCmd.Execute(); err != nil {
-		glog.Exitf("Error executing mcd: %v", err)
+		log.Log.Error(err, "error executing sriov-network-config-daemon")
 	}
 }

--- a/cmd/sriov-network-config-daemon/service.go
+++ b/cmd/sriov-network-config-daemon/service.go
@@ -17,12 +17,11 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"os"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host"
@@ -32,6 +31,8 @@ import (
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/systemd"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/version"
+
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 )
 
 var (
@@ -48,23 +49,24 @@ func init() {
 }
 
 func runServiceCmd(cmd *cobra.Command, args []string) error {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
+	// init logger
+	snolog.InitLog()
+	setupLog := log.Log.WithName("sriov-config-service")
 
 	// To help debugging, immediately log version
-	glog.V(2).Infof("Version: %+v", version.Version)
+	setupLog.V(2).Info("sriov-config-service", "version", version.Version)
 
-	glog.V(0).Info("Starting sriov-config-service")
+	setupLog.V(0).Info("Starting sriov-config-service")
 	supportedNicIds, err := systemd.ReadSriovSupportedNics()
 	if err != nil {
-		glog.Errorf("failed to read list of supported nic ids")
+		setupLog.Error(err, "failed to read list of supported nic ids")
 		sriovResult := &systemd.SriovResult{
 			SyncStatus:    "Failed",
 			LastSyncError: fmt.Sprintf("failed to read list of supported nic ids: %v", err),
 		}
 		err = systemd.WriteSriovResult(sriovResult)
 		if err != nil {
-			glog.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
+			setupLog.Error(err, "failed to write sriov result file", "content", *sriovResult)
 			return fmt.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
 		}
 		return fmt.Errorf("sriov-config-service failed to read list of supported nic ids: %v", err)
@@ -74,14 +76,14 @@ func runServiceCmd(cmd *cobra.Command, args []string) error {
 	nodeStateSpec, err := systemd.ReadConfFile()
 	if err != nil {
 		if _, err := os.Stat(systemd.SriovSystemdConfigPath); !errors.Is(err, os.ErrNotExist) {
-			glog.Errorf("failed to read the sriov configuration file in path %s: %v", systemd.SriovSystemdConfigPath, err)
+			setupLog.Error(err, "failed to read the sriov configuration file", "path", systemd.SriovSystemdConfigPath)
 			sriovResult := &systemd.SriovResult{
 				SyncStatus:    "Failed",
 				LastSyncError: fmt.Sprintf("failed to read the sriov configuration file in path %s: %v", systemd.SriovSystemdConfigPath, err),
 			}
 			err = systemd.WriteSriovResult(sriovResult)
 			if err != nil {
-				glog.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
+				setupLog.Error(err, "failed to write sriov result file", "content", *sriovResult)
 				return fmt.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
 			}
 		}
@@ -93,18 +95,18 @@ func runServiceCmd(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	glog.V(2).Infof("sriov-config-service read config: %v", nodeStateSpec)
+	setupLog.V(2).Info("sriov-config-service", "config", nodeStateSpec)
 
 	storeManager, err := utils.NewStoreManager(true)
 	if err != nil {
-		glog.Errorf("failed to create store manager: %v", err)
+		setupLog.Error(err, "failed to create store manager")
 		return err
 	}
 	// Load kernel modules
 	hostManager := host.NewHostManager(true)
 	_, err = hostManager.TryEnableRdma()
 	if err != nil {
-		glog.Warningf("failed to enable RDMA: %v", err)
+		setupLog.Error(err, "warning, failed to enable RDMA")
 	}
 	hostManager.TryEnableTun()
 	hostManager.TryEnableVhostNet()
@@ -115,40 +117,40 @@ func runServiceCmd(cmd *cobra.Command, args []string) error {
 		// Bare metal support
 		ifaceStatuses, err = utils.DiscoverSriovDevices(nodeStateSpec.UnsupportedNics, storeManager)
 		if err != nil {
-			glog.Errorf("sriov-config-service: failed to discover sriov devices on the host: %v", err)
+			setupLog.Error(err, "failed to discover sriov devices on the host")
 			return fmt.Errorf("sriov-config-service: failed to discover sriov devices on the host:  %v", err)
 		}
 
 		// Create the generic plugin
 		configPlugin, err = generic.NewGenericPlugin(true, hostManager, storeManager)
 		if err != nil {
-			glog.Errorf("sriov-config-service: failed to create generic plugin %v", err)
+			setupLog.Error(err, "failed to create generic plugin")
 			return fmt.Errorf("sriov-config-service failed to create generic plugin %v", err)
 		}
 	} else if nodeStateSpec.PlatformType == utils.VirtualOpenStack {
 		// Openstack support
 		metaData, networkData, err := utils.GetOpenstackData(false)
 		if err != nil {
-			glog.Errorf("sriov-config-service: failed to read OpenStack data: %v", err)
+			setupLog.Error(err, "failed to read OpenStack data")
 			return fmt.Errorf("sriov-config-service failed to read OpenStack data: %v", err)
 		}
 
 		openStackDevicesInfo, err := utils.CreateOpenstackDevicesInfo(metaData, networkData)
 		if err != nil {
-			glog.Errorf("failed to read OpenStack data: %v", err)
+			setupLog.Error(err, "failed to read OpenStack data")
 			return fmt.Errorf("sriov-config-service failed to read OpenStack data: %v", err)
 		}
 
 		ifaceStatuses, err = utils.DiscoverSriovDevicesVirtual(openStackDevicesInfo)
 		if err != nil {
-			glog.Errorf("sriov-config-service:failed to read OpenStack data: %v", err)
+			setupLog.Error(err, "failed to read OpenStack data")
 			return fmt.Errorf("sriov-config-service: failed to read OpenStack data: %v", err)
 		}
 
 		// Create the virtual plugin
 		configPlugin, err = virtual.NewVirtualPlugin(true)
 		if err != nil {
-			glog.Errorf("sriov-config-service: failed to create virtual plugin %v", err)
+			setupLog.Error(err, "failed to create virtual plugin")
 			return fmt.Errorf("sriov-config-service: failed to create virtual plugin %v", err)
 		}
 	}
@@ -160,7 +162,7 @@ func runServiceCmd(cmd *cobra.Command, args []string) error {
 
 	_, _, err = configPlugin.OnNodeStateChange(nodeState)
 	if err != nil {
-		glog.Errorf("sriov-config-service: failed to run OnNodeStateChange to update the generic plugin status %v", err)
+		setupLog.Error(err, "failed to run OnNodeStateChange to update the generic plugin status")
 		return fmt.Errorf("sriov-config-service: failed to run OnNodeStateChange to update the generic plugin status %v", err)
 	}
 
@@ -171,17 +173,17 @@ func runServiceCmd(cmd *cobra.Command, args []string) error {
 
 	err = configPlugin.Apply()
 	if err != nil {
-		glog.Errorf("sriov-config-service failed to run apply node configuration %v", err)
+		setupLog.Error(err, "failed to run apply node configuration")
 		sriovResult.SyncStatus = "Failed"
 		sriovResult.LastSyncError = err.Error()
 	}
 
 	err = systemd.WriteSriovResult(sriovResult)
 	if err != nil {
-		glog.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
+		setupLog.Error(err, "failed to write sriov result file", "content", *sriovResult)
 		return fmt.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
 	}
 
-	glog.V(0).Info("Shutting down sriov-config-service")
+	setupLog.V(0).Info("shutting down sriov-config-service")
 	return nil
 }

--- a/cmd/sriov-network-config-daemon/version.go
+++ b/cmd/sriov-network-config-daemon/version.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -23,9 +22,6 @@ func init() {
 }
 
 func runVersionCmd(cmd *cobra.Command, args []string) {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-
 	program := "SriovNetworkConfigDaemon"
 	version := "v" + version.Version.String()
 

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -4,8 +4,10 @@ import (
 	"flag"
 	"os"
 
-	"github.com/golang/glog"
 	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 )
 
 const (
@@ -21,16 +23,13 @@ var (
 )
 
 func init() {
+	snolog.BindFlags(flag.CommandLine)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 }
 
 func main() {
-	flag.Set("logtostderr", "true")
-	flag.Parse()
-	glog.Info("Run sriov-network-operator-webhook")
-
 	if err := rootCmd.Execute(); err != nil {
-		glog.Exitf("Error executing sriov-network-operator-webhook: %v", err)
+		log.Log.Error(err, "Error executing sriov-network-operator-webhook")
 		os.Exit(1)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/coreos/go-systemd/v22 v22.4.0
 	github.com/fsnotify/fsnotify v1.6.0
-	github.com/golang/glog v1.0.0
 	github.com/golang/mock v1.4.4
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/go-retryablehttp v0.7.0
@@ -75,6 +74,7 @@ require (
 	github.com/go-openapi/swag v0.22.3 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/glog v1.0.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/btree v1.0.1 // indirect

--- a/main.go
+++ b/main.go
@@ -25,7 +25,6 @@ import (
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	openshiftconfigv1 "github.com/openshift/api/config/v1"
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
-	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/api/errors"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
@@ -41,12 +40,12 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/controllers"
 	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/leaderelection"
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 	//+kubebuilder:scaffold:imports
 )
@@ -76,13 +75,9 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	opts := zap.Options{
-		Development: true,
-		TimeEncoder: zapcore.RFC3339NanoTimeEncoder,
-	}
-	opts.BindFlags(flag.CommandLine)
+	snolog.BindFlags(flag.CommandLine)
 	flag.Parse()
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	snolog.InitLog()
 
 	restConfig := ctrl.GetConfigOrDie()
 

--- a/pkg/daemon/event_recorder.go
+++ b/pkg/daemon/event_recorder.go
@@ -3,14 +3,13 @@ package daemon
 import (
 	"context"
 
-	"github.com/golang/glog"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	typedv1core "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	snclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned"
 )
@@ -40,7 +39,7 @@ func NewEventRecorder(c snclientset.Interface, n string, kubeclient kubernetes.I
 func (e *EventRecorder) SendEvent(eventType string, msg string) {
 	nodeState, err := e.client.SriovnetworkV1().SriovNetworkNodeStates(namespace).Get(context.Background(), e.node, metav1.GetOptions{})
 	if err != nil {
-		glog.Warningf("SendEvent(): Failed to fetch node state %s (%v); skip SendEvent", e.node, err)
+		log.Log.V(2).Error(err, "SendEvent(): Failed to fetch node state, skip SendEvent", "name", e.node)
 		return
 	}
 	e.eventRecorder.Event(nodeState, corev1.EventTypeNormal, eventType, msg)

--- a/pkg/leaderelection/leaderelection.go
+++ b/pkg/leaderelection/leaderelection.go
@@ -3,9 +3,9 @@ package leaderelection
 import (
 	"time"
 
-	"github.com/golang/glog"
 	"k8s.io/client-go/tools/leaderelection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 )
@@ -29,7 +29,7 @@ func GetLeaderElectionConfig(c client.Client, enabled bool) (defaultConfig leade
 	if enabled {
 		isSingleNode, err := utils.IsSingleNodeCluster(c)
 		if err != nil {
-			glog.Warningf("unable to get cluster infrastructure status, using HA cluster values for leader election: %v", err)
+			log.Log.Error(err, "warning, unable to get cluster infrastructure status, using HA cluster values for leader election")
 			return
 		}
 		if isSingleNode {

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2023.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package log
+
+import (
+	"flag"
+
+	zzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// Options stores controller-runtime (zap) log config
+var Options = &zap.Options{
+	Development: true,
+	// we dont log with panic level, so this essentially
+	// disables stacktrace, for now, it avoids un-needed clutter in logs
+	StacktraceLevel: zapcore.DPanicLevel,
+	TimeEncoder:     zapcore.RFC3339NanoTimeEncoder,
+	Level:           zzap.NewAtomicLevelAt(zapcore.InfoLevel),
+	// log caller (file and line number) in "caller" key
+	EncoderConfigOptions: []zap.EncoderConfigOption{func(ec *zapcore.EncoderConfig) { ec.CallerKey = "caller" }},
+	ZapOpts:              []zzap.Option{zzap.AddCaller(), zzap.AddCallerSkip(1)},
+}
+
+// BindFlags binds controller-runtime logging flags to provided flag Set
+func BindFlags(fs *flag.FlagSet) {
+	Options.BindFlags(fs)
+}
+
+// InitLog initializes controller-runtime log (zap log)
+// this should be called once Options have been initialized
+// either by parsing flags or directly modifying Options.
+func InitLog() {
+	log.SetLogger(zap.New(zap.UseFlagOptions(Options)))
+}
+
+// SetLogLevel sets log level
+func SetLogLevel(lvl int8) {
+	Options.Level.(zzap.AtomicLevel).SetLevel(zapcore.Level(lvl))
+}

--- a/pkg/plugins/intel/intel_plugin.go
+++ b/pkg/plugins/intel/intel_plugin.go
@@ -1,7 +1,7 @@
 package intel
 
 import (
-	"github.com/golang/glog"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	plugin "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins"
@@ -35,12 +35,12 @@ func (p *IntelPlugin) Spec() string {
 
 // OnNodeStateChange Invoked when SriovNetworkNodeState CR is created or updated, return if need dain and/or reboot node
 func (p *IntelPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeState) (needDrain bool, needReboot bool, err error) {
-	glog.Info("intel-plugin OnNodeStateChange()")
+	log.Log.Info("intel-plugin OnNodeStateChange()")
 	return false, false, nil
 }
 
 // Apply config change
 func (p *IntelPlugin) Apply() error {
-	glog.Info("intel-plugin Apply()")
+	log.Log.Info("intel-plugin Apply()")
 	return nil
 }

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/golang/glog"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
@@ -63,7 +63,7 @@ func (p *MellanoxPlugin) Spec() string {
 
 // OnNodeStateChange Invoked when SriovNetworkNodeState CR is created or updated, return if need dain and/or reboot node
 func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeState) (needDrain bool, needReboot bool, err error) {
-	glog.Info("mellanox-Plugin OnNodeStateChange()")
+	log.Log.Info("mellanox-Plugin OnNodeStateChange()")
 
 	needDrain = false
 	needReboot = false
@@ -99,10 +99,10 @@ func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeS
 
 	if utils.IsKernelLockdownMode(false) {
 		if len(mellanoxNicsSpec) > 0 {
-			glog.Info("Lockdown mode detected, failing on interface update for mellanox devices")
+			log.Log.Info("Lockdown mode detected, failing on interface update for mellanox devices")
 			return false, false, fmt.Errorf("mellanox device detected when in lockdown mode")
 		}
-		glog.Info("Lockdown mode detected, skpping mellanox nic processing")
+		log.Log.Info("Lockdown mode detected, skpping mellanox nic processing")
 		return
 	}
 
@@ -131,7 +131,9 @@ func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeS
 
 		// failing as we can't the fwTotalVf is lower than the request one on a nic with externallyManage configured
 		if ifaceSpec.ExternallyManaged && needReboot {
-			return true, true, fmt.Errorf("interface %s required a change in the TotalVfs but the policy is externally managed failing: firmware TotalVf %d requested TotalVf %d", ifaceSpec.PciAddress, fwCurrent.totalVfs, totalVfs)
+			return true, true, fmt.Errorf(
+				"interface %s required a change in the TotalVfs but the policy is externally managed failing: firmware TotalVf %d requested TotalVf %d",
+				ifaceSpec.PciAddress, fwCurrent.totalVfs, totalVfs)
 		}
 
 		needLinkChange, err := handleLinkType(pciPrefix, fwCurrent, attrs)
@@ -167,29 +169,29 @@ func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeS
 
 		if fwNext.totalVfs > 0 || fwNext.enableSriov {
 			attributesToChange[pciAddress] = mlnxNic{totalVfs: 0}
-			glog.V(2).Infof("Changing TotalVfs %d to 0, doesn't require rebooting", fwNext.totalVfs)
+			log.Log.V(2).Info("Changing TotalVfs to 0, doesn't require rebooting", "fwNext.totalVfs", fwNext.totalVfs)
 		}
 	}
 
 	if needReboot {
 		needDrain = true
 	}
-	glog.V(2).Infof("mellanox-plugin needDrain %v needReboot %v", needDrain, needReboot)
+	log.Log.V(2).Info("mellanox-plugin", "need-drain", needDrain, "need-reboot", needReboot)
 	return
 }
 
 // Apply config change
 func (p *MellanoxPlugin) Apply() error {
 	if utils.IsKernelLockdownMode(false) {
-		glog.Info("mellanox-plugin Apply() - skipping due to lockdown mode")
+		log.Log.Info("mellanox-plugin Apply() - skipping due to lockdown mode")
 		return nil
 	}
-	glog.Info("mellanox-plugin Apply()")
+	log.Log.Info("mellanox-plugin Apply()")
 	return configFW()
 }
 
 func configFW() error {
-	glog.Info("mellanox-plugin configFW()")
+	log.Log.Info("mellanox-plugin configFW()")
 	for pciAddr, fwArgs := range attributesToChange {
 		cmdArgs := []string{"-d", pciAddr, "-y", "set"}
 		if fwArgs.enableSriov {
@@ -207,13 +209,13 @@ func configFW() error {
 			cmdArgs = append(cmdArgs, fmt.Sprintf("%s=%s", LinkTypeP2, fwArgs.linkTypeP2))
 		}
 
-		glog.V(2).Infof("mellanox-plugin: configFW(): %v", cmdArgs)
+		log.Log.V(2).Info("mellanox-plugin: configFW()", "cmd-args", cmdArgs)
 		if len(cmdArgs) <= 4 {
 			continue
 		}
 		_, err := utils.RunCommand("mstconfig", cmdArgs...)
 		if err != nil {
-			glog.Errorf("mellanox-plugin configFW(): failed : %v", err)
+			log.Log.Error(err, "mellanox-plugin configFW(): failed")
 			return err
 		}
 	}
@@ -221,30 +223,30 @@ func configFW() error {
 }
 
 func getMlnxNicFwData(pciAddress string) (current, next *mlnxNic, err error) {
-	glog.Infof("mellanox-plugin getMlnxNicFwData(): device %s", pciAddress)
+	log.Log.Info("mellanox-plugin getMlnxNicFwData()", "device", pciAddress)
 	err = nil
 	attrs := []string{TotalVfs, EnableSriov, LinkTypeP1, LinkTypeP2}
 
 	out, err := utils.MstConfigReadData(pciAddress)
 	if err != nil {
-		glog.Errorf("mellanox-plugin getMlnxNicFwData(): failed %v", err)
+		log.Log.Error(err, "mellanox-plugin getMlnxNicFwData(): failed", err)
 		return
 	}
 	mstCurrentData, mstNextData := utils.ParseMstconfigOutput(out, attrs)
 	current, err = mlnxNicFromMap(mstCurrentData)
 	if err != nil {
-		glog.Errorf("mellanox-plugin getMlnxNicFwData(): %v", err)
+		log.Log.Error(err, "mellanox-plugin mlnxNicFromMap() for current mstconfig data failed")
 		return
 	}
 	next, err = mlnxNicFromMap(mstNextData)
 	if err != nil {
-		glog.Errorf("mellanox-plugin getMlnxNicFwData(): %v", err)
+		log.Log.Error(err, "mellanox-plugin mlnxNicFromMap() for next mstconfig data failed")
 	}
 	return
 }
 
 func mlnxNicFromMap(mstData map[string]string) (*mlnxNic, error) {
-	glog.Infof("mellanox-plugin mlnxNicFromMap() %v", mstData)
+	log.Log.Info("mellanox-plugin mlnxNicFromMap()", "data", mstData)
 	fwData := &mlnxNic{}
 	if strings.Contains(mstData[EnableSriov], "True") {
 		fwData.enableSriov = true
@@ -268,28 +270,29 @@ func getPciAddressPrefix(pciAddress string) string {
 }
 
 func isDualPort(pciAddress string) bool {
-	glog.Infof("mellanox-plugin isDualPort(): pciAddress %s", pciAddress)
+	log.Log.Info("mellanox-plugin isDualPort()", "address", pciAddress)
 	pciAddressPrefix := getPciAddressPrefix(pciAddress)
 	return len(mellanoxNicsStatus[pciAddressPrefix]) > 1
 }
 
 func getLinkType(linkType string) string {
-	glog.Infof("mellanox-plugin getLinkType(): linkType %s", linkType)
+	log.Log.Info("mellanox-plugin getLinkType()", "link-type", linkType)
 	if strings.Contains(linkType, constants.LinkTypeETH) {
 		return constants.LinkTypeETH
 	} else if strings.Contains(linkType, constants.LinkTypeIB) {
 		return constants.LinkTypeIB
 	} else if len(linkType) > 0 {
-		glog.Warningf("mellanox-plugin getLinkType(): link type %s is not one of [ETH, IB]", linkType)
+		log.Log.Error(nil, "mellanox-plugin getLinkType(): link type is not one of [ETH, IB], treating as unknown",
+			"link-type", linkType)
 		return UknownLinkType
 	} else {
-		glog.Warning("mellanox-plugin getLinkType(): LINK_TYPE_P* attribute was not found")
+		log.Log.Info("mellanox-plugin getLinkType(): LINK_TYPE_P* attribute was not found, treating as preconfigured link type")
 		return PreconfiguredLinkType
 	}
 }
 
 func isLinkTypeRequireChange(iface sriovnetworkv1.Interface, ifaceStatus sriovnetworkv1.InterfaceExt, fwLinkType string) (bool, error) {
-	glog.Infof("mellanox-plugin isLinkTypeRequireChange(): device %s", iface.PciAddress)
+	log.Log.Info("mellanox-plugin isLinkTypeRequireChange()", "device", iface.PciAddress)
 	if iface.LinkType != "" && !strings.EqualFold(ifaceStatus.LinkType, iface.LinkType) {
 		if !strings.EqualFold(iface.LinkType, constants.LinkTypeETH) && !strings.EqualFold(iface.LinkType, constants.LinkTypeIB) {
 			return false, fmt.Errorf("mellanox-plugin OnNodeStateChange(): Not supported link type: %s,"+
@@ -309,7 +312,7 @@ func isLinkTypeRequireChange(iface sriovnetworkv1.Interface, ifaceStatus sriovne
 }
 
 func getOtherPortSpec(pciAddress string) *sriovnetworkv1.Interface {
-	glog.Infof("mellanox-plugin getOtherPortSpec(): pciAddress %s", pciAddress)
+	log.Log.Info("mellanox-plugin getOtherPortSpec()", "pciAddress", pciAddress)
 	pciAddrPrefix := getPciAddressPrefix(pciAddress)
 	pciAddrSuffix := pciAddress[len(pciAddrPrefix):]
 
@@ -340,7 +343,8 @@ func handleTotalVfs(fwCurrent, fwNext, attrs *mlnxNic, ifaceSpec sriovnetworkv1.
 	// the configured amount
 	if ifaceSpec.ExternallyManaged {
 		if totalVfs > fwCurrent.totalVfs {
-			glog.Errorf("The nic is externallyManaged and TotalVfs %d configured on the system is lower then requested %d, failing configuration", fwCurrent.totalVfs, totalVfs)
+			log.Log.Error(nil, "The nic is externallyManaged and TotalVfs configured on the system is lower then requested VFs, failing configuration",
+				"current", fwCurrent.totalVfs, "requested", totalVfs)
 			attrs.totalVfs = totalVfs
 			needReboot = true
 			changeWithoutReboot = false
@@ -349,14 +353,15 @@ func handleTotalVfs(fwCurrent, fwNext, attrs *mlnxNic, ifaceSpec sriovnetworkv1.
 	}
 
 	if fwCurrent.totalVfs != totalVfs {
-		glog.V(2).Infof("Changing TotalVfs %d to %d, needs reboot", fwCurrent.totalVfs, totalVfs)
+		log.Log.V(2).Info("Changing TotalVfs, needs reboot", "current", fwCurrent.totalVfs, "requested", totalVfs)
 		attrs.totalVfs = totalVfs
 		needReboot = true
 	}
 
 	// Remove policy then re-apply it
 	if !needReboot && fwNext.totalVfs != totalVfs {
-		glog.V(2).Infof("Changing TotalVfs %d to same as Next Boot value, doesn't require rebooting", fwCurrent.totalVfs)
+		log.Log.V(2).Info("Changing TotalVfs to same as Next Boot value, doesn't require rebooting",
+			"current", fwCurrent.totalVfs, "next", fwNext.totalVfs, "requested", totalVfs)
 		attrs.totalVfs = totalVfs
 		changeWithoutReboot = true
 	}
@@ -368,11 +373,11 @@ func handleTotalVfs(fwCurrent, fwNext, attrs *mlnxNic, ifaceSpec sriovnetworkv1.
 // and need reboot if enableSriov will change
 func handleEnableSriov(totalVfs int, fwCurrent, fwNext, attrs *mlnxNic) (needReboot, changeWithoutReboot bool) {
 	if totalVfs == 0 && fwCurrent.enableSriov {
-		glog.V(2).Info("disabling Sriov, needs reboot")
+		log.Log.V(2).Info("disabling Sriov, needs reboot")
 		attrs.enableSriov = false
 		return true, false
 	} else if totalVfs > 0 && !fwCurrent.enableSriov {
-		glog.V(2).Info("enabling Sriov, needs reboot")
+		log.Log.V(2).Info("enabling Sriov, needs reboot")
 		attrs.enableSriov = true
 		return true, false
 	} else if totalVfs > 0 && !fwNext.enableSriov {
@@ -400,7 +405,8 @@ func handleLinkType(pciPrefix string, fwData, attr *mlnxNic) (bool, error) {
 		}
 
 		if needChange {
-			glog.V(2).Infof("Changing LinkTypeP1 %s to %s, needs reboot", fwData.linkTypeP1, firstPortSpec.LinkType)
+			log.Log.V(2).Info("Changing LinkTypeP1, needs reboot",
+				"from", fwData.linkTypeP1, "to", firstPortSpec.LinkType)
 			attr.linkTypeP1 = firstPortSpec.LinkType
 			needReboot = true
 		}
@@ -415,7 +421,8 @@ func handleLinkType(pciPrefix string, fwData, attr *mlnxNic) (bool, error) {
 		}
 
 		if needChange {
-			glog.V(2).Infof("Changing LinkTypeP2 %s to %s, needs reboot", fwData.linkTypeP2, secondPortSpec.LinkType)
+			log.Log.V(2).Info("Changing LinkTypeP2, needs reboot",
+				"from", fwData.linkTypeP2, "to", secondPortSpec.LinkType)
 			attr.linkTypeP2 = secondPortSpec.LinkType
 			needReboot = true
 		}

--- a/pkg/service/utils.go
+++ b/pkg/service/utils.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 
 	"github.com/coreos/go-systemd/v22/unit"
-	"github.com/golang/glog"
 	"gopkg.in/yaml.v2"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const systemdDir = "/usr/lib/systemd/system/"
@@ -30,7 +30,7 @@ OUTER:
 				continue OUTER
 			}
 		}
-		glog.Infof("DEBUG: %+v %v", optsA, *optB)
+		log.Log.V(2).Info("CompareServices", "ServiceA", optsA, "ServiceB", *optB)
 		return true, nil
 	}
 

--- a/pkg/systemd/systemd.go
+++ b/pkg/systemd/systemd.go
@@ -21,8 +21,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/golang/glog"
 	"gopkg.in/yaml.v3"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
@@ -85,15 +85,17 @@ func WriteConfFile(newState *sriovnetworkv1.SriovNetworkNodeState, unsupportedNi
 			if _, err := os.Stat(HostSriovConfBasePath); os.IsNotExist(err) {
 				err = os.Mkdir(HostSriovConfBasePath, os.ModeDir)
 				if err != nil {
-					glog.Errorf("WriteConfFile(): fail to create sriov-operator folder: %v", err)
+					log.Log.Error(err, "WriteConfFile(): fail to create sriov-operator folder",
+						"path", HostSriovConfBasePath)
 					return false, err
 				}
 			}
 
-			glog.V(2).Infof("WriteConfFile(): file not existed, create it")
+			log.Log.V(2).Info("WriteConfFile(): file not existed, create it",
+				"path", SriovHostSystemdConfigPath)
 			_, err = os.Create(SriovHostSystemdConfigPath)
 			if err != nil {
-				glog.Errorf("WriteConfFile(): fail to create file: %v", err)
+				log.Log.Error(err, "WriteConfFile(): fail to create file")
 				return false, err
 			}
 			newFile = true
@@ -104,41 +106,43 @@ func WriteConfFile(newState *sriovnetworkv1.SriovNetworkNodeState, unsupportedNi
 
 	oldContent, err := os.ReadFile(SriovHostSystemdConfigPath)
 	if err != nil {
-		glog.Errorf("WriteConfFile(): fail to read file: %v", err)
+		log.Log.Error(err, "WriteConfFile(): fail to read file", "path", SriovHostSystemdConfigPath)
 		return false, err
 	}
 
 	oldContentObj := &SriovConfig{}
 	err = yaml.Unmarshal(oldContent, oldContentObj)
 	if err != nil {
-		glog.Errorf("WriteConfFile(): fail to unmarshal old file: %v", err)
+		log.Log.Error(err, "WriteConfFile(): fail to unmarshal old file")
 		return false, err
 	}
 
 	var newContent []byte
 	newContent, err = yaml.Marshal(sriovConfig)
 	if err != nil {
-		glog.Errorf("WriteConfFile(): fail to marshal config: %v", err)
+		log.Log.Error(err, "WriteConfFile(): fail to marshal sriov config")
 		return false, err
 	}
 
 	if bytes.Equal(newContent, oldContent) {
-		glog.V(2).Info("WriteConfFile(): no update")
+		log.Log.V(2).Info("WriteConfFile(): no update")
 		return false, nil
 	}
-	glog.V(2).Infof("WriteConfFile(): previews configuration is not equal: old config:\n%s\nnew config:\n%s\n", string(oldContent), string(newContent))
+	log.Log.V(2).Info("WriteConfFile(): old and new configuration are not equal",
+		"old", string(oldContent), "new", string(newContent))
 
-	glog.V(2).Infof("WriteConfFile(): write '%s' to %s", newContent, SriovHostSystemdConfigPath)
+	log.Log.V(2).Info("WriteConfFile(): write content to file",
+		"content", newContent, "path", SriovHostSystemdConfigPath)
 	err = os.WriteFile(SriovHostSystemdConfigPath, newContent, 0644)
 	if err != nil {
-		glog.Errorf("WriteConfFile(): fail to write file: %v", err)
+		log.Log.Error(err, "WriteConfFile(): fail to write file")
 		return false, err
 	}
 
 	// this will be used to mark the first time we create this file.
 	// this helps to avoid the first reboot after installation
 	if newFile && len(sriovConfig.Spec.Interfaces) == 0 {
-		glog.V(2).Info("WriteConfFile(): first file creation and no interfaces to configure returning reboot false")
+		log.Log.V(2).Info("WriteConfFile(): first file creation and no interfaces to configure returning reboot false")
 		return false, nil
 	}
 
@@ -149,28 +153,29 @@ func WriteSriovResult(result *SriovResult) error {
 	_, err := os.Stat(SriovSystemdResultPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			glog.V(2).Infof("WriteSriovResult(): file not existed, create it")
+			log.Log.V(2).Info("WriteSriovResult(): file not existed, create it")
 			_, err = os.Create(SriovSystemdResultPath)
 			if err != nil {
-				glog.Errorf("WriteSriovResult(): failed to create sriov result file on path %s: %v", SriovSystemdResultPath, err)
+				log.Log.Error(err, "WriteSriovResult(): failed to create sriov result file", "path", SriovSystemdResultPath)
 				return err
 			}
 		} else {
-			glog.Errorf("WriteSriovResult(): failed to check sriov result file on path %s: %v", SriovSystemdResultPath, err)
+			log.Log.Error(err, "WriteSriovResult(): failed to check sriov result file", "path", SriovSystemdResultPath)
 			return err
 		}
 	}
 
 	out, err := yaml.Marshal(result)
 	if err != nil {
-		glog.Errorf("WriteSriovResult(): failed to marshal sriov result file: %v", err)
+		log.Log.Error(err, "WriteSriovResult(): failed to marshal sriov result", err)
 		return err
 	}
 
-	glog.V(2).Infof("WriteSriovResult(): write '%s' to %s", string(out), SriovSystemdResultPath)
+	log.Log.V(2).Info("WriteSriovResult(): write results",
+		"content", string(out), "path", SriovSystemdResultPath)
 	err = os.WriteFile(SriovSystemdResultPath, out, 0644)
 	if err != nil {
-		glog.Errorf("WriteSriovResult(): failed to write sriov result file on path %s: %v", SriovSystemdResultPath, err)
+		log.Log.Error(err, "WriteSriovResult(): failed to write sriov result file", "path", SriovSystemdResultPath)
 		return err
 	}
 
@@ -181,24 +186,24 @@ func ReadSriovResult() (*SriovResult, error) {
 	_, err := os.Stat(SriovHostSystemdResultPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			glog.V(2).Infof("ReadSriovResult(): file not existed, return empty result")
+			log.Log.V(2).Info("ReadSriovResult(): file does not exist, return empty result")
 			return &SriovResult{}, nil
 		} else {
-			glog.Errorf("ReadSriovResult(): failed to check sriov result file on path %s: %v", SriovHostSystemdResultPath, err)
+			log.Log.Error(err, "ReadSriovResult(): failed to check sriov result file", "path", SriovHostSystemdResultPath)
 			return nil, err
 		}
 	}
 
 	rawConfig, err := os.ReadFile(SriovHostSystemdResultPath)
 	if err != nil {
-		glog.Errorf("ReadSriovResult(): failed to read sriov result file on path %s: %v", SriovHostSystemdResultPath, err)
+		log.Log.Error(err, "ReadSriovResult(): failed to read sriov result file", "path", SriovHostSystemdResultPath)
 		return nil, err
 	}
 
 	result := &SriovResult{}
 	err = yaml.Unmarshal(rawConfig, &result)
 	if err != nil {
-		glog.Errorf("ReadSriovResult(): failed to unmarshal sriov result file on path %s: %v", SriovHostSystemdResultPath, err)
+		log.Log.Error(err, "ReadSriovResult(): failed to unmarshal sriov result file", "path", SriovHostSystemdResultPath)
 		return nil, err
 	}
 	return result, err
@@ -208,14 +213,15 @@ func WriteSriovSupportedNics() error {
 	_, err := os.Stat(sriovHostSystemdSupportedNicPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			glog.V(2).Infof("WriteSriovSupportedNics(): file not existed, create it")
+			log.Log.V(2).Info("WriteSriovSupportedNics(): file does not exist, create it")
 			_, err = os.Create(sriovHostSystemdSupportedNicPath)
 			if err != nil {
-				glog.Errorf("WriteSriovSupportedNics(): failed to create sriov supporter nics ids file on path %s: %v", sriovHostSystemdSupportedNicPath, err)
+				log.Log.Error(err, "WriteSriovSupportedNics(): failed to create sriov supporter nics ids file",
+					"path", sriovHostSystemdSupportedNicPath)
 				return err
 			}
 		} else {
-			glog.Errorf("WriteSriovSupportedNics(): failed to check sriov supporter nics ids file on path %s: %v", sriovHostSystemdSupportedNicPath, err)
+			log.Log.Error(err, "WriteSriovSupportedNics(): failed to check sriov supported nics ids file", "path", sriovHostSystemdSupportedNicPath)
 			return err
 		}
 	}
@@ -227,7 +233,8 @@ func WriteSriovSupportedNics() error {
 
 	err = os.WriteFile(sriovHostSystemdSupportedNicPath, rawNicList, 0644)
 	if err != nil {
-		glog.Errorf("WriteSriovSupportedNics(): failed to write sriov supporter nics ids file on path %s: %v", sriovHostSystemdSupportedNicPath, err)
+		log.Log.Error(err, "WriteSriovSupportedNics(): failed to write sriov supported nics ids file",
+			"path", sriovHostSystemdSupportedNicPath)
 		return err
 	}
 
@@ -238,17 +245,17 @@ func ReadSriovSupportedNics() ([]string, error) {
 	_, err := os.Stat(sriovSystemdSupportedNicPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			glog.V(2).Infof("ReadSriovSupportedNics(): file not existed, return empty result")
+			log.Log.V(2).Info("ReadSriovSupportedNics(): file does not exist, return empty result")
 			return nil, err
 		} else {
-			glog.Errorf("ReadSriovSupportedNics(): failed to check sriov supporter nics file on path %s: %v", sriovSystemdSupportedNicPath, err)
+			log.Log.Error(err, "ReadSriovSupportedNics(): failed to check sriov supported nics file", "path", sriovSystemdSupportedNicPath)
 			return nil, err
 		}
 	}
 
 	rawConfig, err := os.ReadFile(sriovSystemdSupportedNicPath)
 	if err != nil {
-		glog.Errorf("ReadSriovSupportedNics(): failed to read sriov supporter nics file on path %s: %v", sriovSystemdSupportedNicPath, err)
+		log.Log.Error(err, "ReadSriovSupportedNics(): failed to read sriov supported nics file", "path", sriovSystemdSupportedNicPath)
 		return nil, err
 	}
 

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/golang/glog"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -77,12 +77,12 @@ func k8sSingleNodeClusterStatus(c client.Client) (bool, error) {
 	nodeList := &corev1.NodeList{}
 	err := c.List(context.TODO(), nodeList)
 	if err != nil {
-		glog.Errorf("k8sSingleNodeClusterStatus(): Failed to list nodes: %v", err)
+		log.Log.Error(err, "k8sSingleNodeClusterStatus(): Failed to list nodes")
 		return false, err
 	}
 
 	if len(nodeList.Items) == 1 {
-		glog.Infof("k8sSingleNodeClusterStatus(): one node found in the cluster")
+		log.Log.Info("k8sSingleNodeClusterStatus(): one node found in the cluster")
 		return true, nil
 	}
 	return false, nil
@@ -93,7 +93,7 @@ func operatorNodeRole(c client.Client) (string, error) {
 	node := corev1.Node{}
 	err := c.Get(context.TODO(), types.NamespacedName{Name: os.Getenv("NODE_NAME")}, &node)
 	if err != nil {
-		glog.Errorf("k8sIsExternalTopologyMode(): Failed to get node: %v", err)
+		log.Log.Error(err, "k8sIsExternalTopologyMode(): Failed to get node")
 		return "", err
 	}
 
@@ -105,9 +105,6 @@ func openshiftControlPlaneTopologyStatus(c client.Client) (configv1.TopologyMode
 	err := c.Get(context.TODO(), types.NamespacedName{Name: infraResourceName}, infra)
 	if err != nil {
 		return "", fmt.Errorf("openshiftControlPlaneTopologyStatus(): Failed to get Infrastructure (name: %s): %v", infraResourceName, err)
-	}
-	if infra == nil {
-		return "", fmt.Errorf("openshiftControlPlaneTopologyStatus(): getting resource Infrastructure (name: %s) succeeded but object was nil", infraResourceName)
 	}
 	return infra.Status.ControlPlaneTopology, nil
 }

--- a/pkg/utils/driver.go
+++ b/pkg/utils/driver.go
@@ -5,9 +5,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/golang/glog"
-
 	dputils "github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/utils"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 )
@@ -16,7 +15,7 @@ var DpdkDrivers = []string{"igb_uio", "vfio-pci", "uio_pci_generic"}
 
 // Unbind unbind driver for one device
 func Unbind(pciAddr string) error {
-	glog.V(2).Infof("Unbind(): unbind device %s driver", pciAddr)
+	log.Log.V(2).Info("Unbind(): unbind device driver for device", "device", pciAddr)
 	yes, driver := hasDriver(pciAddr)
 	if !yes {
 		return nil
@@ -25,7 +24,7 @@ func Unbind(pciAddr string) error {
 	filePath := filepath.Join(sysBusPciDrivers, driver, "unbind")
 	err := os.WriteFile(filePath, []byte(pciAddr), os.ModeAppend)
 	if err != nil {
-		glog.Errorf("Unbind(): fail to unbind driver for device %s. %s", pciAddr, err)
+		log.Log.Error(err, "Unbind(): fail to unbind driver for device", "device", pciAddr)
 		return err
 	}
 	return nil
@@ -34,11 +33,13 @@ func Unbind(pciAddr string) error {
 // BindDpdkDriver bind dpdk driver for one device
 // Bind the device given by "pciAddr" to the driver "driver"
 func BindDpdkDriver(pciAddr, driver string) error {
-	glog.V(2).Infof("BindDpdkDriver(): bind device %s to driver %s", pciAddr, driver)
+	log.Log.V(2).Info("BindDpdkDriver(): bind device to driver",
+		"device", pciAddr, "driver", driver)
 
 	if yes, d := hasDriver(pciAddr); yes {
 		if driver == d {
-			glog.V(2).Infof("BindDpdkDriver(): device %s already bound to driver %s", pciAddr, driver)
+			log.Log.V(2).Info("BindDpdkDriver(): device already bound to driver",
+				"device", pciAddr, "driver", driver)
 			return nil
 		}
 
@@ -50,23 +51,26 @@ func BindDpdkDriver(pciAddr, driver string) error {
 	driverOverridePath := filepath.Join(sysBusPciDevices, pciAddr, "driver_override")
 	err := os.WriteFile(driverOverridePath, []byte(driver), os.ModeAppend)
 	if err != nil {
-		glog.Errorf("BindDpdkDriver(): fail to write driver_override for device %s %s", driver, err)
+		log.Log.Error(err, "BindDpdkDriver(): fail to write driver_override for device",
+			"device", pciAddr, "driver", driver)
 		return err
 	}
 	bindPath := filepath.Join(sysBusPciDrivers, driver, "bind")
 	err = os.WriteFile(bindPath, []byte(pciAddr), os.ModeAppend)
 	if err != nil {
-		glog.Errorf("BindDpdkDriver(): fail to bind driver for device %s: %s", pciAddr, err)
+		log.Log.Error(err, "BindDpdkDriver(): fail to bind driver for device",
+			"driver", driver, "device", pciAddr)
 		_, err := os.Readlink(filepath.Join(sysBusPciDevices, pciAddr, "iommu_group"))
 		if err != nil {
-			glog.Errorf("Could not read IOMMU group for device %s: %s", pciAddr, err)
-			return fmt.Errorf("cannot bind driver %s to %s, make sure IOMMU is enabled in BIOS", driver, pciAddr)
+			log.Log.Error(err, "Could not read IOMMU group for device", "device", pciAddr)
+			return fmt.Errorf(
+				"cannot bind driver %s to device %s, make sure IOMMU is enabled in BIOS. %w", driver, pciAddr, err)
 		}
 		return err
 	}
 	err = os.WriteFile(driverOverridePath, []byte(""), os.ModeAppend)
 	if err != nil {
-		glog.Errorf("BindDpdkDriver(): fail to clear driver_override for device %s: %s", pciAddr, err)
+		log.Log.Error(err, "BindDpdkDriver(): failed to clear driver_override for device", "device", pciAddr)
 		return err
 	}
 
@@ -76,11 +80,12 @@ func BindDpdkDriver(pciAddr, driver string) error {
 // BindDefaultDriver bind driver for one device
 // Bind the device given by "pciAddr" to the default driver
 func BindDefaultDriver(pciAddr string) error {
-	glog.V(2).Infof("BindDefaultDriver(): bind device %s to default driver", pciAddr)
+	log.Log.V(2).Info("BindDefaultDriver(): bind device to default driver", "device", pciAddr)
 
 	if yes, d := hasDriver(pciAddr); yes {
 		if !sriovnetworkv1.StringInArray(d, DpdkDrivers) {
-			glog.V(2).Infof("BindDefaultDriver(): device %s already bound to default driver %s", pciAddr, d)
+			log.Log.V(2).Info("BindDefaultDriver(): device already bound to default driver",
+				"device", pciAddr, "driver", d)
 			return nil
 		}
 		if err := Unbind(pciAddr); err != nil {
@@ -91,12 +96,12 @@ func BindDefaultDriver(pciAddr string) error {
 	driverOverridePath := filepath.Join(sysBusPciDevices, pciAddr, "driver_override")
 	err := os.WriteFile(driverOverridePath, []byte("\x00"), os.ModeAppend)
 	if err != nil {
-		glog.Errorf("BindDefaultDriver(): fail to write driver_override for device %s: %s", pciAddr, err)
+		log.Log.Error(err, "BindDefaultDriver(): failed to write driver_override for device", "device", pciAddr)
 		return err
 	}
 	err = os.WriteFile(sysBusPciDriversProbe, []byte(pciAddr), os.ModeAppend)
 	if err != nil {
-		glog.Errorf("BindDefaultDriver(): fail to bind driver for device %s: %s", pciAddr, err)
+		log.Log.Error(err, "BindDefaultDriver(): failed to bind driver for device", "device", pciAddr)
 		return err
 	}
 
@@ -106,9 +111,9 @@ func BindDefaultDriver(pciAddr string) error {
 func hasDriver(pciAddr string) (bool, string) {
 	driver, err := dputils.GetDriverName(pciAddr)
 	if err != nil {
-		glog.V(2).Infof("hasDriver(): device %s driver is empty", pciAddr)
+		log.Log.V(2).Info("hasDriver(): device driver is empty for device", "device", pciAddr)
 		return false, ""
 	}
-	glog.V(2).Infof("hasDriver(): device %s driver is %s", pciAddr, driver)
+	log.Log.V(2).Info("hasDriver(): device driver for device", "device", pciAddr, "driver", driver)
 	return true, driver
 }

--- a/pkg/utils/store.go
+++ b/pkg/utils/store.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/golang/glog"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 )
@@ -103,7 +103,7 @@ func (s *StoreManager) ClearPCIAddressFolder() error {
 func (s *StoreManager) SaveLastPfAppliedStatus(PfInfo *sriovnetworkv1.Interface) error {
 	data, err := json.Marshal(PfInfo)
 	if err != nil {
-		glog.Errorf("failed to marshal PF status %+v: %v", *PfInfo, err)
+		log.Log.Error(err, "failed to marshal PF status", "status", *PfInfo)
 		return err
 	}
 
@@ -124,13 +124,13 @@ func (s *StoreManager) LoadPfsStatus(pciAddress string) (*sriovnetworkv1.Interfa
 		if os.IsNotExist(err) {
 			return nil, false, nil
 		}
-		glog.Errorf("failed to read PF status from path %s: %v", pathFile, err)
+		log.Log.Error(err, "failed to read PF status", "path", pathFile)
 		return nil, false, err
 	}
 
 	err = json.Unmarshal(data, pfStatus)
 	if err != nil {
-		glog.Errorf("failed to unmarshal PF status %s: %v", data, err)
+		log.Log.Error(err, "failed to unmarshal PF status", "data", string(data))
 		return nil, false, err
 	}
 

--- a/pkg/webhook/client.go
+++ b/pkg/webhook/client.go
@@ -3,10 +3,10 @@ package webhook
 import (
 	"os"
 
-	"github.com/golang/glog"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	snclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned"
 )
@@ -27,7 +27,7 @@ func SetupInClusterClient() error {
 	}
 
 	if err != nil {
-		glog.Error("fail to setup client")
+		log.Log.Error(nil, "fail to setup client")
 		return err
 	}
 

--- a/pkg/webhook/config.go
+++ b/pkg/webhook/config.go
@@ -4,7 +4,7 @@ import (
 	"crypto/tls"
 	"sync"
 
-	"github.com/golang/glog"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Config contains the server (the webhook) cert and key.
@@ -25,7 +25,7 @@ func (keyPair *tlsKeypairReloader) Reload() error {
 	if err != nil {
 		return err
 	}
-	glog.Infof("cetificate reloaded")
+	log.Log.Info("cetificate reloaded")
 	keyPair.certMutex.Lock()
 	defer keyPair.certMutex.Unlock()
 	keyPair.cert = &newCert

--- a/pkg/webhook/mutate.go
+++ b/pkg/webhook/mutate.go
@@ -4,8 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/golang/glog"
 	v1 "k8s.io/api/admission/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 )
@@ -18,7 +18,7 @@ var (
 )
 
 func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1.AdmissionResponse, error) {
-	glog.V(2).Infof("mutateSriovNetworkNodePolicy(): set default value")
+	log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set default value")
 	reviewResponse := v1.AdmissionResponse{}
 	reviewResponse.Allowed = true
 
@@ -31,20 +31,20 @@ func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1.AdmissionRespo
 	patchs := []map[string]interface{}{}
 	spec := cr["spec"]
 	if _, ok := spec.(map[string]interface{})["priority"]; !ok {
-		glog.V(2).Infof("mutateSriovNetworkNodePolicy(): set default priority to lowest for %v", name)
+		log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set default priority to lowest for", "policy-name", name)
 		patchs = append(patchs, defaultPriorityPatch)
 	}
 	if _, ok := spec.(map[string]interface{})["deviceType"]; !ok {
-		glog.V(2).Infof("mutateSriovNetworkNodePolicy(): set default deviceType to netdevice for %v", name)
+		log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set default deviceType to netdevice for policy", "policy-name", name)
 		patchs = append(patchs, defaultDeviceTypePatch)
 	}
 	if _, ok := spec.(map[string]interface{})["isRdma"]; !ok {
-		glog.V(2).Infof("mutateSriovNetworkNodePolicy(): set default isRdma to false for %v", name)
+		log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set default isRdma to false for policy", "policy-name", name)
 		patchs = append(patchs, defaultIsRdmaPatch)
 	}
 	// Device with InfiniBand link type requires isRdma to be true
 	if str, ok := spec.(map[string]interface{})["linkType"].(string); ok && strings.EqualFold(str, constants.LinkTypeIB) {
-		glog.V(2).Infof("mutateSriovNetworkNodePolicy(): set isRdma to true for %v since ib link type is detected", name)
+		log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set isRdma to true for policy since ib link type is detected", "policy-name", name)
 		patchs = append(patchs, InfiniBandIsRdmaPatch)
 	}
 	var err error

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -4,9 +4,9 @@ import (
 	"encoding/json"
 	"os"
 
-	"github.com/golang/glog"
 	v1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 )
@@ -21,19 +21,19 @@ func RetriveSupportedNics() error {
 }
 
 func MutateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
-	glog.V(2).Info("mutating custom resource")
+	log.Log.V(2).Info("mutating custom resource")
 
 	cr := map[string]interface{}{}
 
 	raw := ar.Request.Object.Raw
 	err := json.Unmarshal(raw, &cr)
 	if err != nil {
-		glog.Error(err)
+		log.Log.Error(err, "failed to unmarshal object")
 		return toV1AdmissionResponse(err)
 	}
 	var reviewResp *v1.AdmissionResponse
 	if reviewResp, err = mutateSriovNetworkNodePolicy(cr); err != nil {
-		glog.Error(err)
+		log.Log.Error(err, "failed to mutate object")
 		return toV1AdmissionResponse(err)
 	}
 
@@ -41,7 +41,7 @@ func MutateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 }
 
 func ValidateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
-	glog.V(2).Info("validating custom resource")
+	log.Log.V(2).Info("validating custom resource")
 	var err error
 	var raw []byte
 
@@ -59,7 +59,7 @@ func ValidateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 
 		err = json.Unmarshal(raw, &policy)
 		if err != nil {
-			glog.Error(err)
+			log.Log.Error(err, "failed to unmarshal object")
 			return toV1AdmissionResponse(err)
 		}
 
@@ -73,7 +73,7 @@ func ValidateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 
 		err = json.Unmarshal(raw, &config)
 		if err != nil {
-			glog.Error(err)
+			log.Log.Error(err, "failed to unmarshal object")
 			return toV1AdmissionResponse(err)
 		}
 

--- a/test/util/client/clients.go
+++ b/test/util/client/clients.go
@@ -4,8 +4,6 @@ import (
 	"os"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
-
-	"github.com/golang/glog"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	clientmachineconfigv1 "github.com/openshift/machine-config-operator/pkg/generated/clientset/versioned/typed/machineconfiguration.openshift.io/v1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -17,10 +15,16 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	clientsriovv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/typed/sriovnetwork/v1"
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 )
+
+func init() {
+	snolog.InitLog()
+}
 
 // ClientSet provides the struct to talk with relevant API
 type ClientSet struct {
@@ -45,14 +49,14 @@ func New(kubeconfig string) *ClientSet {
 	}
 
 	if kubeconfig != "" {
-		glog.V(4).Infof("Loading kube client config from path %q", kubeconfig)
+		log.Log.V(4).Info("Loading kube client config", "path", kubeconfig)
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	} else {
-		glog.V(4).Infof("Using in-cluster kube client config")
+		log.Log.V(4).Info("Using in-cluster kube client config")
 		config, err = rest.InClusterConfig()
 	}
 	if err != nil {
-		glog.Warningf("Error while building client config: %v", err)
+		log.Log.Error(err, "Error while building client config")
 		return nil
 	}
 
@@ -75,7 +79,7 @@ func New(kubeconfig string) *ClientSet {
 		Scheme: crScheme,
 	})
 	if err != nil {
-		glog.Warningf("Error while creating ClientSet: %v", err)
+		log.Log.Error(err, "Error while creating ClientSet")
 		return nil
 	}
 	return clientSet


### PR DESCRIPTION
Remove the use of glog package.
use controller-runtime logging & zap instead.


- [x] Remove glog from cmds
- [x] Remove  glog from tests
- [x] Remove glog from pkgs (multiple packages, see below)
   - [x] webhook
  - [x] daemon
  - [x] host
  - [x] leaderelection
  - [x] plugins
  - [x] service
  - [x] systemd
  - [x] utils
- [x] remove glog flags from bindata/manifests 

roughly 460 substitutions required.