### PR TITLE
Update Helm chart kubeVersion check

### DIFF
--- a/deployment/sriov-network-operator/Chart.yaml
+++ b/deployment/sriov-network-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sriov-network-operator
 version: 0.1.0
-kubeVersion: '>= 1.16.0'
+kubeVersion: '>= 1.16.0-0'
 appVersion: 1.2.0
 description: SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster
 type: application


### PR DESCRIPTION
Change the `kubeVersion` constraint to permit pre-release versions as per: https://helm.sh/docs/chart_template_guide/function_list/#working-with-prerelease-versions

Without this change, if I attempt to install the helm chart into k8s version `v1.27.1-3443+19254894103e33-dirty`  I see this error:
```
Error: INSTALLATION FAILED: chart requires kubeVersion: >= 1.16.0 which is incompatible with Kubernetes v1.27.1-3443+19254894103e33-dirty
```