### PR TITLE
Add more checks on generic plugin to discover discrepancies from the desired state

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -273,7 +273,7 @@ func NeedToUpdateSriov(ifaceSpec *Interface, ifaceStatus *InterfaceExt) bool {
 		return true
 	}
 
-	if ifaceStatus.LinkAdminState == "down" {
+	if ifaceStatus.LinkAdminState == consts.LinkAdminStateDown {
 		log.V(2).Info("NeedToUpdateSriov(): PF link status needs update", "desired to include", "up", "current", ifaceStatus.LinkAdminState)
 		return true
 	}

--- a/api/v1/sriovnetworknodestate_types.go
+++ b/api/v1/sriovnetworknodestate_types.go
@@ -64,6 +64,7 @@ type InterfaceExt struct {
 	NumVfs            int               `json:"numVfs,omitempty"`
 	LinkSpeed         string            `json:"linkSpeed,omitempty"`
 	LinkType          string            `json:"linkType,omitempty"`
+	LinkAdminState    string            `json:"linkAdminState,omitempty"`
 	EswitchMode       string            `json:"eSwitchMode,omitempty"`
 	ExternallyManaged bool              `json:"externallyManaged,omitempty"`
 	TotalVfs          int               `json:"totalvfs,omitempty"`
@@ -84,6 +85,7 @@ type VirtualFunction struct {
 	VfID            int    `json:"vfID"`
 	VdpaType        string `json:"vdpaType,omitempty"`
 	RepresentorName string `json:"representorName,omitempty"`
+	GUID            string `json:"guid,omitempty"`
 }
 
 // Bridges contains list of bridges

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -268,6 +268,8 @@ spec:
                             type: string
                           driver:
                             type: string
+                          guid:
+                            type: string
                           mac:
                             type: string
                           mtu:
@@ -297,6 +299,8 @@ spec:
                       type: string
                     externallyManaged:
                       type: boolean
+                    linkAdminState:
+                      type: string
                     linkSpeed:
                       type: string
                     linkType:

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -268,6 +268,8 @@ spec:
                             type: string
                           driver:
                             type: string
+                          guid:
+                            type: string
                           mac:
                             type: string
                           mtu:
@@ -297,6 +299,8 @@ spec:
                       type: string
                     externallyManaged:
                       type: boolean
+                    linkAdminState:
+                      type: string
                     linkSpeed:
                       type: string
                     linkType:

--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -43,6 +43,9 @@ const (
 	LinkTypeIB  = "IB"
 	LinkTypeETH = "ETH"
 
+	LinkAdminStateUp   = "up"
+	LinkAdminStateDown = "down"
+
 	UninitializedNodeGUID = "0000:0000:0000:0000"
 
 	DeviceTypeVfioPci   = "vfio-pci"

--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -43,6 +43,8 @@ const (
 	LinkTypeIB  = "IB"
 	LinkTypeETH = "ETH"
 
+	UninitializedNodeGUID = "0000:0000:0000:0000"
+
 	DeviceTypeVfioPci   = "vfio-pci"
 	DeviceTypeNetDevice = "netdevice"
 	VdpaTypeVirtio      = "virtio"

--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -415,6 +415,20 @@ func (mr *MockHostHelpersInterfaceMockRecorder) GetMlxNicFwData(pciAddress inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMlxNicFwData", reflect.TypeOf((*MockHostHelpersInterface)(nil).GetMlxNicFwData), pciAddress)
 }
 
+// GetNetDevLinkAdminState mocks base method.
+func (m *MockHostHelpersInterface) GetNetDevLinkAdminState(ifaceName string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetDevLinkAdminState", ifaceName)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNetDevLinkAdminState indicates an expected call of GetNetDevLinkAdminState.
+func (mr *MockHostHelpersInterfaceMockRecorder) GetNetDevLinkAdminState(ifaceName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetDevLinkAdminState", reflect.TypeOf((*MockHostHelpersInterface)(nil).GetNetDevLinkAdminState), ifaceName)
+}
+
 // GetNetDevLinkSpeed mocks base method.
 func (m *MockHostHelpersInterface) GetNetDevLinkSpeed(name string) string {
 	m.ctrl.T.Helper()
@@ -441,6 +455,20 @@ func (m *MockHostHelpersInterface) GetNetDevMac(name string) string {
 func (mr *MockHostHelpersInterfaceMockRecorder) GetNetDevMac(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetDevMac", reflect.TypeOf((*MockHostHelpersInterface)(nil).GetNetDevMac), name)
+}
+
+// GetNetDevNodeGUID mocks base method.
+func (m *MockHostHelpersInterface) GetNetDevNodeGUID(pciAddr string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetDevNodeGUID", pciAddr)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNetDevNodeGUID indicates an expected call of GetNetDevNodeGUID.
+func (mr *MockHostHelpersInterfaceMockRecorder) GetNetDevNodeGUID(pciAddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetDevNodeGUID", reflect.TypeOf((*MockHostHelpersInterface)(nil).GetNetDevNodeGUID), pciAddr)
 }
 
 // GetNetdevMTU mocks base method.

--- a/pkg/host/internal/lib/netlink/mock/mock_netlink.go
+++ b/pkg/host/internal/lib/netlink/mock/mock_netlink.go
@@ -230,6 +230,21 @@ func (mr *MockNetlinkLibMockRecorder) LinkSetVfPortGUID(link, vf, portguid inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetVfPortGUID", reflect.TypeOf((*MockNetlinkLib)(nil).LinkSetVfPortGUID), link, vf, portguid)
 }
 
+// RdmaLinkByName mocks base method.
+func (m *MockNetlinkLib) RdmaLinkByName(name string) (*netlink0.RdmaLink, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RdmaLinkByName", name)
+	ret0, _ := ret[0].(*netlink0.RdmaLink)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RdmaLinkByName indicates an expected call of RdmaLinkByName.
+func (mr *MockNetlinkLibMockRecorder) RdmaLinkByName(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RdmaLinkByName", reflect.TypeOf((*MockNetlinkLib)(nil).RdmaLinkByName), name)
+}
+
 // VDPADelDev mocks base method.
 func (m *MockNetlinkLib) VDPADelDev(name string) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/internal/lib/netlink/mock/mock_netlink.go
+++ b/pkg/host/internal/lib/netlink/mock/mock_netlink.go
@@ -145,6 +145,20 @@ func (mr *MockNetlinkLibMockRecorder) DevlinkSetDeviceParam(bus, device, param, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DevlinkSetDeviceParam", reflect.TypeOf((*MockNetlinkLib)(nil).DevlinkSetDeviceParam), bus, device, param, cmode, value)
 }
 
+// IsLinkAdminStateUp mocks base method.
+func (m *MockNetlinkLib) IsLinkAdminStateUp(link netlink.Link) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsLinkAdminStateUp", link)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsLinkAdminStateUp indicates an expected call of IsLinkAdminStateUp.
+func (mr *MockNetlinkLibMockRecorder) IsLinkAdminStateUp(link interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsLinkAdminStateUp", reflect.TypeOf((*MockNetlinkLib)(nil).IsLinkAdminStateUp), link)
+}
+
 // LinkByName mocks base method.
 func (m *MockNetlinkLib) LinkByName(name string) (netlink.Link, error) {
 	m.ctrl.T.Helper()

--- a/pkg/host/internal/lib/netlink/netlink.go
+++ b/pkg/host/internal/lib/netlink/netlink.go
@@ -61,6 +61,8 @@ type NetlinkLib interface {
 	// RdmaLinkByName finds a link by name and returns a pointer to the object if
 	// found and nil error, otherwise returns error code.
 	RdmaLinkByName(name string) (*netlink.RdmaLink, error)
+	// IsLinkAdminStateUp checks if the admin state of a link is up
+	IsLinkAdminStateUp(link Link) bool
 }
 
 type libWrapper struct{}
@@ -150,4 +152,9 @@ func (w *libWrapper) DevlinkSetDeviceParam(bus string, device string, param stri
 // found and nil error, otherwise returns error code.
 func (w *libWrapper) RdmaLinkByName(name string) (*netlink.RdmaLink, error) {
 	return netlink.RdmaLinkByName(name)
+}
+
+// IsLinkAdminStateUp checks if the admin state of a link is up
+func (w *libWrapper) IsLinkAdminStateUp(link Link) bool {
+	return link.Attrs().Flags&net.FlagUp == 1
 }

--- a/pkg/host/internal/lib/netlink/netlink.go
+++ b/pkg/host/internal/lib/netlink/netlink.go
@@ -58,6 +58,9 @@ type NetlinkLib interface {
 	// cmode argument should contain valid cmode value as uint8, modes are define in nl.DEVLINK_PARAM_CMODE_* constants
 	// value argument should have one of the following types: uint8, uint16, uint32, string, bool
 	DevlinkSetDeviceParam(bus string, device string, param string, cmode uint8, value interface{}) error
+	// RdmaLinkByName finds a link by name and returns a pointer to the object if
+	// found and nil error, otherwise returns error code.
+	RdmaLinkByName(name string) (*netlink.RdmaLink, error)
 }
 
 type libWrapper struct{}
@@ -141,4 +144,10 @@ func (w *libWrapper) DevlinkGetDeviceParamByName(bus string, device string, para
 // value argument should have one of the following types: uint8, uint16, uint32, string, bool
 func (w *libWrapper) DevlinkSetDeviceParam(bus string, device string, param string, cmode uint8, value interface{}) error {
 	return netlink.DevlinkSetDeviceParam(bus, device, param, cmode, value)
+}
+
+// RdmaLinkByName finds a link by name and returns a pointer to the object if
+// found and nil error, otherwise returns error code.
+func (w *libWrapper) RdmaLinkByName(name string) (*netlink.RdmaLink, error) {
+	return netlink.RdmaLinkByName(name)
 }

--- a/pkg/host/internal/network/network.go
+++ b/pkg/host/internal/network/network.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -375,9 +374,9 @@ func (n *network) GetNetDevLinkAdminState(ifaceName string) string {
 		return ""
 	}
 
-	if link.Attrs().Flags&net.FlagUp == 0 {
-		return "down"
+	if n.netlinkLib.IsLinkAdminStateUp(link) {
+		return consts.LinkAdminStateUp
 	}
 
-	return "up"
+	return consts.LinkAdminStateDown
 }

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -3,7 +3,6 @@ package sriov
 import (
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -574,7 +573,7 @@ func (s *sriov) configSriovDevice(iface *sriovnetworkv1.Interface, skipVFConfigu
 	if err != nil {
 		return err
 	}
-	if pfLink.Attrs().Flags&net.FlagUp == 0 {
+	if !s.netlinkLib.IsLinkAdminStateUp(pfLink) {
 		err = s.netlinkLib.LinkSetUp(pfLink)
 		if err != nil {
 			return err

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -120,7 +120,8 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(3)
-			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{OperState: netlink.OperDown, EncapType: "ether"}).Times(2)
+			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Flags: 0, EncapType: "ether"})
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
@@ -187,7 +188,7 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
-			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{OperState: netlink.OperDown})
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
@@ -240,7 +241,7 @@ var _ = Describe("SRIOV", func() {
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).Times(2)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
 			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
-			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{OperState: netlink.OperDown})
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
 				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)

--- a/pkg/host/mock/mock_host.go
+++ b/pkg/host/mock/mock_host.go
@@ -339,6 +339,20 @@ func (mr *MockHostManagerInterfaceMockRecorder) GetLinkType(name interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLinkType", reflect.TypeOf((*MockHostManagerInterface)(nil).GetLinkType), name)
 }
 
+// GetNetDevLinkAdminState mocks base method.
+func (m *MockHostManagerInterface) GetNetDevLinkAdminState(ifaceName string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetDevLinkAdminState", ifaceName)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNetDevLinkAdminState indicates an expected call of GetNetDevLinkAdminState.
+func (mr *MockHostManagerInterfaceMockRecorder) GetNetDevLinkAdminState(ifaceName interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetDevLinkAdminState", reflect.TypeOf((*MockHostManagerInterface)(nil).GetNetDevLinkAdminState), ifaceName)
+}
+
 // GetNetDevLinkSpeed mocks base method.
 func (m *MockHostManagerInterface) GetNetDevLinkSpeed(name string) string {
 	m.ctrl.T.Helper()
@@ -365,6 +379,20 @@ func (m *MockHostManagerInterface) GetNetDevMac(name string) string {
 func (mr *MockHostManagerInterfaceMockRecorder) GetNetDevMac(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetDevMac", reflect.TypeOf((*MockHostManagerInterface)(nil).GetNetDevMac), name)
+}
+
+// GetNetDevNodeGUID mocks base method.
+func (m *MockHostManagerInterface) GetNetDevNodeGUID(pciAddr string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNetDevNodeGUID", pciAddr)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNetDevNodeGUID indicates an expected call of GetNetDevNodeGUID.
+func (mr *MockHostManagerInterfaceMockRecorder) GetNetDevNodeGUID(pciAddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNetDevNodeGUID", reflect.TypeOf((*MockHostManagerInterface)(nil).GetNetDevNodeGUID), pciAddr)
 }
 
 // GetNetdevMTU mocks base method.

--- a/pkg/host/types/interfaces.go
+++ b/pkg/host/types/interfaces.go
@@ -94,6 +94,8 @@ type NetworkInterface interface {
 	SetNetdevMTU(pciAddr string, mtu int) error
 	// GetNetDevMac returns the network interface mac address
 	GetNetDevMac(name string) string
+	// GetNetDevNodeGUID returns the network interface node GUID if device is RDMA capable otherwise returns empty string
+	GetNetDevNodeGUID(pciAddr string) string
 	// GetNetDevLinkSpeed returns the network interface link speed
 	GetNetDevLinkSpeed(name string) string
 	// GetDevlinkDeviceParam returns devlink parameter for the device as a string, if the parameter has multiple values
@@ -105,6 +107,8 @@ type NetworkInterface interface {
 	SetDevlinkDeviceParam(pciAddr, paramName, value string) error
 	// EnableHwTcOffload make sure that hw-tc-offload feature is enabled if device supports it
 	EnableHwTcOffload(ifaceName string) error
+	// GetNetDevLinkAdminState returns the admin state of the interface.
+	GetNetDevLinkAdminState(ifaceName string) string
 }
 
 type ServiceInterface interface {

--- a/pkg/plugins/generic/generic_plugin_test.go
+++ b/pkg/plugins/generic/generic_plugin_test.go
@@ -53,18 +53,19 @@ var _ = Describe("Generic plugin", func() {
 				},
 				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
 					Interfaces: sriovnetworkv1.InterfaceExts{{
-						PciAddress:  "0000:00:00.0",
-						NumVfs:      1,
-						TotalVfs:    1,
-						DeviceID:    "1015",
-						Vendor:      "15b3",
-						Name:        "sriovif1",
-						Mtu:         1500,
-						Mac:         "0c:42:a1:55:ee:46",
-						Driver:      "mlx5_core",
-						EswitchMode: "legacy",
-						LinkSpeed:   "25000 Mb/s",
-						LinkType:    "ETH",
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
 						VFs: []sriovnetworkv1.VirtualFunction{{
 							PciAddress: "0000:00:00.1",
 							DeviceID:   "1016",
@@ -84,7 +85,255 @@ var _ = Describe("Generic plugin", func() {
 			Expect(needDrain).To(BeFalse())
 		})
 
-		It("should drain", func() {
+		It("should drain because MTU value has changed on PF", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            300, // Bad MTU value, changed by the user application
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Mac:        "8e:d6:2c:62:87:1b",
+							Driver:     "mlx5_core",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should drain because numVFs value has changed on PF", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         2, // Bad numVFs value, changed by the user application
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Mac:        "8e:d6:2c:62:87:1b",
+							Driver:     "mlx5_core",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should drain because PF link is down", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "IB",
+						LinkAdminState: "down",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should not drain if PF link is not down", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "IB",
+						LinkAdminState: "",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeFalse())
+		})
+
+		It("should drain because driver has changed on VF of type netdevice", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Mac:        "8e:d6:2c:62:87:1b",
+							Driver:     "igb_uio", // The user has requested netdevice == mlx5_core
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should drain because MTU value has changed on VF of type netdevice", func() {
 			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
 				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
 					Interfaces: sriovnetworkv1.Interfaces{{
@@ -101,18 +350,19 @@ var _ = Describe("Generic plugin", func() {
 				},
 				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
 					Interfaces: sriovnetworkv1.InterfaceExts{{
-						PciAddress:  "0000:00:00.0",
-						NumVfs:      2,
-						TotalVfs:    2,
-						DeviceID:    "1015",
-						Vendor:      "15b3",
-						Name:        "sriovif1",
-						Mtu:         1500,
-						Mac:         "0c:42:a1:55:ee:46",
-						Driver:      "mlx5_core",
-						EswitchMode: "legacy",
-						LinkSpeed:   "25000 Mb/s",
-						LinkType:    "ETH",
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         2,
+						TotalVfs:       2,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
 						VFs: []sriovnetworkv1.VirtualFunction{{
 							PciAddress: "0000:00:00.1",
 							DeviceID:   "1016",
@@ -127,6 +377,7 @@ var _ = Describe("Generic plugin", func() {
 							DeviceID:   "1016",
 							Vendor:     "15b3",
 							VfID:       0,
+							Mtu:        1500,
 							Driver:     "mlx5_core",
 						}},
 					}},
@@ -136,6 +387,362 @@ var _ = Describe("Generic plugin", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(needReboot).To(BeFalse())
 			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should drain because GUID address value is the default one on VF of type netdevice, rdma enabled and link type ETH", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+							IsRdma:       true,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+							Mac:        "0c:42:a1:55:ee:46",
+							GUID:       "0000:0000:0000:0000",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should not drain if GUID address value is not set on VF of type netdevice, rdma enabled and link type ETH", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+							IsRdma:       true,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+							Mac:        "0c:42:a1:55:ee:46",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeFalse())
+		})
+
+		It("should not drain if GUID address value is the default one on VF of type netdevice, rdma disabled and link type ETH", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+							Mac:        "0c:42:a1:55:ee:46",
+							GUID:       "0000:0000:0000:0000",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeFalse())
+		})
+
+		It("should drain because GUID address value is the default one on VF of type netdevice and link type IB", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "IB",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+							GUID:       "0000:0000:0000:0000",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should not drain if GUID address value is not set on VF of type netdevice and link type IB", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "IB",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeFalse())
+		})
+
+		It("should drain because GUID address value is the default one on VF of type netdevice, rdma enabled and link type ETH", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+							IsRdma:       true,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+							Mac:        "0c:42:a1:55:ee:46",
+							GUID:       "0000:0000:0000:0000",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeTrue())
+		})
+
+		It("should not drain if GUID address value is not set on VF of type netdevice, rdma enabled and link type ETH", func() {
+			networkNodeState := &sriovnetworkv1.SriovNetworkNodeState{
+				Spec: sriovnetworkv1.SriovNetworkNodeStateSpec{
+					Interfaces: sriovnetworkv1.Interfaces{{
+						PciAddress: "0000:00:00.0",
+						NumVfs:     1,
+						Mtu:        1500,
+						VfGroups: []sriovnetworkv1.VfGroup{{
+							DeviceType:   "netdevice",
+							PolicyName:   "policy-1",
+							ResourceName: "resource-1",
+							VfRange:      "0-1",
+							Mtu:          1500,
+							IsRdma:       true,
+						}}}},
+				},
+				Status: sriovnetworkv1.SriovNetworkNodeStateStatus{
+					Interfaces: sriovnetworkv1.InterfaceExts{{
+						PciAddress:     "0000:00:00.0",
+						NumVfs:         1,
+						TotalVfs:       1,
+						DeviceID:       "1015",
+						Vendor:         "15b3",
+						Name:           "sriovif1",
+						Mtu:            1500,
+						Mac:            "0c:42:a1:55:ee:46",
+						Driver:         "mlx5_core",
+						EswitchMode:    "legacy",
+						LinkSpeed:      "25000 Mb/s",
+						LinkType:       "ETH",
+						LinkAdminState: "up",
+						VFs: []sriovnetworkv1.VirtualFunction{{
+							PciAddress: "0000:00:00.1",
+							DeviceID:   "1016",
+							Vendor:     "15b3",
+							VfID:       0,
+							Name:       "sriovif1v0",
+							Mtu:        1500,
+							Driver:     "mlx5_core",
+							Mac:        "0c:42:a1:55:ee:46",
+						}},
+					}},
+				},
+			}
+
+			needDrain, needReboot, err := genericPlugin.OnNodeStateChange(networkNodeState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(needReboot).To(BeFalse())
+			Expect(needDrain).To(BeFalse())
 		})
 
 		It("should not detect changes on status", func() {


### PR DESCRIPTION
## Summary 

This PR does the following things:
* Adds additional test coverage for `OnNodeStateChange()` function to indicate when we are draining the node
* Adjusts `NeedToUpdateSriov()` helper function to ensure that:
  * VF MAC Address is set when we are in Ethernet mode
  * VF GUID is set when we are in Ethernet mode and RDMA is enabled
  * VF GUID is set when we are in Infiniband mode
  * PF Link is up
* (API Change) Adds necessary fields in the `SriovNetworkNodeState` struct to facilitate the above

## Partial Reconciliation

Today we reconcile on `.spec` change since we skip reconciliation if the generation of the object is the same as the object that was last reconciled successfully. Therefore, changes in `.status`, like what we try to detect with that PR, are not reconciled unless the `.spec` changes when the config daemon runs continuously (i.e. no restart). On daemon restart, the `.status` field will be reconciled the first time until the last successfully reconciled generation is saved in memory.

## Decisions

* Decided to add tests on the `OnNodeStateChange()` instead of `NeedToUpdateSriov()` because that one looks to be the most impactful for the whole system (i.e. decides whether to drain). I can add on both `Apply()` and `OnNodeStateChange()` if we choose to split the `NeedToUpdateSriov()` (see open questions below).
* Decided to just look for Node GUID and not the Port GUID since we expect both of them to be populated together on bind/unbind. This is the case because we parse the GUID from the RDMA link, and the node GUID is populated there on bind/unbind.

## Open questions

* [ ] Is it enough to partially reconcile or do we need to change the logic to take into account changes on `.status` (i.e. full reconciliation of changes that the controller does to the system)? (relatively big change in the operator behaviour I suppose)
* [ ] Do we need to drain on any of the discrepancies we find? (e.g. link is not up). If not, we will need to adjust the function that is used in `Apply()` and `OnNodeStateChange()` to be something different than `NeedToUpdateSriov()`.
* [ ] Are there additional end to end tests to be added? I would appreciate if you can point out the place I should be putting those (if we want to test end to end).
* [ ] Do we prefer getting info by reading directly `/sys/class/net/*` or use netlink? I see both approaches:
  * https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/09c987aaa8e5b1913f3306b3f889209e06adb8a1/pkg/host/network.go#L195-L205
  * https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/09c987aaa8e5b1913f3306b3f889209e06adb8a1/pkg/host/sriov.go#L618-L635
  Based on the answer I will use or discard https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/587/commits/d18aae1e1e975cdf9b5fca18172a1d0cafc9ca0e