### PR TITLE
Fix equality comparison of policy specs

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -348,7 +348,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(ctx context
 			}
 		}
 		newVersion.Spec.DpConfigVersion = cksum
-		if equality.Semantic.DeepDerivative(newVersion.Spec, found.Spec) {
+		if equality.Semantic.DeepEqual(newVersion.Spec, found.Spec) {
 			logger.Info("SriovNetworkNodeState did not change, not updating")
 			return nil
 		}


### PR DESCRIPTION
When the last policy is deleted, the network node states objects are not updated because the DeepDerivative function only compares the DPConfigVersion and ignores the Interfaces. The new spec has no interfaces. The node states are eventually updated when the resync period forces the reconcilation loop to trigger again.

This causes a long delay on the processing of the deletion by the sriov config daemon. This started to be an issue when we changed the order of the methdos syncAllSriovNetworkNodeStates and syncDevicePluginConfigMap. The last one was run first and the param DPConfigVersion was always different for this particular case.