### PR TITLE
e2e: Skip tests when no VF-IO devices are available

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -1071,7 +1071,9 @@ var _ = Describe("[sriov] operator", func() {
 					}
 
 					vfioNode, vfioNic = sriovInfos.FindOneVfioSriovDevice()
-					Expect(vfioNode).ToNot(Equal(""))
+					if vfioNode == "" {
+						Skip("skip test as no vfio-pci capable PF was found")
+					}
 					By("Using device " + vfioNic.Name + " on node " + vfioNode)
 				})
 
@@ -1108,20 +1110,20 @@ var _ = Describe("[sriov] operator", func() {
 			})
 
 			Context("PF Partitioning", func() {
-				var vfioNode string
-				var vfioNic sriovv1.InterfaceExt
-
 				// 27633
 				BeforeEach(func() {
 					if discovery.Enabled() {
 						Skip("Test unsuitable to be run in discovery mode")
 					}
-					vfioNode, vfioNic = sriovInfos.FindOneVfioSriovDevice()
-					Expect(vfioNode).ToNot(Equal(""))
-					By("Using device " + vfioNic.Name + " on node " + vfioNode)
 				})
 
 				It("Should be possible to partition the pf's vfs", func() {
+					vfioNode, vfioNic := sriovInfos.FindOneVfioSriovDevice()
+					if vfioNode == "" {
+						Skip("skip test as no vfio-pci capable PF was found")
+					}
+					By("Using device " + vfioNic.Name + " on node " + vfioNode)
+
 					_, err := network.CreateSriovPolicy(clients, "test-policy-", operatorNamespace, vfioNic.Name+"#2-4", vfioNode, 5, testResourceName, "netdevice")
 					Expect(err).ToNot(HaveOccurred())
 
@@ -2030,14 +2032,16 @@ var _ = Describe("[sriov] operator", func() {
 		Context("ExternallyManaged Validation", func() {
 			numVfs := 5
 			var node string
-			var nic sriovv1.InterfaceExt
+			var nic *sriovv1.InterfaceExt
 			externallyManage := func(policy *sriovv1.SriovNetworkNodePolicy) {
 				policy.Spec.ExternallyManaged = true
 			}
 
 			execute.BeforeAll(func() {
-				node, nic = sriovInfos.FindOneVfioSriovDevice()
-				Expect(node).ToNot(Equal(""))
+				var err error
+				node, nic, err = sriovInfos.FindOneSriovNodeAndDevice()
+				Expect(err).ToNot(HaveOccurred())
+
 				By("Using device " + nic.Name + " on node " + node)
 			})
 

--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -179,6 +180,24 @@ func (n *EnabledNodes) FindSriovDevicesIgnoreFilters(node string) ([]*sriovv1.In
 		}
 	}
 	return devices, nil
+}
+
+// FindOneSriovNodeAndDevice finds a cluster node with one SR-IOV devices respecting the `SRIOV_NODE_AND_DEVICE_NAME_FILTER` filter.
+func (n *EnabledNodes) FindOneSriovNodeAndDevice() (string, *sriovv1.InterfaceExt, error) {
+	errs := []error{}
+	for _, node := range n.Nodes {
+		devices, err := n.FindSriovDevices(node)
+		if err != nil {
+			errs = append(errs, err)
+			continue
+		}
+
+		if len(devices) > 0 {
+			return node, devices[0], nil
+		}
+	}
+
+	return "", nil, fmt.Errorf("can't find any SR-IOV devices in cluster's nodes: %w", errors.Join(errs...))
 }
 
 // FindOneVfioSriovDevice retrieves a node with a valid sriov device for vfio


### PR DESCRIPTION
Test cases in
```
... Create vfio-pci node policy Should be possible to create a vfio-pci resource
... PF Partitioning Should be possible to partition the pf's vfs
```

should be skipped if there are no available SR-IOV devices in the cluster that support vfio-pci mode.

Make `ExternallyManaged Validation` test cases don't need vfio-pci devices. Use a the function `FindOneSriovNodeAndDevice()` to less striclty discover NICs.

Refs:
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/commit/aeb60e2f64aa6f61d74613c68a3f7ba7cc520e3d