### PR TITLE
re-enable mtu test on virtual cluster

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -1446,10 +1446,6 @@ var _ = Describe("[sriov] operator", func() {
 
 			Context("MTU", func() {
 				BeforeEach(func() {
-					if cluster.VirtualCluster() {
-						// https://bugzilla.redhat.com/show_bug.cgi?id=2214977
-						Skip("Bug in IGB driver")
-					}
 
 					var node string
 					resourceName := "mturesource"

--- a/test/util/pod/pod.go
+++ b/test/util/pod/pod.go
@@ -29,7 +29,11 @@ func GetDefinition() *corev1.Pod {
 		Spec: corev1.PodSpec{
 			TerminationGracePeriodSeconds: pointer.Int64Ptr(0),
 			Containers: []corev1.Container{{Name: "test",
-				Image:   images.Test(),
+				Image: images.Test(),
+				SecurityContext: &corev1.SecurityContext{
+					Capabilities: &corev1.Capabilities{
+						Add: []corev1.Capability{"NET_RAW"},
+					}},
 				Command: []string{"/bin/bash", "-c", "sleep INF"}}}}}
 
 	return podObject


### PR DESCRIPTION
QEMU 8.2.0 introduce a fix to the kernel panic
when allocation jumbo MTU so we can re-enable the test