### PR TITLE
Optimize a request to find device plugin pods.

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -732,8 +732,9 @@ func (dn *Daemon) restartDevicePluginPod() error {
 
 	var podToDelete string
 	pods, err := dn.kubeClient.CoreV1().Pods(vars.Namespace).List(context.Background(), metav1.ListOptions{
-		LabelSelector: "app=sriov-device-plugin",
-		FieldSelector: "spec.nodeName=" + vars.NodeName,
+		LabelSelector:   "app=sriov-device-plugin",
+		FieldSelector:   "spec.nodeName=" + vars.NodeName,
+		ResourceVersion: "0",
 	})
 	if err != nil {
 		if errors.IsNotFound(err) {


### PR DESCRIPTION
Add a resourceVersion=0 to the reuqest to find device plugin pods on a given node from the latest cache from the kube-apiserver. Without a resourceVersion the request needs to reach etcd first and then kube-apiserver will filter out the pods.

Due to this etcd can get overloaded. Since it runs in daemonset, they get created on every node. If a cluster has a lot of nodes the list requests will put a cluster down.