### PR TITLE
[switchdev 1/x] Add additional methods to host/kernel.go

### DIFF
--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -77,13 +77,16 @@ const (
 	CheckpointFileName = "sno-initial-node-state.json"
 	Unknown            = "Unknown"
 
-	SysBusPciDevices      = "/sys/bus/pci/devices"
-	SysBusPciDrivers      = "/sys/bus/pci/drivers"
-	SysBusPciDriversProbe = "/sys/bus/pci/drivers_probe"
+	SysBus                = "/sys/bus"
+	SysBusPciDevices      = SysBus + "/pci/devices"
+	SysBusPciDrivers      = SysBus + "/pci/drivers"
+	SysBusPciDriversProbe = SysBus + "/pci/drivers_probe"
 	SysClassNet           = "/sys/class/net"
 	ProcKernelCmdLine     = "/proc/cmdline"
 	NetClass              = 0x02
 	NumVfsFile            = "sriov_numvfs"
+	BusPci                = "pci"
+	BusVdpa               = "vdpa"
 
 	UdevFolder          = "/etc/udev"
 	UdevRulesFolder     = UdevFolder + "/rules.d"

--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -81,6 +81,20 @@ func (mr *MockHostHelpersInterfaceMockRecorder) BindDpdkDriver(arg0, arg1 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindDpdkDriver", reflect.TypeOf((*MockHostHelpersInterface)(nil).BindDpdkDriver), arg0, arg1)
 }
 
+// BindDriverByBusAndDevice mocks base method.
+func (m *MockHostHelpersInterface) BindDriverByBusAndDevice(arg0, arg1, arg2 string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BindDriverByBusAndDevice", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BindDriverByBusAndDevice indicates an expected call of BindDriverByBusAndDevice.
+func (mr *MockHostHelpersInterfaceMockRecorder) BindDriverByBusAndDevice(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindDriverByBusAndDevice", reflect.TypeOf((*MockHostHelpersInterface)(nil).BindDriverByBusAndDevice), arg0, arg1, arg2)
+}
+
 // Chroot mocks base method.
 func (m *MockHostHelpersInterface) Chroot(arg0 string) (func() error, error) {
 	m.ctrl.T.Helper()
@@ -992,6 +1006,20 @@ func (m *MockHostHelpersInterface) Unbind(arg0 string) error {
 func (mr *MockHostHelpersInterfaceMockRecorder) Unbind(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unbind", reflect.TypeOf((*MockHostHelpersInterface)(nil).Unbind), arg0)
+}
+
+// UnbindDriverByBusAndDevice mocks base method.
+func (m *MockHostHelpersInterface) UnbindDriverByBusAndDevice(bus, device string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnbindDriverByBusAndDevice", bus, device)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UnbindDriverByBusAndDevice indicates an expected call of UnbindDriverByBusAndDevice.
+func (mr *MockHostHelpersInterfaceMockRecorder) UnbindDriverByBusAndDevice(bus, device interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnbindDriverByBusAndDevice", reflect.TypeOf((*MockHostHelpersInterface)(nil).UnbindDriverByBusAndDevice), bus, device)
 }
 
 // UnbindDriverIfNeeded mocks base method.

--- a/pkg/host/kernel_test.go
+++ b/pkg/host/kernel_test.go
@@ -1,0 +1,216 @@
+package host
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/fakefilesystem"
+)
+
+func assertFileContentsEquals(path, expectedContent string) {
+	d, err := os.ReadFile(filepath.Join(vars.FilesystemRoot, path))
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, string(d)).To(Equal(expectedContent))
+}
+
+var _ = Describe("Kernel", func() {
+	Context("Drivers", func() {
+		var (
+			k KernelInterface
+		)
+		configureFS := func(f *fakefilesystem.FS) {
+			var (
+				cleanFakeFs func()
+				err         error
+			)
+			vars.FilesystemRoot, cleanFakeFs, err = f.Use()
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(cleanFakeFs)
+		}
+		BeforeEach(func() {
+			k = newKernelInterface(nil)
+		})
+		Context("Unbind, UnbindDriverByBusAndDevice", func() {
+			It("unknown device", func() {
+				Expect(k.UnbindDriverByBusAndDevice(consts.BusPci, "unknown-dev")).NotTo(HaveOccurred())
+			})
+			It("known device, no driver", func() {
+				configureFS(&fakefilesystem.FS{Dirs: []string{"/sys/bus/pci/devices/0000:d8:00.0"}})
+				Expect(k.Unbind("0000:d8:00.0")).NotTo(HaveOccurred())
+			})
+			It("has driver, succeed", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0",
+						"/sys/bus/pci/drivers/test-driver"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/test-driver"},
+					Files: map[string][]byte{
+						"/sys/bus/pci/drivers/test-driver/unbind": {}},
+				})
+				Expect(k.Unbind("0000:d8:00.0")).NotTo(HaveOccurred())
+				// check that echo to unbind path was done
+				assertFileContentsEquals("/sys/bus/pci/drivers/test-driver/unbind", "0000:d8:00.0")
+			})
+			It("has driver, failed to unbind", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/test-driver"},
+				})
+				Expect(k.Unbind("0000:d8:00.0")).To(HaveOccurred())
+			})
+		})
+		Context("HasDriver", func() {
+			It("unknown device", func() {
+				has, driver := k.HasDriver("unknown-dev")
+				Expect(has).To(BeFalse())
+				Expect(driver).To(BeEmpty())
+			})
+			It("known device, no driver", func() {
+				configureFS(&fakefilesystem.FS{Dirs: []string{"/sys/bus/pci/devices/0000:d8:00.0"}})
+				has, driver := k.HasDriver("0000:d8:00.0")
+				Expect(has).To(BeFalse())
+				Expect(driver).To(BeEmpty())
+			})
+			It("has driver", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0",
+						"/sys/bus/pci/drivers/test-driver"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/test-driver"},
+				})
+				has, driver := k.HasDriver("0000:d8:00.0")
+				Expect(has).To(BeTrue())
+				Expect(driver).To(Equal("test-driver"))
+			})
+		})
+		Context("BindDefaultDriver", func() {
+			It("unknown device", func() {
+				Expect(k.BindDefaultDriver("unknown-dev")).To(HaveOccurred())
+			})
+			It("no driver", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0"},
+					Files: map[string][]byte{
+						"/sys/bus/pci/drivers_probe": {}, "/sys/bus/pci/devices/0000:d8:00.0/driver_override": {}},
+				})
+				Expect(k.BindDefaultDriver("0000:d8:00.0")).NotTo(HaveOccurred())
+				// should probe driver for dev
+				assertFileContentsEquals("/sys/bus/pci/drivers_probe", "0000:d8:00.0")
+			})
+			It("already bind to default driver", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/test-driver"},
+				})
+				Expect(k.BindDefaultDriver("0000:d8:00.0")).NotTo(HaveOccurred())
+			})
+			It("bind to dpdk driver", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0",
+						"/sys/bus/pci/drivers/vfio-pci"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/vfio-pci"},
+					Files: map[string][]byte{
+						"/sys/bus/pci/drivers_probe":           {},
+						"/sys/bus/pci/drivers/vfio-pci/unbind": {}},
+				})
+				Expect(k.BindDefaultDriver("0000:d8:00.0")).NotTo(HaveOccurred())
+				// should unbind from dpdk driver
+				assertFileContentsEquals("/sys/bus/pci/drivers/vfio-pci/unbind", "0000:d8:00.0")
+				// should probe driver for dev
+				assertFileContentsEquals("/sys/bus/pci/drivers_probe", "0000:d8:00.0")
+			})
+		})
+		Context("BindDpdkDriver", func() {
+			It("unknown device", func() {
+				Expect(k.BindDpdkDriver("unknown-dev", "vfio-pci")).To(HaveOccurred())
+			})
+			It("no driver", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0",
+						"/sys/bus/pci/drivers/vfio-pci"},
+					Files: map[string][]byte{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver_override": {}},
+				})
+				Expect(k.BindDpdkDriver("0000:d8:00.0", "vfio-pci")).NotTo(HaveOccurred())
+				// should reset driver override
+				assertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/driver_override", "\x00")
+			})
+			It("already bind to required driver", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/vfio-pci"},
+				})
+				Expect(k.BindDpdkDriver("0000:d8:00.0", "vfio-pci")).NotTo(HaveOccurred())
+			})
+			It("bind to wrong driver", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0",
+						"/sys/bus/pci/drivers/test-driver",
+						"/sys/bus/pci/drivers/vfio-pci"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/test-driver"},
+					Files: map[string][]byte{
+						"/sys/bus/pci/drivers/test-driver/unbind":           {},
+						"/sys/bus/pci/drivers/vfio-pci/bind":                {},
+						"/sys/bus/pci/devices/0000:d8:00.0/driver_override": {}},
+				})
+				Expect(k.BindDpdkDriver("0000:d8:00.0", "vfio-pci")).NotTo(HaveOccurred())
+				// should unbind from driver1
+				assertFileContentsEquals("/sys/bus/pci/drivers/test-driver/unbind", "0000:d8:00.0")
+				// should bind to driver2
+				assertFileContentsEquals("/sys/bus/pci/drivers/vfio-pci/bind", "0000:d8:00.0")
+			})
+			It("fail to bind", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0",
+						"/sys/bus/pci/drivers/test-driver"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/test-driver"},
+					Files: map[string][]byte{
+						"/sys/bus/pci/drivers/test-driver/unbind":           {},
+						"/sys/bus/pci/devices/0000:d8:00.0/driver_override": {}},
+				})
+				Expect(k.BindDpdkDriver("0000:d8:00.0", "vfio-pci")).To(HaveOccurred())
+			})
+		})
+		Context("BindDriverByBusAndDevice", func() {
+			It("device doesn't support driver_override", func() {
+				configureFS(&fakefilesystem.FS{
+					Dirs: []string{
+						"/sys/bus/pci/devices/0000:d8:00.0",
+						"/sys/bus/pci/drivers/test-driver",
+						"/sys/bus/pci/drivers/vfio-pci"},
+					Symlinks: map[string]string{
+						"/sys/bus/pci/devices/0000:d8:00.0/driver": "../../../../bus/pci/drivers/test-driver"},
+					Files: map[string][]byte{
+						"/sys/bus/pci/drivers/test-driver/unbind": {},
+						"/sys/bus/pci/drivers/vfio-pci/bind":      {}},
+				})
+				Expect(k.BindDriverByBusAndDevice(consts.BusPci, "0000:d8:00.0", "vfio-pci")).NotTo(HaveOccurred())
+				// should unbind from driver1
+				assertFileContentsEquals("/sys/bus/pci/drivers/test-driver/unbind", "0000:d8:00.0")
+				// should bind to driver2
+				assertFileContentsEquals("/sys/bus/pci/drivers/vfio-pci/bind", "0000:d8:00.0")
+			})
+		})
+	})
+})

--- a/pkg/host/suite_test.go
+++ b/pkg/host/suite_test.go
@@ -1,0 +1,21 @@
+package host
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestHostManager(t *testing.T) {
+	log.SetLogger(zap.New(
+		zap.WriteTo(GinkgoWriter),
+		zap.Level(zapcore.Level(-2)),
+		zap.UseDevMode(true)))
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Package Host Suite")
+}


### PR DESCRIPTION
New methods are:
* BindDriverByBusAndDevice - binds device to the provided driver
* UnbindDriverByBusAndDevice unbind device identified by bus and device ID from the driver

Both methods allows to work with devices not
only on PCI bus.

+refactor driver-related methods
+add unit-tests for changed methods

Context: 
- part of [switchdev refactoring](https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/559)
- these changes are required to configure drivers for VDPA devices. VDPA device are on `/sys/bus/vdpa`, not on `/sys/bus/pci`