### PR TITLE
[switchdev 4/x] split systemd service to two parts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
     - name: test pkg
       run: make test-pkg
 
+    - name: test cmd
+      run: make test-cmd
+
     - name: test controllers on opensfhit
       run: CLUSTER_TYPE=openshift make test-controllers
 
@@ -83,6 +86,9 @@ jobs:
 
     - name: test pkg
       run: make test-pkg
+
+    - name: test cmd
+      run: make test-cmd
 
     - name: test controllers on opensfhit
       run: CLUSTER_TYPE=openshift make test-controllers

--- a/bindata/manifests/sriov-config-service/kubernetes/sriov-config-post-network-service.yaml
+++ b/bindata/manifests/sriov-config-service/kubernetes/sriov-config-post-network-service.yaml
@@ -1,0 +1,15 @@
+contents: |
+  [Unit]
+  Description=Configures SRIOV NIC - post network configuration
+  After=systemd-networkd-wait-online.service NetworkManager-wait-online.service
+  Before=network-online.target
+
+  [Service]
+  Type=oneshot
+  ExecStart=/var/lib/sriov/sriov-network-config-daemon -v 2 --zap-log-level 2 service --phase post
+  StandardOutput=journal+console
+
+  [Install]
+  WantedBy=network-online.target
+enabled: true
+name: sriov-config-post-network.service

--- a/bindata/manifests/sriov-config-service/kubernetes/sriov-config-service.yaml
+++ b/bindata/manifests/sriov-config-service/kubernetes/sriov-config-service.yaml
@@ -1,14 +1,15 @@
 contents: |
   [Unit]
-  Description=Configures SRIOV NIC
-  After=network-pre.target
-  Before=NetworkManager.service kubelet.service
-  
+  Description=Configures SRIOV NIC - pre network configuration
+  DefaultDependencies=no
+  After=network-pre.target systemd-udev-settle.service systemd-sysusers.service systemd-sysctl.service
+  Before=network.target NetworkManager.service systemd-networkd.service ovs-vswitchd.service ovsdb-server.service
+
   [Service]
   Type=oneshot
-  ExecStart=/var/lib/sriov/sriov-network-config-daemon -v 2 service
+  ExecStart=/var/lib/sriov/sriov-network-config-daemon -v 2 --zap-log-level 2 service --phase pre
   StandardOutput=journal+console
-  
+
   [Install]
   WantedBy=multi-user.target
 enabled: true

--- a/bindata/manifests/sriov-config-service/openshift/sriov-config-service.yaml
+++ b/bindata/manifests/sriov-config-service/openshift/sriov-config-service.yaml
@@ -12,19 +12,36 @@ spec:
       units:
         - contents: |
             [Unit]
-            Description=Configures SRIOV NIC
             # Removal of this file signals firstboot completion
             ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
-            # This service is used to configure the SR-IOV VFs on NICs
-            After=network-pre.target
-            Before=NetworkManager.service kubelet.service
-            
+            Description=Configures SRIOV NIC - pre network configuration
+            DefaultDependencies=no
+            After=network-pre.target systemd-udev-settle.service systemd-sysusers.service systemd-sysctl.service
+            Before=network.target NetworkManager.service systemd-networkd.service ovs-vswitchd.service ovsdb-server.service
+
             [Service]
             Type=oneshot
-            ExecStart=/var/lib/sriov/sriov-network-config-daemon service -v {{ .LogLevel }}
+            ExecStart=/var/lib/sriov/sriov-network-config-daemon service -v {{ .LogLevel }} --zap-log-level {{ .LogLevel }} --phase pre
             StandardOutput=journal+console
-            
+
             [Install]
             WantedBy=multi-user.target
           enabled: true
           name: "sriov-config.service"
+        - contents: |
+            [Unit]
+            # Removal of this file signals firstboot completion
+            ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
+            Description=Configures SRIOV NIC - post network configuration
+            After=systemd-networkd-wait-online.service NetworkManager-wait-online.service
+            Before=network-online.target
+
+            [Service]
+            Type=oneshot
+            ExecStart=/var/lib/sriov/sriov-network-config-daemon service -v {{ .LogLevel }} --zap-log-level {{ .LogLevel }} --phase post
+            StandardOutput=journal+console
+
+            [Install]
+            WantedBy=network-online.target
+          enabled: true
+          name: "sriov-config-post-network.service"

--- a/cmd/sriov-network-config-daemon/service.go
+++ b/cmd/sriov-network-config-daemon/service.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -36,6 +37,11 @@ import (
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/version"
 )
 
+const (
+	PhasePre  = "pre"
+	PhasePost = "post"
+)
+
 var (
 	serviceCmd = &cobra.Command{
 		Use:   "service",
@@ -43,164 +49,247 @@ var (
 		Long:  "",
 		RunE:  runServiceCmd,
 	}
+	phaseArg string
+
+	newGenericPluginFunc  = generic.NewGenericPlugin
+	newVirtualPluginFunc  = virtual.NewVirtualPlugin
+	newHostHelpersFunc    = helper.NewDefaultHostHelpers
+	newPlatformHelperFunc = platforms.NewDefaultPlatformHelper
 )
 
 func init() {
 	rootCmd.AddCommand(serviceCmd)
+	serviceCmd.Flags().StringVarP(&phaseArg, "phase", "p", PhasePre, fmt.Sprintf("configuration phase, supported values are: %s, %s", PhasePre, PhasePost))
 }
 
+// The service supports two configuration phases:
+// * pre(default) - before the NetworkManager or systemd-networkd
+// * post - after the NetworkManager or systemd-networkd
+// "sriov-config" systemd unit is responsible for starting the service in the "pre" phase mode.
+// "sriov-config-post-network" systemd unit starts the service in the "post" phase mode.
+// The service may use different plugins for each phase and call different initialization flows.
+// The "post" phase checks the completion status of the "pre" phase by reading the sriov result file.
+// The "pre" phase should set "InProgress" status if it succeeds or "Failed" otherwise.
+// If the result of the "pre" phase is different than "InProgress", then the "post" phase will not be executed
+// and the execution result will be forcefully set to "Failed".
 func runServiceCmd(cmd *cobra.Command, args []string) error {
+	if phaseArg != PhasePre && phaseArg != PhasePost {
+		return fmt.Errorf("invalid value for \"--phase\" argument, valid values are: %s, %s", PhasePre, PhasePost)
+	}
 	// init logger
 	snolog.InitLog()
-	setupLog := log.Log.WithName("sriov-config-service")
+	setupLog := log.Log.WithName("sriov-config-service").WithValues("phase", phaseArg)
 
-	// To help debugging, immediately log version
-	setupLog.V(2).Info("sriov-config-service", "version", version.Version)
-
-	setupLog.V(0).Info("Starting sriov-config-service")
+	setupLog.V(0).Info("Starting sriov-config-service", "version", version.Version)
 
 	// Mark that we are running on host
 	vars.UsingSystemdMode = true
 	vars.InChroot = true
 
-	supportedNicIds, err := systemd.ReadSriovSupportedNics()
+	sriovConf, err := readConf(setupLog)
 	if err != nil {
-		setupLog.Error(err, "failed to read list of supported nic ids")
-		sriovResult := &systemd.SriovResult{
-			SyncStatus:    consts.SyncStatusFailed,
-			LastSyncError: fmt.Sprintf("failed to read list of supported nic ids: %v", err),
-		}
-		err = systemd.WriteSriovResult(sriovResult)
-		if err != nil {
-			setupLog.Error(err, "failed to write sriov result file", "content", *sriovResult)
-			return fmt.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
-		}
-		return fmt.Errorf("sriov-config-service failed to read list of supported nic ids: %v", err)
+		return updateSriovResultErr(setupLog, phaseArg, err)
 	}
-	sriovv1.InitNicIDMapFromList(supportedNicIds)
+	setupLog.V(2).Info("sriov-config-service", "config", sriovConf)
+	vars.DevMode = sriovConf.UnsupportedNics
 
+	if err := initSupportedNics(); err != nil {
+		return updateSriovResultErr(setupLog, phaseArg, fmt.Errorf("failed to initialize list of supported NIC ids: %v", err))
+	}
+
+	hostHelpers, err := newHostHelpersFunc()
+	if err != nil {
+		return updateSriovResultErr(setupLog, phaseArg, fmt.Errorf("failed to create hostHelpers: %v", err))
+	}
+
+	if phaseArg == PhasePre {
+		err = phasePre(setupLog, sriovConf, hostHelpers)
+	} else {
+		err = phasePost(setupLog, sriovConf, hostHelpers)
+	}
+	if err != nil {
+		return updateSriovResultErr(setupLog, phaseArg, err)
+	}
+	return updateSriovResultOk(setupLog, phaseArg)
+}
+
+func readConf(setupLog logr.Logger) (*systemd.SriovConfig, error) {
 	nodeStateSpec, err := systemd.ReadConfFile()
 	if err != nil {
 		if _, err := os.Stat(systemd.SriovSystemdConfigPath); !errors.Is(err, os.ErrNotExist) {
-			setupLog.Error(err, "failed to read the sriov configuration file", "path", systemd.SriovSystemdConfigPath)
-			sriovResult := &systemd.SriovResult{
-				SyncStatus:    consts.SyncStatusFailed,
-				LastSyncError: fmt.Sprintf("failed to read the sriov configuration file in path %s: %v", systemd.SriovSystemdConfigPath, err),
-			}
-			err = systemd.WriteSriovResult(sriovResult)
-			if err != nil {
-				setupLog.Error(err, "failed to write sriov result file", "content", *sriovResult)
-				return fmt.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
-			}
+			return nil, fmt.Errorf("failed to read the sriov configuration file in path %s: %v", systemd.SriovSystemdConfigPath, err)
 		}
-
+		setupLog.Info("configuration file not found, use default config")
 		nodeStateSpec = &systemd.SriovConfig{
 			Spec:            sriovv1.SriovNetworkNodeStateSpec{},
 			UnsupportedNics: false,
 			PlatformType:    consts.Baremetal,
 		}
 	}
+	return nodeStateSpec, nil
+}
 
-	setupLog.V(2).Info("sriov-config-service", "config", nodeStateSpec)
-	hostHelpers, err := helper.NewDefaultHostHelpers()
+func initSupportedNics() error {
+	supportedNicIds, err := systemd.ReadSriovSupportedNics()
 	if err != nil {
-		setupLog.Error(err, "failed to create hostHelpers")
-		return updateSriovResultErr("failed to create hostHelpers")
+		return fmt.Errorf("failed to read list of supported nic ids: %v", err)
 	}
-	platformHelper, err := platforms.NewDefaultPlatformHelper()
-	if err != nil {
-		setupLog.Error(err, "failed to create platformHelpers")
-		return updateSriovResultErr("failed to create platformHelpers")
+	sriovv1.InitNicIDMapFromList(supportedNicIds)
+	return nil
+}
+
+func phasePre(setupLog logr.Logger, conf *systemd.SriovConfig, hostHelpers helper.HostHelpersInterface) error {
+	// make sure there is no stale result file to avoid situation when we
+	// read outdated info in the Post phase when the Pre silently failed (should not happen)
+	if err := systemd.RemoveSriovResult(); err != nil {
+		return fmt.Errorf("failed to remove sriov result file: %v", err)
 	}
 
-	_, err = hostHelpers.TryEnableRdma()
+	_, err := hostHelpers.TryEnableRdma()
 	if err != nil {
 		setupLog.Error(err, "warning, failed to enable RDMA")
 	}
 	hostHelpers.TryEnableTun()
 	hostHelpers.TryEnableVhostNet()
 
-	var configPlugin plugin.VendorPlugin
-	var ifaceStatuses []sriovv1.InterfaceExt
-	if nodeStateSpec.PlatformType == consts.Baremetal {
-		// Bare metal support
-		vars.DevMode = nodeStateSpec.UnsupportedNics
-		ifaceStatuses, err = hostHelpers.DiscoverSriovDevices(hostHelpers)
-		if err != nil {
-			setupLog.Error(err, "failed to discover sriov devices on the host")
-			return updateSriovResultErr(fmt.Sprintf("sriov-config-service: failed to discover sriov devices on the host:  %v", err))
-		}
+	return callPlugin(setupLog, PhasePre, conf, hostHelpers)
+}
 
-		// Create the generic plugin
-		configPlugin, err = generic.NewGenericPlugin(hostHelpers)
-		if err != nil {
-			setupLog.Error(err, "failed to create generic plugin")
-			return updateSriovResultErr(fmt.Sprintf("sriov-config-service failed to create generic plugin %v", err))
-		}
-	} else if nodeStateSpec.PlatformType == consts.VirtualOpenStack {
-		err = platformHelper.CreateOpenstackDevicesInfo()
-		if err != nil {
-			setupLog.Error(err, "failed to read OpenStack data")
-			return updateSriovResultErr(fmt.Sprintf("sriov-config-service failed to read OpenStack data: %v", err))
-		}
+func phasePost(setupLog logr.Logger, conf *systemd.SriovConfig, hostHelpers helper.HostHelpersInterface) error {
+	setupLog.V(0).Info("check result of the Pre phase")
+	prePhaseResult, err := systemd.ReadSriovResult()
+	if err != nil {
+		return fmt.Errorf("failed to read result of the pre phase: %v", err)
+	}
+	if prePhaseResult.SyncStatus != consts.SyncStatusInProgress {
+		return fmt.Errorf("unexpected result of the pre phase: %s, syncError: %s", prePhaseResult.SyncStatus, prePhaseResult.LastSyncError)
+	}
+	setupLog.V(0).Info("Pre phase succeed, continue execution")
 
-		ifaceStatuses, err = platformHelper.DiscoverSriovDevicesVirtual()
-		if err != nil {
-			setupLog.Error(err, "failed to read OpenStack data")
-			return updateSriovResultErr(fmt.Sprintf("sriov-config-service: failed to read OpenStack data: %v", err))
-		}
+	return callPlugin(setupLog, PhasePost, conf, hostHelpers)
+}
 
-		// Create the virtual plugin
-		configPlugin, err = virtual.NewVirtualPlugin(hostHelpers)
-		if err != nil {
-			setupLog.Error(err, "failed to create virtual plugin")
-			return updateSriovResultErr(fmt.Sprintf("sriov-config-service: failed to create virtual plugin %v", err))
-		}
+func callPlugin(setupLog logr.Logger, phase string, conf *systemd.SriovConfig, hostHelpers helper.HostHelpersInterface) error {
+	configPlugin, err := getPlugin(setupLog, phase, conf, hostHelpers)
+	if err != nil {
+		return err
 	}
 
-	nodeState := &sriovv1.SriovNetworkNodeState{
-		Spec:   nodeStateSpec.Spec,
-		Status: sriovv1.SriovNetworkNodeStateStatus{Interfaces: ifaceStatuses},
+	if configPlugin == nil {
+		setupLog.V(0).Info("no plugin for the platform for the current phase, skip calling", "platform", conf.PlatformType)
+		return nil
 	}
 
+	nodeState, err := getNetworkNodeState(setupLog, conf, hostHelpers)
+	if err != nil {
+		return nil
+	}
 	_, _, err = configPlugin.OnNodeStateChange(nodeState)
 	if err != nil {
-		setupLog.Error(err, "failed to run OnNodeStateChange to update the generic plugin status")
-		return updateSriovResultErr(fmt.Sprintf("sriov-config-service: failed to run OnNodeStateChange to update the generic plugin status %v", err))
+		return fmt.Errorf("failed to run OnNodeStateChange to update the plugin status %v", err)
 	}
 
-	sriovResult := &systemd.SriovResult{
-		SyncStatus:    consts.SyncStatusSucceeded,
-		LastSyncError: "",
+	if err = configPlugin.Apply(); err != nil {
+		return fmt.Errorf("failed to apply configuration: %v", err)
 	}
+	setupLog.V(0).Info("plugin call succeed")
+	return nil
+}
 
-	err = configPlugin.Apply()
+func getPlugin(setupLog logr.Logger, phase string,
+	conf *systemd.SriovConfig, hostHelpers helper.HostHelpersInterface) (plugin.VendorPlugin, error) {
+	var (
+		configPlugin plugin.VendorPlugin
+		err          error
+	)
+	switch conf.PlatformType {
+	case consts.Baremetal:
+		switch phase {
+		case PhasePre:
+			configPlugin, err = newGenericPluginFunc(hostHelpers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create generic plugin for %v", err)
+			}
+		case PhasePost:
+			// TODO add initialization for the generic plugin for the post phase
+			setupLog.Info("post phase is not implemented for generic plugin yet, skip")
+			return nil, nil
+		}
+	case consts.VirtualOpenStack:
+		switch phase {
+		case PhasePre:
+			configPlugin, err = newVirtualPluginFunc(hostHelpers)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create virtual plugin %v", err)
+			}
+		case PhasePost:
+			setupLog.Info("skip post configuration phase for virtual cluster")
+			return nil, nil
+		}
+	}
+	return configPlugin, nil
+}
+
+func getNetworkNodeState(setupLog logr.Logger, conf *systemd.SriovConfig,
+	hostHelpers helper.HostHelpersInterface) (*sriovv1.SriovNetworkNodeState, error) {
+	var (
+		ifaceStatuses []sriovv1.InterfaceExt
+		err           error
+	)
+	switch conf.PlatformType {
+	case consts.Baremetal:
+		ifaceStatuses, err = hostHelpers.DiscoverSriovDevices(hostHelpers)
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover sriov devices on the host:  %v", err)
+		}
+	case consts.VirtualOpenStack:
+		platformHelper, err := newPlatformHelperFunc()
+		if err != nil {
+			return nil, fmt.Errorf("failed to create platformHelpers")
+		}
+		err = platformHelper.CreateOpenstackDevicesInfo()
+		if err != nil {
+			return nil, fmt.Errorf("failed to read OpenStack data: %v", err)
+		}
+		ifaceStatuses, err = platformHelper.DiscoverSriovDevicesVirtual()
+		if err != nil {
+			return nil, fmt.Errorf("failed to discover devices: %v", err)
+		}
+	}
+	return &sriovv1.SriovNetworkNodeState{
+		Spec:   conf.Spec,
+		Status: sriovv1.SriovNetworkNodeStateStatus{Interfaces: ifaceStatuses},
+	}, nil
+}
+
+func updateSriovResultErr(setupLog logr.Logger, phase string, origErr error) error {
+	setupLog.Error(origErr, "service call failed")
+	err := updateResult(setupLog, consts.SyncStatusFailed, fmt.Sprintf("%s: %v", phase, origErr))
 	if err != nil {
-		setupLog.Error(err, "failed to run apply node configuration")
-		sriovResult.SyncStatus = consts.SyncStatusFailed
-		sriovResult.LastSyncError = err.Error()
+		return err
 	}
+	return origErr
+}
 
-	err = systemd.WriteSriovResult(sriovResult)
+func updateSriovResultOk(setupLog logr.Logger, phase string) error {
+	setupLog.V(0).Info("service call succeed")
+	syncStatus := consts.SyncStatusSucceeded
+	if phase == PhasePre {
+		syncStatus = consts.SyncStatusInProgress
+	}
+	return updateResult(setupLog, syncStatus, "")
+}
+
+func updateResult(setupLog logr.Logger, result, msg string) error {
+	sriovResult := &systemd.SriovResult{
+		SyncStatus:    result,
+		LastSyncError: msg,
+	}
+	err := systemd.WriteSriovResult(sriovResult)
 	if err != nil {
 		setupLog.Error(err, "failed to write sriov result file", "content", *sriovResult)
 		return fmt.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
 	}
-
-	setupLog.V(0).Info("shutting down sriov-config-service")
-	return nil
-}
-
-func updateSriovResultErr(errMsg string) error {
-	sriovResult := &systemd.SriovResult{
-		SyncStatus:    consts.SyncStatusFailed,
-		LastSyncError: errMsg,
-	}
-
-	err := systemd.WriteSriovResult(sriovResult)
-	if err != nil {
-		log.Log.Error(err, "failed to write sriov result file", "content", *sriovResult)
-		return fmt.Errorf("sriov-config-service failed to write sriov result file with content %v error: %v", *sriovResult, err)
-	}
+	setupLog.V(0).Info("result file updated", "SyncStatus", sriovResult.SyncStatus, "LastSyncError", msg)
 	return nil
 }

--- a/cmd/sriov-network-config-daemon/service_test.go
+++ b/cmd/sriov-network-config-daemon/service_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/helper"
+	helperMock "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/helper/mock"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms"
+	platformsMock "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms/mock"
+	plugin "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins"
+	pluginsMock "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins/mock"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/systemd"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/fakefilesystem"
+	testHelpers "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/helpers"
+)
+
+func restoreOrigFuncs() {
+	origNewGenericPluginFunc := newGenericPluginFunc
+	origNewVirtualPluginFunc := newVirtualPluginFunc
+	origNewHostHelpersFunc := newHostHelpersFunc
+	origNewPlatformHelperFunc := newPlatformHelperFunc
+	DeferCleanup(func() {
+		newGenericPluginFunc = origNewGenericPluginFunc
+		newVirtualPluginFunc = origNewVirtualPluginFunc
+		newHostHelpersFunc = origNewHostHelpersFunc
+		newPlatformHelperFunc = origNewPlatformHelperFunc
+	})
+}
+
+func getTestSriovInterfaceConfig(platform int) []byte {
+	return []byte(fmt.Sprintf(`spec:
+    dpconfigversion: ""
+    interfaces:
+        - pciaddress: 0000:d8:00.0
+          numvfs: 4
+          mtu: 1500
+          name: enp216s0f0np0
+          linktype: ""
+          eswitchmode: legacy
+          vfgroups:
+            - resourcename: legacy
+              devicetype: ""
+              vfrange: 0-3
+              policyname: test-legacy
+              mtu: 1500
+              isrdma: false
+              vdpatype: ""
+          externallymanaged: false
+unsupportedNics: false
+platformType: %d
+`, platform))
+}
+
+var testSriovSupportedNicIDs = `8086 1583 154c
+8086 0d58 154c
+8086 10c9 10ca
+`
+
+func getTestResultFileContent(syncStatus, errMsg string) []byte {
+	data, err := yaml.Marshal(systemd.SriovResult{SyncStatus: syncStatus, LastSyncError: errMsg})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return data
+}
+
+// checks if NodeState contains deviceName in spec and status fields
+func newNodeStateContainsDeviceMatcher(deviceName string) gomock.Matcher {
+	return &nodeStateContainsDeviceMatcher{deviceName: deviceName}
+}
+
+type nodeStateContainsDeviceMatcher struct {
+	deviceName string
+}
+
+func (ns *nodeStateContainsDeviceMatcher) Matches(x interface{}) bool {
+	s, ok := x.(*sriovnetworkv1.SriovNetworkNodeState)
+	if !ok {
+		return false
+	}
+	specFound := false
+	for _, i := range s.Spec.Interfaces {
+		if i.Name == ns.deviceName {
+			specFound = true
+			break
+		}
+	}
+	if !specFound {
+		return false
+	}
+	statusFound := false
+	for _, i := range s.Status.Interfaces {
+		if i.Name == ns.deviceName {
+			statusFound = true
+			break
+		}
+	}
+	return statusFound
+}
+
+func (ns *nodeStateContainsDeviceMatcher) String() string {
+	return "node state contains match: " + ns.deviceName
+}
+
+var _ = Describe("Service", func() {
+	var (
+		hostHelpers    *helperMock.MockHostHelpersInterface
+		platformHelper *platformsMock.MockInterface
+		genericPlugin  *pluginsMock.MockVendorPlugin
+		virtualPlugin  *pluginsMock.MockVendorPlugin
+
+		testCtrl  *gomock.Controller
+		testError = fmt.Errorf("test")
+	)
+
+	BeforeEach(func() {
+		restoreOrigFuncs()
+
+		testCtrl = gomock.NewController(GinkgoT())
+		hostHelpers = helperMock.NewMockHostHelpersInterface(testCtrl)
+		platformHelper = platformsMock.NewMockInterface(testCtrl)
+		genericPlugin = pluginsMock.NewMockVendorPlugin(testCtrl)
+		virtualPlugin = pluginsMock.NewMockVendorPlugin(testCtrl)
+
+		newGenericPluginFunc = func(_ helper.HostHelpersInterface) (plugin.VendorPlugin, error) {
+			return genericPlugin, nil
+		}
+		newVirtualPluginFunc = func(_ helper.HostHelpersInterface) (plugin.VendorPlugin, error) {
+			return virtualPlugin, nil
+		}
+		newHostHelpersFunc = func() (helper.HostHelpersInterface, error) {
+			return hostHelpers, nil
+		}
+		newPlatformHelperFunc = func() (platforms.Interface, error) {
+			return platformHelper, nil
+		}
+
+	})
+	AfterEach(func() {
+		phaseArg = ""
+		testCtrl.Finish()
+	})
+
+	It("Pre phase - baremetal cluster", func() {
+		phaseArg = PhasePre
+		testHelpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+			Dirs: []string{"/etc/sriov-operator"},
+			Files: map[string][]byte{
+				"/etc/sriov-operator/sriov-supported-nics-ids.yaml": []byte(testSriovSupportedNicIDs),
+				"/etc/sriov-operator/sriov-interface-config.yaml":   getTestSriovInterfaceConfig(0),
+				"/etc/sriov-operator/sriov-interface-result.yaml":   []byte("something"),
+			},
+		})
+		hostHelpers.EXPECT().TryEnableRdma().Return(true, nil)
+		hostHelpers.EXPECT().TryEnableTun().Return()
+		hostHelpers.EXPECT().TryEnableVhostNet().Return()
+		hostHelpers.EXPECT().DiscoverSriovDevices(hostHelpers).Return([]sriovnetworkv1.InterfaceExt{{
+			Name: "enp216s0f0np0",
+		}}, nil)
+		genericPlugin.EXPECT().OnNodeStateChange(newNodeStateContainsDeviceMatcher("enp216s0f0np0")).Return(true, false, nil)
+		genericPlugin.EXPECT().Apply().Return(nil)
+
+		Expect(runServiceCmd(&cobra.Command{}, []string{})).NotTo(HaveOccurred())
+
+		testHelpers.GinkgoAssertFileContentsEquals("/etc/sriov-operator/sriov-interface-result.yaml",
+			string(getTestResultFileContent("InProgress", "")))
+	})
+
+	It("Pre phase - virtual cluster", func() {
+		phaseArg = PhasePre
+		testHelpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+			Dirs: []string{"/etc/sriov-operator"},
+			Files: map[string][]byte{
+				"/etc/sriov-operator/sriov-supported-nics-ids.yaml": []byte(testSriovSupportedNicIDs),
+				"/etc/sriov-operator/sriov-interface-config.yaml":   getTestSriovInterfaceConfig(1),
+				"/etc/sriov-operator/sriov-interface-result.yaml":   []byte("something"),
+			},
+		})
+		hostHelpers.EXPECT().TryEnableRdma().Return(true, nil)
+		hostHelpers.EXPECT().TryEnableTun().Return()
+		hostHelpers.EXPECT().TryEnableVhostNet().Return()
+
+		platformHelper.EXPECT().CreateOpenstackDevicesInfo().Return(nil)
+		platformHelper.EXPECT().DiscoverSriovDevicesVirtual().Return([]sriovnetworkv1.InterfaceExt{{
+			Name: "enp216s0f0np0",
+		}}, nil)
+
+		virtualPlugin.EXPECT().OnNodeStateChange(newNodeStateContainsDeviceMatcher("enp216s0f0np0")).Return(true, false, nil)
+		virtualPlugin.EXPECT().Apply().Return(nil)
+
+		Expect(runServiceCmd(&cobra.Command{}, []string{})).NotTo(HaveOccurred())
+
+		testHelpers.GinkgoAssertFileContentsEquals("/etc/sriov-operator/sriov-interface-result.yaml",
+			string(getTestResultFileContent("InProgress", "")))
+	})
+
+	It("Pre phase - apply failed", func() {
+		phaseArg = PhasePre
+		testHelpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+			Dirs: []string{"/etc/sriov-operator"},
+			Files: map[string][]byte{
+				"/etc/sriov-operator/sriov-supported-nics-ids.yaml": []byte(testSriovSupportedNicIDs),
+				"/etc/sriov-operator/sriov-interface-config.yaml":   getTestSriovInterfaceConfig(0),
+				"/etc/sriov-operator/sriov-interface-result.yaml":   []byte("something"),
+			},
+		})
+		hostHelpers.EXPECT().TryEnableRdma().Return(true, nil)
+		hostHelpers.EXPECT().TryEnableTun().Return()
+		hostHelpers.EXPECT().TryEnableVhostNet().Return()
+		hostHelpers.EXPECT().DiscoverSriovDevices(hostHelpers).Return([]sriovnetworkv1.InterfaceExt{{
+			Name: "enp216s0f0np0",
+		}}, nil)
+		genericPlugin.EXPECT().OnNodeStateChange(newNodeStateContainsDeviceMatcher("enp216s0f0np0")).Return(true, false, nil)
+		genericPlugin.EXPECT().Apply().Return(testError)
+
+		Expect(runServiceCmd(&cobra.Command{}, []string{})).To(MatchError(ContainSubstring("test")))
+
+		testHelpers.GinkgoAssertFileContentsEquals("/etc/sriov-operator/sriov-interface-result.yaml",
+			string(getTestResultFileContent("Failed", "pre: failed to apply configuration: test")))
+	})
+
+	It("Post phase - baremetal cluster", func() {
+		phaseArg = PhasePost
+		testHelpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+			Dirs: []string{"/etc/sriov-operator"},
+			Files: map[string][]byte{
+				"/etc/sriov-operator/sriov-supported-nics-ids.yaml": []byte(testSriovSupportedNicIDs),
+				"/etc/sriov-operator/sriov-interface-config.yaml":   getTestSriovInterfaceConfig(0),
+				"/etc/sriov-operator/sriov-interface-result.yaml":   getTestResultFileContent("InProgress", ""),
+			},
+		})
+		Expect(runServiceCmd(&cobra.Command{}, []string{})).NotTo(HaveOccurred())
+		testHelpers.GinkgoAssertFileContentsEquals("/etc/sriov-operator/sriov-interface-result.yaml",
+			string(getTestResultFileContent("Succeeded", "")))
+	})
+
+	It("Post phase - virtual cluster", func() {
+		phaseArg = PhasePost
+		testHelpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+			Dirs: []string{"/etc/sriov-operator"},
+			Files: map[string][]byte{
+				"/etc/sriov-operator/sriov-supported-nics-ids.yaml": []byte(testSriovSupportedNicIDs),
+				"/etc/sriov-operator/sriov-interface-config.yaml":   getTestSriovInterfaceConfig(1),
+				"/etc/sriov-operator/sriov-interface-result.yaml":   getTestResultFileContent("InProgress", ""),
+			},
+		})
+		Expect(runServiceCmd(&cobra.Command{}, []string{})).NotTo(HaveOccurred())
+		testHelpers.GinkgoAssertFileContentsEquals("/etc/sriov-operator/sriov-interface-result.yaml",
+			string(getTestResultFileContent("Succeeded", "")))
+	})
+
+	It("Post phase - wrong result of the pre phase", func() {
+		phaseArg = PhasePost
+		testHelpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+			Dirs: []string{"/etc/sriov-operator"},
+			Files: map[string][]byte{
+				"/etc/sriov-operator/sriov-supported-nics-ids.yaml": []byte(testSriovSupportedNicIDs),
+				"/etc/sriov-operator/sriov-interface-config.yaml":   getTestSriovInterfaceConfig(1),
+				"/etc/sriov-operator/sriov-interface-result.yaml":   getTestResultFileContent("Failed", "pretest"),
+			},
+		})
+		Expect(runServiceCmd(&cobra.Command{}, []string{})).To(HaveOccurred())
+		testHelpers.GinkgoAssertFileContentsEquals("/etc/sriov-operator/sriov-interface-result.yaml",
+			string(getTestResultFileContent("Failed", "post: unexpected result of the pre phase: Failed, syncError: pretest")))
+	})
+})

--- a/cmd/sriov-network-config-daemon/suite_test.go
+++ b/cmd/sriov-network-config-daemon/suite_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestConfigDaemon(t *testing.T) {
+	log.SetLogger(zap.New(
+		zap.WriteTo(GinkgoWriter),
+		zap.Level(zapcore.Level(-2)),
+		zap.UseDevMode(true)))
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "sriov-network-config-daemon Suite")
+}

--- a/pkg/plugins/k8s/k8s_plugin_test.go
+++ b/pkg/plugins/k8s/k8s_plugin_test.go
@@ -1,0 +1,194 @@
+package k8s
+
+import (
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	mock_helper "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/helper/mock"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host"
+	hostTypes "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/types"
+	plugin "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
+)
+
+func TestK8sPlugin(t *testing.T) {
+	log.SetLogger(zap.New(
+		zap.WriteTo(GinkgoWriter),
+		zap.Level(zapcore.Level(-2)),
+		zap.UseDevMode(true)))
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Test K8s Plugin")
+}
+
+// changes current working dir before calling the real function
+func registerCall(m *gomock.Call, realF interface{}) *gomock.Call {
+	cur, _ := os.Getwd()
+	return m.Do(func(_ ...interface{}) {
+		os.Chdir("../../..")
+	}).DoAndReturn(realF).Do(func(_ ...interface{}) {
+		os.Chdir(cur)
+	}).AnyTimes()
+}
+
+func setIsSystemdMode(val bool) {
+	origUsingSystemdMode := vars.UsingSystemdMode
+	DeferCleanup(func() {
+		vars.UsingSystemdMode = origUsingSystemdMode
+	})
+	vars.UsingSystemdMode = val
+}
+
+func newServiceNameMatcher(name string) gomock.Matcher {
+	return &serviceNameMatcher{name: name}
+}
+
+type serviceNameMatcher struct {
+	name string
+}
+
+func (snm *serviceNameMatcher) Matches(x interface{}) bool {
+	s, ok := x.(*hostTypes.Service)
+	if !ok {
+		return false
+	}
+	return snm.name == s.Name
+}
+
+func (snm *serviceNameMatcher) String() string {
+	return "service name match: " + snm.name
+}
+
+var _ = Describe("K8s plugin", func() {
+	var (
+		k8sPlugin  plugin.VendorPlugin
+		err        error
+		testCtrl   *gomock.Controller
+		hostHelper *mock_helper.MockHostHelpersInterface
+	)
+
+	BeforeEach(func() {
+		testCtrl = gomock.NewController(GinkgoT())
+
+		hostHelper = mock_helper.NewMockHostHelpersInterface(testCtrl)
+		realHostMgr := host.NewHostManager(hostHelper)
+
+		// proxy some functions to real host manager to simplify testing and to additionally validate manifests
+		for _, f := range []string{
+			"bindata/manifests/switchdev-config/files/switchdev-configuration-before-nm.sh.yaml",
+			"bindata/manifests/switchdev-config/files/switchdev-configuration-after-nm.sh.yaml",
+			"bindata/manifests/switchdev-config/files/switchdev-vf-link-name.sh.yaml",
+		} {
+			registerCall(hostHelper.EXPECT().ReadScriptManifestFile(f), realHostMgr.ReadScriptManifestFile)
+		}
+		for _, f := range []string{
+			"bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-before-nm.yaml",
+			"bindata/manifests/switchdev-config/switchdev-units/switchdev-configuration-after-nm.yaml",
+			"bindata/manifests/sriov-config-service/kubernetes/sriov-config-service.yaml",
+			"bindata/manifests/sriov-config-service/kubernetes/sriov-config-post-network-service.yaml",
+		} {
+			registerCall(hostHelper.EXPECT().ReadServiceManifestFile(f), realHostMgr.ReadServiceManifestFile)
+		}
+		for _, s := range []string{
+			"switchdev-configuration-before-nm.service",
+			"switchdev-configuration-after-nm.service",
+		} {
+			registerCall(hostHelper.EXPECT().RemoveFromService(newServiceNameMatcher(s), gomock.Any()), realHostMgr.RemoveFromService)
+		}
+		for _, s := range []string{
+			"bindata/manifests/switchdev-config/switchdev-units/NetworkManager.service.yaml",
+			"bindata/manifests/switchdev-config/ovs-units/ovs-vswitchd.service.yaml",
+		} {
+			registerCall(hostHelper.EXPECT().ReadServiceInjectionManifestFile(s), realHostMgr.ReadServiceInjectionManifestFile)
+		}
+		k8sPlugin, err = NewK8sPlugin(hostHelper)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		testCtrl.Finish()
+	})
+
+	It("no switchdev, no systemd", func() {
+		setIsSystemdMode(false)
+		needDrain, needReboot, err := k8sPlugin.OnNodeStateChange(&sriovnetworkv1.SriovNetworkNodeState{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(needReboot).To(BeFalse())
+		Expect(needDrain).To(BeFalse())
+		Expect(k8sPlugin.Apply()).NotTo(HaveOccurred())
+	})
+
+	It("systemd, created", func() {
+		setIsSystemdMode(true)
+
+		hostHelper.EXPECT().IsServiceEnabled("/etc/systemd/system/sriov-config.service").Return(false, nil)
+		hostHelper.EXPECT().IsServiceEnabled("/etc/systemd/system/sriov-config-post-network.service").Return(false, nil)
+		hostHelper.EXPECT().EnableService(newServiceNameMatcher("sriov-config.service")).Return(nil)
+		hostHelper.EXPECT().EnableService(newServiceNameMatcher("sriov-config-post-network.service")).Return(nil)
+		hostHelper.EXPECT().UpdateSystemService(newServiceNameMatcher("sriov-config.service")).Return(nil)
+		hostHelper.EXPECT().UpdateSystemService(newServiceNameMatcher("sriov-config-post-network.service")).Return(nil)
+
+		needDrain, needReboot, err := k8sPlugin.OnNodeStateChange(&sriovnetworkv1.SriovNetworkNodeState{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(needReboot).To(BeTrue())
+		Expect(needDrain).To(BeTrue())
+		Expect(k8sPlugin.Apply()).NotTo(HaveOccurred())
+	})
+	It("systemd, already configured", func() {
+		setIsSystemdMode(true)
+
+		hostHelper.EXPECT().IsServiceEnabled("/etc/systemd/system/sriov-config.service").Return(true, nil)
+		hostHelper.EXPECT().ReadService("/etc/systemd/system/sriov-config.service").Return(
+			&hostTypes.Service{Name: "sriov-config.service"}, nil)
+		hostHelper.EXPECT().CompareServices(
+			&hostTypes.Service{Name: "sriov-config.service"},
+			newServiceNameMatcher("sriov-config.service"),
+		).Return(false, nil)
+
+		hostHelper.EXPECT().IsServiceEnabled("/etc/systemd/system/sriov-config-post-network.service").Return(true, nil)
+		hostHelper.EXPECT().ReadService("/etc/systemd/system/sriov-config-post-network.service").Return(
+			&hostTypes.Service{Name: "sriov-config-post-network.service"}, nil)
+		hostHelper.EXPECT().CompareServices(&hostTypes.Service{Name: "sriov-config-post-network.service"},
+			newServiceNameMatcher("sriov-config-post-network.service"),
+		).Return(false, nil)
+
+		needDrain, needReboot, err := k8sPlugin.OnNodeStateChange(&sriovnetworkv1.SriovNetworkNodeState{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(needReboot).To(BeFalse())
+		Expect(needDrain).To(BeFalse())
+		Expect(k8sPlugin.Apply()).NotTo(HaveOccurred())
+	})
+	It("systemd, update required", func() {
+		setIsSystemdMode(true)
+
+		hostHelper.EXPECT().IsServiceEnabled("/etc/systemd/system/sriov-config.service").Return(true, nil)
+		hostHelper.EXPECT().ReadService("/etc/systemd/system/sriov-config.service").Return(
+			&hostTypes.Service{Name: "sriov-config.service"}, nil)
+		hostHelper.EXPECT().CompareServices(
+			&hostTypes.Service{Name: "sriov-config.service"},
+			newServiceNameMatcher("sriov-config.service"),
+		).Return(true, nil)
+		hostHelper.EXPECT().EnableService(newServiceNameMatcher("sriov-config.service")).Return(nil)
+		hostHelper.EXPECT().UpdateSystemService(newServiceNameMatcher("sriov-config.service")).Return(nil)
+
+		hostHelper.EXPECT().IsServiceEnabled("/etc/systemd/system/sriov-config-post-network.service").Return(true, nil)
+		hostHelper.EXPECT().ReadService("/etc/systemd/system/sriov-config-post-network.service").Return(
+			&hostTypes.Service{Name: "sriov-config-post-network.service"}, nil)
+		hostHelper.EXPECT().CompareServices(&hostTypes.Service{Name: "sriov-config-post-network.service"},
+			newServiceNameMatcher("sriov-config-post-network.service"),
+		).Return(false, nil)
+
+		needDrain, needReboot, err := k8sPlugin.OnNodeStateChange(&sriovnetworkv1.SriovNetworkNodeState{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(needReboot).To(BeTrue())
+		Expect(needDrain).To(BeTrue())
+		Expect(k8sPlugin.Apply()).NotTo(HaveOccurred())
+	})
+})

--- a/pkg/systemd/systemd.go
+++ b/pkg/systemd/systemd.go
@@ -36,7 +36,8 @@ const (
 	sriovSystemdSupportedNicPath  = consts.SriovConfBasePath + "/sriov-supported-nics-ids.yaml"
 	sriovSystemdServiceBinaryPath = "/var/lib/sriov/sriov-network-config-daemon"
 
-	SriovServicePath = "/etc/systemd/system/sriov-config.service"
+	SriovServicePath            = "/etc/systemd/system/sriov-config.service"
+	SriovPostNetworkServicePath = "/etc/systemd/system/sriov-config-post-network.service"
 )
 
 // TODO: move this to the host interface also
@@ -297,6 +298,10 @@ func CleanSriovFilesFromHost(isOpenShift bool) error {
 	// in openshift we should not remove the systemd service it will be done by the machine config operator
 	if !isOpenShift {
 		err = os.Remove(utils.GetHostExtensionPath(SriovServicePath))
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		err = os.Remove(utils.GetHostExtensionPath(SriovPostNetworkServicePath))
 		if err != nil && !os.IsNotExist(err) {
 			return err
 		}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -114,6 +114,10 @@ func GetHostExtension() string {
 	return filepath.Join(vars.FilesystemRoot, consts.Host)
 }
 
+func GetHostExtensionPath(path string) string {
+	return filepath.Join(GetHostExtension(), path)
+}
+
 func GetChrootExtension() string {
 	if vars.InChroot {
 		return vars.FilesystemRoot


### PR DESCRIPTION
split systemd service to two parts:
The first part is executed before the
NeworkManager or systemd-networkd
starts on the host.
The second part is triggered after the
network configuration is complete.

This change is required to support hw offload
use-case with systemd service.

cc @adrianchiris @zeeke @SchSeba 