### PR TITLE
Add check to ensure jq can be found in $PATH when enabling switchdev mode

### DIFF
--- a/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
@@ -13,7 +13,7 @@ contents:
       exit
     fi
 
-    which jq 2>&1 >/dev/null || (echo "Required tool jq is not found in PATH." && exit 1)
+    which jq
 
     append_to_file(){
       content="$1"

--- a/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
+++ b/bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml
@@ -13,6 +13,8 @@ contents:
       exit
     fi
 
+    which jq 2>&1 >/dev/null || (echo "Required tool jq is not found in PATH." && exit 1)
+
     append_to_file(){
       content="$1"
       file_name="$2"


### PR DESCRIPTION
### Description

When using switchdev mode and the `switchdev-configuration-before-nm` systemd service starts, this underlying script can fail but have exit code 0 (since we are not setting `-o pipefail`) making the systemd service report success. This leaves the system in a bad state and user interaction may be needed on the node.

In particular, if `jq` is not installed, it will fail very early. To reduce the scope of the change, I decided to add a check on `jq` existence in $PATH rather than doing the `-o pipefail` which may change the behavior of other lines of code.

### Testing

Before:
```
$ journalctl -f -u switchdev-configuration-before-nm.service --since "10 minutes ago"
-- Logs begin at Mon 2023-05-08 07:49:34 UTC. --
systemd[1]: Starting Configures SRIOV NIC to switchdev mode...
switchdev-configuration-before-nm.sh[190673]: + input=/etc/sriov-operator/sriov_config.json
switchdev-configuration-before-nm.sh[190673]: + UDEV_RULE_FILE=/etc/udev/rules.d/10-persistent-net.rules
switchdev-configuration-before-nm.sh[190673]: + '[' '!' -f /etc/sriov-operator/sriov_config.json ']'
switchdev-configuration-before-nm.sh[190682]: + jq -c '.interfaces[]' /etc/sriov-operator/sriov_config.json
switchdev-configuration-before-nm.sh[190684]: + read iface
switchdev-configuration-before-nm.sh[190682]: /usr/local/bin/switchdev-configuration-before-nm.sh: line 31: jq: command not found
switchdev-configuration-before-nm.sh[190673]: + sleep 5
switchdev-configuration-before-nm.sh[190720]: + jq -c '.interfaces[]' /etc/sriov-operator/sriov_config.json
switchdev-configuration-before-nm.sh[190721]: + read iface
systemd[1]: switchdev-configuration-before-nm.service: Succeeded.
switchdev-configuration-before-nm.sh[190720]: /usr/local/bin/switchdev-configuration-before-nm.sh: line 42: jq: command not found
systemd[1]: Finished Configures SRIOV NIC to switchdev mode.

$ systemctl status switchdev-configuration-before-nm.service
● switchdev-configuration-before-nm.service - Configures SRIOV NIC to switchdev mode
     Loaded: loaded (/etc/systemd/system/switchdev-configuration-before-nm.service; enabled; vendor preset: enabled)
     Active: inactive (dead) since Wed 2023-11-22 15:32:04 UTC; 1min 31s ago
    Process: 190673 ExecStart=/usr/local/bin/switchdev-configuration-before-nm.sh (code=exited, status=0/SUCCESS)
   Main PID: 190673 (code=exited, status=0/SUCCESS)
```

After:
```
$ journalctl -f -u switchdev-configuration-before-nm.service --since "10 minutes ago"
-- Logs begin at Mon 2023-05-08 07:49:34 UTC. --
systemd[1]: Starting Configures SRIOV NIC to switchdev mode...
switchdev-configuration-before-nm.sh[195824]: + input=/etc/sriov-operator/sriov_config.json
switchdev-configuration-before-nm.sh[195824]: + UDEV_RULE_FILE=/etc/udev/rules.d/10-persistent-net.rules
switchdev-configuration-before-nm.sh[195824]: + '[' '!' -f /etc/sriov-operator/sriov_config.json ']'
switchdev-configuration-before-nm.sh[195824]: + which jq
systemd[1]: switchdev-configuration-before-nm.service: Main process exited, code=exited, status=1/FAILURE
switchdev-configuration-before-nm.sh[195835]: + echo 'Required tool jq is not found in PATH.'
switchdev-configuration-before-nm.sh[195835]: Required tool jq is not found in PATH.
switchdev-configuration-before-nm.sh[195835]: + exit 1
switchdev-configuration-before-nm.service: Failed with result 'exit-code'.
systemd[1]: Failed to start Configures SRIOV NIC to switchdev mode.

$ systemctl status switchdev-configuration-before-nm.service
● switchdev-configuration-before-nm.service - Configures SRIOV NIC to switchdev mode
     Loaded: loaded (/etc/systemd/system/switchdev-configuration-before-nm.service; enabled; vendor preset: enabled)
     Active: failed (Result: exit-code) since Wed 2023-11-22 15:43:01 UTC; 59s ago
    Process: 195824 ExecStart=/usr/local/bin/switchdev-configuration-before-nm.sh (code=exited, status=1/FAILURE)
   Main PID: 195824 (code=exited, status=1/FAILURE)
```