### PR TITLE
Ignore nil objects occured when rendering a file

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -103,6 +103,11 @@ func RenderTemplate(path string, d *RenderData) ([]*unstructured.Unstructured, e
 			}
 			return nil, errors.Wrapf(err, "failed to unmarshal manifest %s", path)
 		}
+
+		if u.Object == nil {
+			continue
+		}
+
 		out = append(out, &u)
 	}
 

--- a/pkg/render/render_test.go
+++ b/pkg/render/render_test.go
@@ -85,14 +85,35 @@ func TestTemplate(t *testing.T) {
 	g.Expect(o[0].Object["bar"]).To(Equal("myns"))
 }
 
+// TestTemplateWithEmptyObject tests the case where a file generates additional nil objects when rendered. An empty
+// object can also occur in the particular case shown in the testfile below when minus is missing at the end of the
+// first expression (i.e. {{- if .Enable }}).
+func TestTemplateWithEmptyObject(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	p := "testdata/manifests/template_with_empty_object.yaml"
+
+	d := MakeRenderData()
+	d.Data["Enable"] = true
+	o, err := RenderTemplate(p, &d)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(len(o)).To(Equal(2))
+	g.Expect(o[0].GetName()).To(Equal("pod1"))
+	g.Expect(o[0].GetNamespace()).To(Equal("namespace1"))
+	g.Expect(o[1].GetName()).To(Equal("pod2"))
+	g.Expect(o[1].GetNamespace()).To(Equal("namespace2"))
+}
+
 func TestRenderDir(t *testing.T) {
 	g := NewGomegaWithT(t)
 
 	d := MakeRenderData()
 	d.Funcs["fname"] = func(s string) string { return s }
 	d.Data["Namespace"] = "myns"
+	d.Data["Enable"] = true
 
 	o, err := RenderDir("testdata/manifests", &d)
 	g.Expect(err).NotTo(HaveOccurred())
-	g.Expect(o).To(HaveLen(6))
+	g.Expect(o).To(HaveLen(8))
 }

--- a/pkg/render/testdata/manifests/template_with_empty_object.yaml
+++ b/pkg/render/testdata/manifests/template_with_empty_object.yaml
@@ -1,0 +1,20 @@
+{{- if .Enable }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: namespace1
+  name: pod1
+spec:
+  containers:
+  - image: "busybox"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: namespace2
+  name: pod2
+spec:
+  containers:
+  - image: "busybox"
+{{- end }}


### PR DESCRIPTION
This commits addresses an edge case where a nil object can occur while rendering a file. In that situation, in one of the places the renderer is used, it will try to add ownership to a nil object and fail.

### Testing

Before:
```
$ go test ./pkg/render/ -run TestTemplateWithEmptyObject
--- FAIL: TestTemplateWithEmptyObject (0.00s)
    render_test.go:101:
        Expected
            <int>: 3
        to equal
            <int>: 2
FAIL
FAIL    github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/render       0.019s
FAIL
```