### PR TITLE
Extend Makefile to build webhook image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ IMAGE_BUILDER?=docker
 IMAGE_BUILD_OPTS?=
 DOCKERFILE?=Dockerfile
 DOCKERFILE_CONFIG_DAEMON?=Dockerfile.sriov-network-config-daemon
+DOCKERFILE_WEBHOOK?=Dockerfile.webhook
 
 CRD_BASES=./config/crd/bases
 
@@ -22,6 +23,7 @@ TARGET=$(TARGET_DIR)/bin/$(APP_NAME)
 IMAGE_REPO?=ghcr.io/k8snetworkplumbingwg
 IMAGE_TAG?=$(IMAGE_REPO)/$(APP_NAME):latest
 CONFIG_DAEMON_IMAGE_TAG?=$(IMAGE_REPO)/sriov-network-config-daemon:latest
+WEBHOOK_IMAGE_TAG?=$(IMAGE_REPO)/$(APP_NAME)-webhook:latest
 MAIN_PKG=cmd/manager/main.go
 export NAMESPACE?=openshift-sriov-network-operator
 export WATCH_NAMESPACE?=openshift-sriov-network-operator
@@ -71,6 +73,7 @@ update-codegen:
 image: ; $(info Building image...)
 	$(IMAGE_BUILDER) build -f $(DOCKERFILE) -t $(IMAGE_TAG) $(CURPATH) $(IMAGE_BUILD_OPTS)
 	$(IMAGE_BUILDER) build -f $(DOCKERFILE_CONFIG_DAEMON) -t $(CONFIG_DAEMON_IMAGE_TAG) $(CURPATH) $(IMAGE_BUILD_OPTS)
+	$(IMAGE_BUILDER) build -f $(DOCKERFILE_WEBHOOK) -t $(WEBHOOK_IMAGE_TAG) $(CURPATH) $(IMAGE_BUILD_OPTS)
 
 # Run tests
 test: generate vet manifests envtest


### PR DESCRIPTION
We already build the webhook under the `build` make target but we are not creating an image for it under the `image` make target. This PR introduces that.