### PR TITLE
Reduce operator's controller logs via `OperatorConfig.LogLevel`

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -276,7 +276,6 @@ func (r *SriovNetworkNodePolicyReconciler) syncAllSriovNetworkNodeStates(ctx con
 		for _, ns := range nsList.Items {
 			found := false
 			for _, node := range nl.Items {
-				logger.Info("validate", "SriovNetworkNodeState", ns.GetName(), "node", node.GetName())
 				if ns.GetName() == node.GetName() {
 					found = true
 					break

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -102,6 +102,7 @@ func (r *SriovNetworkNodePolicyReconciler) Reconcile(ctx context.Context, req ct
 				reqLogger.Error(err, "Failed to create default Policy", "Namespace", namespace, "Name", constants.DefaultPolicyName)
 				return reconcile.Result{}, err
 			}
+			reqLogger.Info("Default policy created")
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -197,7 +197,7 @@ func (r *SriovNetworkNodePolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 
 func (r *SriovNetworkNodePolicyReconciler) syncDevicePluginConfigMap(ctx context.Context, pl *sriovnetworkv1.SriovNetworkNodePolicyList, nl *corev1.NodeList) error {
 	logger := log.Log.WithName("syncDevicePluginConfigMap")
-	logger.Info("Start to sync device plugin ConfigMap")
+	logger.V(1).Info("Start to sync device plugin ConfigMap")
 
 	configData := make(map[string]string)
 	for _, node := range nl.Items {
@@ -231,12 +231,12 @@ func (r *SriovNetworkNodePolicyReconciler) syncDevicePluginConfigMap(ctx context
 			if err != nil {
 				return fmt.Errorf("couldn't create ConfigMap: %v", err)
 			}
-			logger.Info("Created ConfigMap for", cm.Namespace, cm.Name)
+			logger.V(1).Info("Created ConfigMap for", cm.Namespace, cm.Name)
 		} else {
 			return fmt.Errorf("failed to get ConfigMap: %v", err)
 		}
 	} else {
-		logger.Info("ConfigMap already exists, updating")
+		logger.V(1).Info("ConfigMap already exists, updating")
 		err = r.Update(ctx, cm)
 		if err != nil {
 			return fmt.Errorf("couldn't update ConfigMap: %v", err)
@@ -247,29 +247,29 @@ func (r *SriovNetworkNodePolicyReconciler) syncDevicePluginConfigMap(ctx context
 
 func (r *SriovNetworkNodePolicyReconciler) syncAllSriovNetworkNodeStates(ctx context.Context, np *sriovnetworkv1.SriovNetworkNodePolicy, npl *sriovnetworkv1.SriovNetworkNodePolicyList, nl *corev1.NodeList) error {
 	logger := log.Log.WithName("syncAllSriovNetworkNodeStates")
-	logger.Info("Start to sync all SriovNetworkNodeState custom resource")
+	logger.V(1).Info("Start to sync all SriovNetworkNodeState custom resource")
 	found := &corev1.ConfigMap{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: constants.ConfigMapName}, found); err != nil {
-		logger.Info("Fail to get", "ConfigMap", constants.ConfigMapName)
+		logger.V(1).Info("Fail to get", "ConfigMap", constants.ConfigMapName)
 	}
 	for _, node := range nl.Items {
-		logger.Info("Sync SriovNetworkNodeState CR", "name", node.Name)
+		logger.V(1).Info("Sync SriovNetworkNodeState CR", "name", node.Name)
 		ns := &sriovnetworkv1.SriovNetworkNodeState{}
 		ns.Name = node.Name
 		ns.Namespace = namespace
 		j, _ := json.Marshal(ns)
-		logger.Info("SriovNetworkNodeState CR", "content", j)
+		logger.V(2).Info("SriovNetworkNodeState CR", "content", j)
 		if err := r.syncSriovNetworkNodeState(ctx, np, npl, ns, &node, utils.HashConfigMap(found)); err != nil {
 			logger.Error(err, "Fail to sync", "SriovNetworkNodeState", ns.Name)
 			return err
 		}
 	}
-	logger.Info("Remove SriovNetworkNodeState custom resource for unselected node")
+	logger.V(1).Info("Remove SriovNetworkNodeState custom resource for unselected node")
 	nsList := &sriovnetworkv1.SriovNetworkNodeStateList{}
 	err := r.List(ctx, nsList, &client.ListOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
-			logger.Info("Fail to list SriovNetworkNodeState CRs")
+			logger.Error(err, "Fail to list SriovNetworkNodeState CRs")
 			return err
 		}
 	} else {
@@ -284,7 +284,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncAllSriovNetworkNodeStates(ctx con
 			if !found {
 				err := r.Delete(ctx, &ns, &client.DeleteOptions{})
 				if err != nil {
-					logger.Info("Fail to Delete", "SriovNetworkNodeState CR:", ns.GetName())
+					logger.Error(err, "Fail to Delete", "SriovNetworkNodeState CR:", ns.GetName())
 					return err
 				}
 			}
@@ -295,7 +295,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncAllSriovNetworkNodeStates(ctx con
 
 func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(ctx context.Context, np *sriovnetworkv1.SriovNetworkNodePolicy, npl *sriovnetworkv1.SriovNetworkNodePolicyList, ns *sriovnetworkv1.SriovNetworkNodeState, node *corev1.Node, cksum string) error {
 	logger := log.Log.WithName("syncSriovNetworkNodeState")
-	logger.Info("Start to sync SriovNetworkNodeState", "Name", ns.Name, "cksum", cksum)
+	logger.V(1).Info("Start to sync SriovNetworkNodeState", "Name", ns.Name, "cksum", cksum)
 
 	if err := controllerutil.SetControllerReference(np, ns, r.Scheme); err != nil {
 		return err
@@ -303,7 +303,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(ctx context
 	found := &sriovnetworkv1.SriovNetworkNodeState{}
 	err := r.Get(ctx, types.NamespacedName{Namespace: ns.Namespace, Name: ns.Name}, found)
 	if err != nil {
-		logger.Info("Fail to get SriovNetworkNodeState", "namespace", ns.Namespace, "name", ns.Name)
+		logger.Error(err, "Fail to get SriovNetworkNodeState", "namespace", ns.Namespace, "name", ns.Name)
 		if errors.IsNotFound(err) {
 			ns.Spec.DpConfigVersion = cksum
 			err = r.Create(ctx, ns)
@@ -321,7 +321,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(ctx context
 			return nil
 		}
 
-		logger.Info("SriovNetworkNodeState already exists, updating")
+		logger.V(1).Info("SriovNetworkNodeState already exists, updating")
 		newVersion := found.DeepCopy()
 		newVersion.Spec = ns.Spec
 
@@ -350,7 +350,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(ctx context
 		}
 		newVersion.Spec.DpConfigVersion = cksum
 		if equality.Semantic.DeepEqual(newVersion.Spec, found.Spec) {
-			logger.Info("SriovNetworkNodeState did not change, not updating")
+			logger.V(1).Info("SriovNetworkNodeState did not change, not updating")
 			return nil
 		}
 		err = r.Update(ctx, newVersion)
@@ -363,7 +363,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(ctx context
 
 func (r *SriovNetworkNodePolicyReconciler) syncPluginDaemonObjs(ctx context.Context, operatorConfig *sriovnetworkv1.SriovOperatorConfig, dp *sriovnetworkv1.SriovNetworkNodePolicy, pl *sriovnetworkv1.SriovNetworkNodePolicyList) error {
 	logger := log.Log.WithName("syncPluginDaemonObjs")
-	logger.Info("Start to sync sriov daemons objects")
+	logger.V(1).Info("Start to sync sriov daemons objects")
 
 	// render plugin manifests
 	data := render.MakeRenderData()
@@ -486,7 +486,7 @@ func (r *SriovNetworkNodePolicyReconciler) deleteK8sResource(ctx context.Context
 func (r *SriovNetworkNodePolicyReconciler) syncDsObject(ctx context.Context, dp *sriovnetworkv1.SriovNetworkNodePolicy, pl *sriovnetworkv1.SriovNetworkNodePolicyList, obj *uns.Unstructured) error {
 	logger := log.Log.WithName("syncDsObject")
 	kind := obj.GetKind()
-	logger.Info("Start to sync Objects", "Kind", kind)
+	logger.V(1).Info("Start to sync Objects", "Kind", kind)
 	switch kind {
 	case "ServiceAccount", "Role", "RoleBinding":
 		if err := controllerutil.SetControllerReference(dp, obj, r.Scheme); err != nil {
@@ -510,7 +510,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncDsObject(ctx context.Context, dp 
 
 func (r *SriovNetworkNodePolicyReconciler) syncDaemonSet(ctx context.Context, cr *sriovnetworkv1.SriovNetworkNodePolicy, pl *sriovnetworkv1.SriovNetworkNodePolicyList, in *appsv1.DaemonSet) error {
 	logger := log.Log.WithName("syncDaemonSet")
-	logger.Info("Start to sync DaemonSet", "Namespace", in.Namespace, "Name", in.Name)
+	logger.V(1).Info("Start to sync DaemonSet", "Namespace", in.Namespace, "Name", in.Name)
 	var err error
 
 	if pl != nil {
@@ -536,7 +536,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncDaemonSet(ctx context.Context, cr
 			return err
 		}
 	} else {
-		logger.Info("DaemonSet already exists, updating")
+		logger.V(1).Info("DaemonSet already exists, updating")
 		// DeepDerivative checks for changes only comparing non zero fields in the source struct.
 		// This skips default values added by the api server.
 		// References in https://github.com/kubernetes-sigs/kubebuilder/issues/592#issuecomment-625738183
@@ -545,7 +545,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncDaemonSet(ctx context.Context, cr
 			// https://bugzilla.redhat.com/show_bug.cgi?id=1914066
 			if equality.Semantic.DeepEqual(in.Spec.Template.Spec.Affinity.NodeAffinity,
 				ds.Spec.Template.Spec.Affinity.NodeAffinity) {
-				logger.Info("Daemonset spec did not change, not updating")
+				logger.V(1).Info("Daemonset spec did not change, not updating")
 				return nil
 			}
 		}
@@ -604,7 +604,7 @@ func nodeSelectorTermsForPolicyList(policies []sriovnetworkv1.SriovNetworkNodePo
 // renderDsForCR returns a busybox pod with the same name/namespace as the cr
 func renderDsForCR(path string, data *render.RenderData) ([]*uns.Unstructured, error) {
 	logger := log.Log.WithName("renderDsForCR")
-	logger.Info("Start to render objects")
+	logger.V(1).Info("Start to render objects")
 
 	objs, err := render.RenderDir(path, data)
 	if err != nil {
@@ -615,7 +615,7 @@ func renderDsForCR(path string, data *render.RenderData) ([]*uns.Unstructured, e
 
 func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(ctx context.Context, pl *sriovnetworkv1.SriovNetworkNodePolicyList, node *corev1.Node) (dptypes.ResourceConfList, error) {
 	logger := log.Log.WithName("renderDevicePluginConfigData")
-	logger.Info("Start to render device plugin config data", "node", node.Name)
+	logger.V(1).Info("Start to render device plugin config data", "node", node.Name)
 	rcl := dptypes.ResourceConfList{}
 	for _, p := range pl.Items {
 		if p.Name == constants.DefaultPolicyName {
@@ -640,14 +640,14 @@ func (r *SriovNetworkNodePolicyReconciler) renderDevicePluginConfigData(ctx cont
 			if err != nil {
 				return rcl, err
 			}
-			logger.Info("Update resource", "Resource", rcl.ResourceList[i])
+			logger.V(1).Info("Update resource", "Resource", rcl.ResourceList[i])
 		} else {
 			rc, err := createDevicePluginResource(ctx, &p, nodeState)
 			if err != nil {
 				return rcl, err
 			}
 			rcl.ResourceList = append(rcl.ResourceList, *rc)
-			logger.Info("Add resource", "Resource", *rc)
+			logger.V(1).Info("Add resource", "Resource", *rc)
 		}
 	}
 	return rcl, nil

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -39,6 +39,7 @@ import (
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	apply "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/apply"
 	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 	render "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/render"
 	utils "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 )
@@ -123,6 +124,8 @@ func (r *SriovOperatorConfigReconciler) Reconcile(ctx context.Context, req ctrl.
 	if err = r.syncPluginDaemonSet(ctx, defaultConfig); err != nil {
 		return reconcile.Result{}, err
 	}
+
+	snolog.SetLogLevel(defaultConfig.Spec.LogLevel)
 
 	// For Openshift we need to create the systemd files using a machine config
 	if utils.ClusterType == utils.ClusterTypeOpenshift {

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -152,7 +152,7 @@ func (r *SriovOperatorConfigReconciler) SetupWithManager(mgr ctrl.Manager) error
 
 func (r *SriovOperatorConfigReconciler) syncPluginDaemonSet(ctx context.Context, dc *sriovnetworkv1.SriovOperatorConfig) error {
 	logger := log.Log.WithName("syncConfigDaemonset")
-	logger.Info("Start to sync SRIOV plugin daemonsets nodeSelector")
+	logger.V(1).Info("Start to sync SRIOV plugin daemonsets nodeSelector")
 	ds := &appsv1.DaemonSet{}
 
 	names := []string{"sriov-cni", "sriov-device-plugin"}
@@ -183,7 +183,7 @@ func (r *SriovOperatorConfigReconciler) syncPluginDaemonSet(ctx context.Context,
 
 func (r *SriovOperatorConfigReconciler) syncConfigDaemonSet(ctx context.Context, dc *sriovnetworkv1.SriovOperatorConfig) error {
 	logger := log.Log.WithName("syncConfigDaemonset")
-	logger.Info("Start to sync config daemonset")
+	logger.V(1).Info("Start to sync config daemonset")
 
 	data := render.MakeRenderData()
 	data.Data["Image"] = os.Getenv("SRIOV_NETWORK_CONFIG_DAEMON_IMAGE")
@@ -204,7 +204,7 @@ func (r *SriovOperatorConfigReconciler) syncConfigDaemonSet(ctx context.Context,
 	if envCniBinPath == "" {
 		data.Data["CNIBinPath"] = "/var/lib/cni/bin"
 	} else {
-		logger.Info("New cni bin found", "CNIBinPath", envCniBinPath)
+		logger.V(1).Info("New cni bin found", "CNIBinPath", envCniBinPath)
 		data.Data["CNIBinPath"] = envCniBinPath
 	}
 	objs, err := render.RenderDir(constants.ConfigDaemonPath, &data)
@@ -240,7 +240,7 @@ func (r *SriovOperatorConfigReconciler) syncConfigDaemonSet(ctx context.Context,
 
 func (r *SriovOperatorConfigReconciler) syncWebhookObjs(ctx context.Context, dc *sriovnetworkv1.SriovOperatorConfig) error {
 	logger := log.Log.WithName("syncWebhookObjs")
-	logger.Info("Start to sync webhook objects")
+	logger.V(1).Info("Start to sync webhook objects")
 
 	for name, path := range webhooks {
 		// Render Webhook manifests

--- a/pkg/apply/apply.go
+++ b/pkg/apply/apply.go
@@ -3,7 +3,6 @@ package apply
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/pkg/errors"
 
@@ -24,7 +23,6 @@ func DeleteObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruc
 	gvk := obj.GroupVersionKind()
 	// used for logging and errors
 	objDesc := fmt.Sprintf("(%s) %s/%s", gvk.String(), namespace, name)
-	log.Printf("reconciling %s", objDesc)
 
 	if err := IsObjectSupported(obj); err != nil {
 		return errors.Wrapf(err, "object %s unsupported", objDesc)
@@ -36,7 +34,6 @@ func DeleteObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruc
 	err := client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
 
 	if err != nil && apierrors.IsNotFound(err) {
-		log.Printf("does not exist, do nothing %s", objDesc)
 		return nil
 	}
 	if err != nil {
@@ -45,8 +42,6 @@ func DeleteObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruc
 
 	if err = client.Delete(ctx, existing); err != nil {
 		return errors.Wrapf(err, "could not delete object %s", objDesc)
-	} else {
-		log.Printf("delete was successful")
 	}
 	return nil
 }
@@ -62,7 +57,6 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 	gvk := obj.GroupVersionKind()
 	// used for logging and errors
 	objDesc := fmt.Sprintf("(%s) %s/%s", gvk.String(), namespace, name)
-	log.Printf("reconciling %s", objDesc)
 
 	if err := IsObjectSupported(obj); err != nil {
 		return errors.Wrapf(err, "object %s unsupported", objDesc)
@@ -74,12 +68,10 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 	err := client.Get(ctx, types.NamespacedName{Name: obj.GetName(), Namespace: obj.GetNamespace()}, existing)
 
 	if err != nil && apierrors.IsNotFound(err) {
-		log.Printf("does not exist, creating %s", objDesc)
 		err := client.Create(ctx, obj)
 		if err != nil {
 			return errors.Wrapf(err, "could not create %s", objDesc)
 		}
-		log.Printf("successfully created %s", objDesc)
 		return nil
 	}
 	if err != nil {
@@ -93,8 +85,6 @@ func ApplyObject(ctx context.Context, client k8sclient.Client, obj *uns.Unstruct
 	if !equality.Semantic.DeepEqual(existing, obj) {
 		if err := client.Update(ctx, obj); err != nil {
 			return errors.Wrapf(err, "could not update object %s", objDesc)
-		} else {
-			log.Printf("update was successful %s", objDesc)
 		}
 	}
 

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -17,7 +17,6 @@ import (
 	mcfgv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	daemonconsts "github.com/openshift/machine-config-operator/pkg/daemon/constants"
 	mcfginformers "github.com/openshift/machine-config-operator/pkg/generated/informers/externalversions"
-	"go.uber.org/zap"
 	"golang.org/x/time/rate"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -426,22 +425,12 @@ func (dn *Daemon) operatorConfigAddHandler(obj interface{}) {
 
 func (dn *Daemon) operatorConfigChangeHandler(old, new interface{}) {
 	newCfg := new.(*sriovnetworkv1.SriovOperatorConfig)
-	dn.handleLogLevelChange(newCfg.Spec.LogLevel)
+	snolog.SetLogLevel(newCfg.Spec.LogLevel)
 
 	newDisableDrain := newCfg.Spec.DisableDrain
 	if dn.disableDrain != newDisableDrain {
 		dn.disableDrain = newDisableDrain
 		log.Log.Info("Set Disable Drain", "value", dn.disableDrain)
-	}
-}
-
-// handleLogLevelChange handles log level change
-func (dn *Daemon) handleLogLevelChange(logLevel int) {
-	newLevel := int8(logLevel * -1)
-	currLevel := int8(snolog.Options.Level.(zap.AtomicLevel).Level())
-	if newLevel != currLevel {
-		log.Log.Info("Set log verbose level", "new-level", newLevel, "current-level", currLevel)
-		snolog.SetLogLevel(newLevel)
 	}
 }
 

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -49,7 +49,21 @@ func InitLog() {
 	log.SetLogger(zap.New(zap.UseFlagOptions(Options)))
 }
 
-// SetLogLevel sets log level
-func SetLogLevel(lvl int8) {
-	Options.Level.(zzap.AtomicLevel).SetLevel(zapcore.Level(lvl))
+// SetLogLevel provides conversion from the operators LogLevel value ({0,1,2} where 2 is the most verbose) and sets
+// the current logging level accordingly.
+func SetLogLevel(operatorLevel int) {
+	newLevel := operatorToZapLevel(operatorLevel)
+	currLevel := Options.Level.(zzap.AtomicLevel).Level()
+	if newLevel != currLevel {
+		log.Log.Info("Set log verbose level", "new-level", operatorLevel, "current-level", zapToOperatorLevel(currLevel))
+		Options.Level.(zzap.AtomicLevel).SetLevel(newLevel)
+	}
+}
+
+func zapToOperatorLevel(zapLevel zapcore.Level) int {
+	return int(zapLevel) * -1
+}
+
+func operatorToZapLevel(operatorLevel int) zapcore.Level {
+	return zapcore.Level(operatorLevel * -1)
 }

--- a/pkg/log/log_test.go
+++ b/pkg/log/log_test.go
@@ -1,0 +1,92 @@
+package log
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	g "github.com/onsi/ginkgo/v2"
+	o "github.com/onsi/gomega"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var tempLogFile *os.File
+var origWriter io.Writer
+
+var _ = g.Describe("Logging", func() {
+
+	g.BeforeEach(func() {
+		err := os.Truncate(tempLogFile.Name(), 0)
+		o.Expect(err).ToNot(o.HaveOccurred())
+	})
+
+	g.It("LogLevel 0", func() {
+
+		log.Log.Info("test level 0")
+		log.Log.V(1).Info("test level 1")
+		log.Log.V(2).Info("test level 2")
+
+		out, err := os.ReadFile(tempLogFile.Name())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(string(out)).Should(o.ContainSubstring("test level 0"))
+		o.Expect(string(out)).ShouldNot(o.ContainSubstring("test level 1"))
+		o.Expect(string(out)).ShouldNot(o.ContainSubstring("test level 2"))
+	})
+
+	g.It("LogLevel 1", func() {
+
+		SetLogLevel(1)
+
+		log.Log.Info("test level 0")
+		log.Log.V(1).Info("test level 1")
+		log.Log.V(2).Info("test level 2")
+
+		out, err := os.ReadFile(tempLogFile.Name())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(string(out)).Should(o.ContainSubstring("test level 0"))
+		o.Expect(string(out)).Should(o.ContainSubstring("test level 1"))
+		o.Expect(string(out)).ShouldNot(o.ContainSubstring("test level 2"))
+	})
+
+	g.It("LogLevel 2", func() {
+
+		SetLogLevel(2)
+
+		log.Log.Info("test level 0")
+		log.Log.V(1).Info("test level 1")
+		log.Log.V(2).Info("test level 2")
+
+		out, err := os.ReadFile(tempLogFile.Name())
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		o.Expect(string(out)).Should(o.ContainSubstring("test level 0"))
+		o.Expect(string(out)).Should(o.ContainSubstring("test level 1"))
+		o.Expect(string(out)).Should(o.ContainSubstring("test level 2"))
+	})
+})
+
+func TestLogging(t *testing.T) {
+	o.RegisterFailHandler(g.Fail)
+	g.RunSpecs(t, "Logging Suite")
+}
+
+var _ = g.BeforeSuite(func() {
+	var err error
+	tempLogFile, err = os.CreateTemp("", "zap-output")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	origWriter = Options.DestWriter
+	Options.DestWriter = tempLogFile
+
+	InitLog()
+})
+
+var _ = g.AfterSuite(func() {
+	Options.DestWriter = origWriter
+	o.Expect(tempLogFile.Close()).To(o.Succeed())
+	o.Expect(os.RemoveAll(tempLogFile.Name())).To(o.Succeed())
+
+	SetLogLevel(2)
+})

--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -188,6 +188,82 @@ var _ = Describe("[sriov] operator", func() {
 			})
 		})
 
+		Context("LogLevel affects operator's logs", func() {
+			It("when set to 0 no lifecycle logs are present", func() {
+				if discovery.Enabled() {
+					Skip("Test unsuitable to be run in discovery mode")
+				}
+
+				initialLogLevelValue := getOperatorConfigLogLevel()
+				DeferCleanup(func() {
+					By("Restore LogLevel to its initial value")
+					setOperatorConfigLogLevel(initialLogLevelValue)
+				})
+
+				initialDisableDrain, err := cluster.GetNodeDrainState(clients, operatorNamespace)
+				Expect(err).ToNot(HaveOccurred())
+
+				DeferCleanup(func() {
+					By("Restore DisableDrain to its initial value")
+					Eventually(func() error {
+						return cluster.SetDisableNodeDrainState(clients, operatorNamespace, initialDisableDrain)
+					}, 1*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+				})
+
+				By("Set operator LogLevel to 2")
+				setOperatorConfigLogLevel(2)
+
+				By("Flip DisableDrain to trigger operator activity")
+				since := time.Now()
+				Eventually(func() error {
+					return cluster.SetDisableNodeDrainState(clients, operatorNamespace, !initialDisableDrain)
+				}, 1*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+
+				By("Assert logs contains verbose output")
+				Eventually(func(g Gomega) {
+					logs := getOperatorLogs(since)
+					g.Expect(logs).To(
+						ContainElement(And(
+							ContainSubstring("Reconciling SriovOperatorConfig"),
+						)),
+					)
+
+					// Should contain verbose logging
+					g.Expect(logs).To(
+						ContainElement(
+							ContainSubstring("Start to sync webhook objects"),
+						),
+					)
+				}, 1*time.Minute, 5*time.Second).Should(Succeed())
+
+				By("Reduce operator LogLevel to 0")
+				setOperatorConfigLogLevel(0)
+
+				By("Flip DisableDrain again to trigger operator activity")
+				since = time.Now()
+				Eventually(func() error {
+					return cluster.SetDisableNodeDrainState(clients, operatorNamespace, initialDisableDrain)
+				}, 1*time.Minute, 5*time.Second).ShouldNot(HaveOccurred())
+
+				By("Assert logs contains less operator activity")
+				Eventually(func(g Gomega) {
+					logs := getOperatorLogs(since)
+					g.Expect(logs).To(
+						ContainElement(And(
+							ContainSubstring("Reconciling SriovOperatorConfig"),
+						)),
+					)
+
+					// Should not contain verbose logging
+					g.Expect(logs).ToNot(
+						ContainElement(
+							ContainSubstring("Start to sync webhook objects"),
+						),
+					)
+				}, 1*time.Minute, 5*time.Second).Should(Succeed())
+
+			})
+		})
 	})
 
 	Describe("Generic SriovNetworkNodePolicy", func() {
@@ -2511,6 +2587,66 @@ func setSriovOperatorSpecFlag(flagName string, flagValue bool) {
 			}
 		}, 1*time.Minute, 10*time.Second).WithOffset(1).Should(Succeed())
 	}
+}
+
+func setOperatorConfigLogLevel(level int) {
+	instantBeforeSettingLogLevel := time.Now()
+
+	Eventually(func(g Gomega) {
+		cfg := sriovv1.SriovOperatorConfig{}
+		err := clients.Get(context.TODO(), runtimeclient.ObjectKey{
+			Name:      "default",
+			Namespace: operatorNamespace,
+		}, &cfg)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		if cfg.Spec.LogLevel == level {
+			return
+		}
+
+		cfg.Spec.LogLevel = level
+
+		err = clients.Update(context.TODO(), &cfg)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		logs := getOperatorLogs(instantBeforeSettingLogLevel)
+		g.Expect(logs).To(
+			ContainElement(
+				ContainSubstring(fmt.Sprintf(`"new-level": %d`, level)),
+			),
+		)
+	}, 1*time.Minute, 5*time.Second).Should(Succeed())
+}
+
+func getOperatorConfigLogLevel() int {
+	cfg := sriovv1.SriovOperatorConfig{}
+	err := clients.Get(context.TODO(), runtimeclient.ObjectKey{
+		Name:      "default",
+		Namespace: operatorNamespace,
+	}, &cfg)
+	Expect(err).ToNot(HaveOccurred())
+
+	return cfg.Spec.LogLevel
+}
+
+func getOperatorLogs(since time.Time) []string {
+	podList, err := clients.Pods(operatorNamespace).List(context.Background(), metav1.ListOptions{
+		LabelSelector: "name=sriov-network-operator",
+	})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+	ExpectWithOffset(1, podList.Items).To(HaveLen(1), "One operator pod expected")
+
+	pod := podList.Items[0]
+	logStart := metav1.NewTime(since)
+	rawLogs, err := clients.Pods(pod.Namespace).
+		GetLogs(pod.Name, &corev1.PodLogOptions{
+			Container: pod.Spec.Containers[0].Name,
+			SinceTime: &logStart,
+		}).
+		DoRaw(context.Background())
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	return strings.Split(string(rawLogs), "\n")
 }
 
 func assertObjectIsNotFound(name string, obj runtimeclient.Object) {


### PR DESCRIPTION
Field `SriovOperatorConfig.Spec.LogLevel` controls the verbosity
of the operator logging system. This PR adjusts the operator
controller's log level to that field, as it happens in the
config-daemon.

Log the current and new values for the logger according to what
the user had set in the LogLevel field. Before this commit, a value of
-2 would produce a misleading line:
```
Set log verbose level	{"new-level": 0, "current-level": -2}
```

Also:
- Remove log.Printf(...) instances
- Reduce the number of `syncAllSriovNetworkNodeStates` log lines
- Add end2end test to make sure the LogLevel logic has no regression. Feedback is particularly welcome on this topic, as I'm not sure the test is robust enough to pay back its hypothetical flakiness.