### PR TITLE
Change behavior when deleting default SriovNetworkNodePolicy and SriovOperatorConfig

### DIFF
--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -40,7 +40,7 @@ func validateSriovOperatorConfig(cr *sriovnetworkv1.SriovOperatorConfig, operati
 	}
 
 	if operation == v1.Delete {
-		return false, warnings, fmt.Errorf("default SriovOperatorConfig shouldn't be deleted")
+		warnings = append(warnings, "default SriovOperatorConfig shouldn't be deleted")
 	}
 
 	if cr.Spec.DisableDrain {
@@ -97,12 +97,11 @@ func validateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy, o
 
 	if cr.GetName() == constants.DefaultPolicyName && cr.GetNamespace() == os.Getenv("NAMESPACE") {
 		if operation == v1.Delete {
-			// reject deletion of default policy
-			return false, warnings, fmt.Errorf("default SriovNetworkNodePolicy shouldn't be deleted")
-		} else {
-			// skip validating default policy
-			return true, warnings, nil
+			warnings = append(warnings, "default SriovNetworkNodePolicy shouldn't be deleted")
 		}
+
+		// skip validating default policy
+		return true, warnings, nil
 	}
 
 	if cr.GetNamespace() != os.Getenv("NAMESPACE") {
@@ -110,7 +109,6 @@ func validateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy, o
 			fmt.Sprintf(" is created or updated but not used. Only policy in %s namespace is respected.", os.Getenv("NAMESPACE")))
 	}
 
-	// DELETE should always succeed unless it's for the default object
 	if operation == v1.Delete {
 		return true, warnings, nil
 	}

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -156,15 +156,16 @@ func TestValidateSriovOperatorConfigWithDefaultOperatorConfig(t *testing.T) {
 	config := newDefaultOperatorConfig()
 	snclient = fakesnclientset.NewSimpleClientset()
 
-	ok, _, err := validateSriovOperatorConfig(config, "DELETE")
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(ok).To(Equal(false))
+	ok, w, err := validateSriovOperatorConfig(config, "DELETE")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(Equal(true))
+	g.Expect(w[0]).To(ContainSubstring("default SriovOperatorConfig shouldn't be deleted"))
 
 	ok, _, err = validateSriovOperatorConfig(config, "UPDATE")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ok).To(Equal(true))
 
-	ok, w, err := validateSriovOperatorConfig(config, "UPDATE")
+	ok, w, err = validateSriovOperatorConfig(config, "UPDATE")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ok).To(Equal(true))
 	g.Expect(w[0]).To(ContainSubstring("Node draining is disabled"))
@@ -224,9 +225,10 @@ func TestValidateSriovNetworkNodePolicyWithDefaultPolicy(t *testing.T) {
 	}
 	os.Setenv("NAMESPACE", "openshift-sriov-network-operator")
 	g := NewGomegaWithT(t)
-	ok, _, err = validateSriovNetworkNodePolicy(policy, "DELETE")
-	g.Expect(err).To(HaveOccurred())
-	g.Expect(ok).To(Equal(false))
+	ok, w, err := validateSriovNetworkNodePolicy(policy, "DELETE")
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(ok).To(Equal(true))
+	g.Expect(w[0]).To(ContainSubstring("default SriovNetworkNodePolicy shouldn't be deleted"))
 
 	ok, _, err = validateSriovNetworkNodePolicy(policy, "UPDATE")
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Opening this PR for discussion as it looks to me like the simplest way forward. I'm not sure how bad is it to delete the default CRs and if warning the user instead of blocking the user is sufficient.

---

This commit changes the behavior of the webhook when deleting the default `SriovNetworkNodePolicy` and `SriovOperatorConfig`. This change is needed so that we can smoothly uninstall Helm releases that have the webhooks enabled.

Without this change, when running `helm uninstall`, it fails because the webhook doesn't allow deletion of such resources mentioned above.

Since these Webhook Configurations resources are deployed via the controller itself and not Helm, it's much more difficult to handle the lifecycle of them via Helm in the current state. Instead, it's easier to send a warning that these resources should not be deleted.

### Testing

Used Case 5 of https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/561 and managed to install and uninstall without any issue. `helm uninstall` log looks like this:
```
...
client.go:310: [debug] Starting delete for "default" SriovNetworkNodePolicy
W1227 13:20:14.885788  123736 warnings.go:70] default SriovNetworkNodePolicy shouldn't be deleted
client.go:310: [debug] Starting delete for "default" SriovOperatorConfig
W1227 13:20:15.078219  123736 warnings.go:70] default SriovOperatorConfig shouldn't be deleted
...
```