### PR TITLE
e2e: Add `cluster-info` as job artifact

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,6 +101,8 @@ jobs:
       golangci,
     ]
     runs-on: [ sriov ]
+    env:
+      TEST_REPORT_PATH: k8s-artifacts
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -116,8 +118,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: k8s-artifact
-          path: ./k8s-artifacts
+          name: ${{ env.TEST_REPORT_PATH }}
+          path: ./${{ env.TEST_REPORT_PATH }}
 
       - name: remove virtual cluster
         if: always()
@@ -132,8 +134,9 @@ jobs:
       test,
       golangci,
     ]
-
     runs-on: [ ocp ]
+    env:
+      TEST_REPORT_PATH: ocp-artifacts
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -149,8 +152,8 @@ jobs:
       - uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ocp-artifact
-          path: ./ocp-artifacts
+          name: ${{ env.TEST_REPORT_PATH }}
+          path: ./${{ env.TEST_REPORT_PATH }}
 
       - name: remove virtual cluster
         if: always()

--- a/hack/run-e2e-conformance-virtual-cluster.sh
+++ b/hack/run-e2e-conformance-virtual-cluster.sh
@@ -364,5 +364,14 @@ hack/deploy-wait.sh
 
 if [ -z $SKIP_TEST ]; then
   echo "## run sriov e2e conformance tests"
-  SUITE=./test/conformance JUNIT_OUTPUT=`pwd`/k8s-artifacts hack/run-e2e-conformance.sh
+
+  if [[ -v TEST_REPORT_PATH ]]; then
+    export JUNIT_OUTPUT="${root}/${TEST_REPORT_PATH}/conformance-test-report"
+  fi
+
+  SUITE=./test/conformance hack/run-e2e-conformance.sh
+
+  if [[ -v TEST_REPORT_PATH ]]; then
+    kubectl cluster-info dump --namespaces ${NAMESPACE} --output-directory "${root}/${TEST_REPORT_PATH}/cluster-info"
+  fi
 fi

--- a/hack/run-e2e-conformance-virtual-ocp.sh
+++ b/hack/run-e2e-conformance-virtual-ocp.sh
@@ -239,5 +239,14 @@ hack/deploy-wait.sh
 
 if [ -z $SKIP_TEST ]; then
   echo "## run sriov e2e conformance tests"
-  SUITE=./test/conformance JUNIT_OUTPUT=`pwd`/ocp-artifacts hack/run-e2e-conformance.sh
+
+  if [[ -v TEST_REPORT_PATH ]]; then
+    export JUNIT_OUTPUT="${root}/${TEST_REPORT_PATH}/conformance-test-report"
+  fi
+
+  SUITE=./test/conformance hack/run-e2e-conformance.sh
+
+  if [[ -v TEST_REPORT_PATH ]]; then
+    kubectl cluster-info dump --namespaces ${NAMESPACE} --output-directory "${root}/${TEST_REPORT_PATH}/cluster-info"
+  fi
 fi


### PR DESCRIPTION
Use `kubectl cluster-info dump` to retrieve useful debug information at the end of the end-to-end test run.