### PR TITLE
Minor improvments for systemd mode implementation

### DIFF
--- a/pkg/plugins/k8s/k8s_plugin.go
+++ b/pkg/plugins/k8s/k8s_plugin.go
@@ -322,13 +322,13 @@ func (p *K8sPlugin) switchdevServiceStateUpdate() error {
 
 func (p *K8sPlugin) sriovServiceStateUpdate() error {
 	log.Log.Info("sriovServiceStateUpdate()")
-	exist, err := p.serviceManager.IsServiceExist(p.sriovService.Path)
+	isServiceEnabled, err := p.serviceManager.IsServiceEnabled(p.sriovService.Path)
 	if err != nil {
 		return err
 	}
 
-	// create the service if it doesn't exist
-	if !exist {
+	// create and enable the service if it doesn't exist or is not enabled
+	if !isServiceEnabled {
 		p.updateTarget.sriovScript = true
 	} else {
 		p.updateTarget.sriovScript = p.isSystemServiceNeedUpdate(p.sriovService)

--- a/pkg/systemd/systemd.go
+++ b/pkg/systemd/systemd.go
@@ -209,6 +209,20 @@ func ReadSriovResult() (*SriovResult, error) {
 	return result, err
 }
 
+func RemoveSriovResult() error {
+	err := os.Remove(SriovHostSystemdResultPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Log.V(2).Info("RemoveSriovResult(): result file not found")
+			return nil
+		}
+		log.Log.Error(err, "RemoveSriovResult(): failed to remove sriov result file", "path", SriovHostSystemdResultPath)
+		return err
+	}
+	log.Log.V(2).Info("RemoveSriovResult(): result file removed")
+	return nil
+}
+
 func WriteSriovSupportedNics() error {
 	_, err := os.Stat(sriovHostSystemdSupportedNicPath)
 	if err != nil {


### PR DESCRIPTION
Couple improvements for systemd mode implementation to cover edge cases:
- check that service enabled in addition to check which validates that service exist
- remove old result file when we update configuration for systemd service to make sure that there is no chance to read outdated info

The original implementation can't detect situation when the service exists on the node, but for some reason was disabled by the user. In this case daemon was not able to detect this misconfiguration.