### PR TITLE
Increase end-to-end test coverage

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -113,6 +113,8 @@ var _ = Describe("[sriov] operator", func() {
 					Skip("Test unsuitable to be run in discovery mode")
 				}
 
+				testStartingTime := time.Now()
+
 				By("Checking that a daemon is scheduled on each worker node")
 				Eventually(func() bool {
 					return daemonsScheduledOnNodes("node-role.kubernetes.io/worker=")
@@ -168,6 +170,21 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func() bool {
 					return daemonsScheduledOnNodes("node-role.kubernetes.io/worker")
 				}, 1*time.Minute, 1*time.Second).Should(Equal(true))
+
+				By("Checking that a daemon is able to publish events")
+				Eventually(func() bool {
+					events, err := clients.Events(operatorNamespace).List(
+						context.Background(), metav1.ListOptions{TypeMeta: sriovv1.SriovNetworkNodeState{}.TypeMeta})
+					Expect(err).ToNot(HaveOccurred())
+
+					for _, e := range events.Items {
+						if e.Reason == "ConfigDaemonStart" &&
+							e.CreationTimestamp.Time.After(testStartingTime) {
+							return true
+						}
+					}
+					return false
+				}, 30*time.Second, 5*time.Second).Should(BeTrue(), "Config Daemon should record an event when starting")
 			})
 		})
 


### PR DESCRIPTION
Add a basic assertion in the end-to-end suite to
verify that the config-daemon can publish
k8s Events.
cc @rollandf 

Add an end-to-end test to verify that configuring the LogLevel
field of a SriovNetwork makes sriov cni Add command logging
to multus pods
cc @andreaskaris 
