### PR TITLE
Fix error overwrite for setSriovNumVfs

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -428,11 +428,11 @@ func configSriovDevice(iface *sriovnetworkv1.Interface, ifaceStatus *sriovnetwor
 
 			err = setSriovNumVfs(iface.PciAddress, iface.NumVfs)
 			if err != nil {
-				err = RemoveUdevRule(iface.PciAddress)
-				if err != nil {
-					return err
+				log.Log.Error(err, "configSriovDevice(): fail to set NumVfs for device", "device", iface.PciAddress)
+				errRemove := RemoveUdevRule(iface.PciAddress)
+				if errRemove != nil {
+					log.Log.Error(errRemove, "configSriovDevice(): fail to remove udev rule", "device", iface.PciAddress)
 				}
-				log.Log.Error(nil, "configSriovDevice(): fail to set NumVfs for device", "device", iface.PciAddress)
 				return err
 			}
 		}


### PR DESCRIPTION
When setSriovNumVfs fails, the error is overwritten by the return error of RemoveUdevRule. If the latter function doesn't return an error (most cases), the reconciliation loop will report success even if vfs were not created/configured.

Issue found while trying to run the operator on a node that didn't have sriov enabled on the bios.