### PR TITLE
[switchdev 2/x] API: Add vdpaType field to the node SriovNetworkNodeState CRD

### DIFF
--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -82,6 +82,7 @@ type VirtualFunction struct {
 	Vlan       int    `json:"Vlan,omitempty"`
 	Mtu        int    `json:"mtu,omitempty"`
 	VfID       int    `json:"vfID"`
+	VdpaType   string `json:"vdpaType,omitempty"`
 }
 
 // SriovNetworkNodeStateStatus defines the observed state of SriovNetworkNodeState

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -112,6 +112,8 @@ spec:
                             type: string
                           pciAddress:
                             type: string
+                          vdpaType:
+                            type: string
                           vendor:
                             type: string
                           vfID:

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -112,6 +112,8 @@ spec:
                             type: string
                           pciAddress:
                             type: string
+                          vdpaType:
+                            type: string
                           vendor:
                             type: string
                           vfID:


### PR DESCRIPTION
This field should be used to report information about type of the VDPA device that is configured for VF.
Empty string means that there is no VDPA device.

Valid values are: `virtio`, `vhost` (same as in `SriovNetworkNodePolicySpec`)

Context:

- part of [switchdev refactoring](https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/559)