### PR TITLE
fix: sriov config service unit-file dependencies

### DIFF
--- a/bindata/manifests/sriov-config-service/kubernetes/sriov-config-service.yaml
+++ b/bindata/manifests/sriov-config-service/kubernetes/sriov-config-service.yaml
@@ -1,12 +1,12 @@
 contents: |
   [Unit]
   Description=Configures SRIOV NIC
-  Wants=network-pre.target
-  Before=network-pre.target
+  After=network-pre.target
+  Before=NetworkManager.service kubelet.service
   
   [Service]
   Type=oneshot
-  ExecStart=/var/lib/sriov/sriov-network-config-daemon service
+  ExecStart=/var/lib/sriov/sriov-network-config-daemon -v 2 service
   StandardOutput=journal+console
   
   [Install]

--- a/bindata/manifests/sriov-config-service/openshift/sriov-config-service.yaml
+++ b/bindata/manifests/sriov-config-service/openshift/sriov-config-service.yaml
@@ -16,8 +16,8 @@ spec:
             # Removal of this file signals firstboot completion
             ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
             # This service is used to configure the SR-IOV VFs on NICs
-            Wants=network-pre.target
-            Before=network-pre.target
+            After=network-pre.target
+            Before=NetworkManager.service kubelet.service
             
             [Service]
             Type=oneshot


### PR DESCRIPTION
run after initial networking has been configured
but before NetworkManager and kubelet.

that way we ensre NICs have a netdev to use during configurations.