### PR TITLE
Fix number of args passed to log.Info

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -132,7 +132,7 @@ func IsVfSupportedModel(vendorID, deviceID string) bool {
 			return true
 		}
 	}
-	log.Info("IsVfSupportedModel():", "Unsupported VF model:", "vendorId:", vendorID, "deviceId:", deviceID)
+	log.Info("IsVfSupportedModel(): found unsupported VF model", "vendorId:", vendorID, "deviceId:", deviceID)
 	return false
 }
 


### PR DESCRIPTION
This fix a crash:
```
DPANIC	sriovnetwork	webhook/validate.go:446	odd number of arguments passed as key-value pairs for logging	{"ignored key": "10ed"}
```