### PR TITLE
Logs `sriov-network-config-daemon` by default

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -21,6 +21,8 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+      annotations:
+        kubectl.kubernetes.io/default-container: sriov-network-config-daemon
     spec:
       hostNetwork: true
       hostPID: true


### PR DESCRIPTION
Container `sriov-network-config-daemon` in the daemonset is the most interesting in the list. Make `kubectl logs ...` target that by default.

