### PR TITLE
Externally managed fixes

### DIFF
--- a/pkg/daemon/plugin.go
+++ b/pkg/daemon/plugin.go
@@ -82,7 +82,9 @@ func registerVendorPlugins(ns *sriovnetworkv1.SriovNetworkNodeState, helpers hel
 				log.Log.Error(err, "registerVendorPlugins(): failed to load plugin", "plugin-name", plug.Name())
 				return vendorPlugins, fmt.Errorf("registerVendorPlugins(): failed to load the %s plugin error: %v", plug.Name(), err)
 			}
-			vendorPlugins[plug.Name()] = plug
+			if _, ok := vendorPlugins[plug.Name()]; !ok {
+				vendorPlugins[plug.Name()] = plug
+			}
 		}
 	}
 

--- a/pkg/host/sriov.go
+++ b/pkg/host/sriov.go
@@ -343,6 +343,12 @@ func (s *sriov) ConfigSriovDevice(iface *sriovnetworkv1.Interface, ifaceStatus *
 	}
 	// set PF mtu
 	if iface.Mtu > 0 && iface.Mtu > ifaceStatus.Mtu {
+		if iface.ExternallyManaged {
+			err := fmt.Errorf("ConfigSriovDevice(): requested MTU(%d) is greater than configured MTU(%d) for device %s. cannot change MTU as policy is configured as ExternallyManaged",
+				iface.Mtu, ifaceStatus.Mtu, iface.PciAddress)
+			log.Log.Error(nil, err.Error())
+			return err
+		}
 		err = s.networkHelper.SetNetdevMTU(iface.PciAddress, iface.Mtu)
 		if err != nil {
 			log.Log.Error(err, "configSriovDevice(): fail to set mtu for PF", "device", iface.PciAddress)


### PR DESCRIPTION
- block mtu change on PF when externally managed
- fix handling in mellanox plugin for externally managed interfaces