### PR TITLE
Move default policy creation in controller tests to BeforeSuite.

### DIFF
--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -11,52 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
-	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
 	util "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util"
 )
 
 var _ = Describe("Operator", func() {
-	var config *sriovnetworkv1.SriovOperatorConfig
-	BeforeEach(func() {
-		defaultPolicy := &sriovnetworkv1.SriovNetworkNodePolicy{}
-		defaultPolicy.SetNamespace(vars.Namespace)
-		defaultPolicy.SetName(constants.DefaultPolicyName)
-		defaultPolicy.Spec = sriovnetworkv1.SriovNetworkNodePolicySpec{
-			NumVfs:       0,
-			NodeSelector: make(map[string]string),
-			NicSelector:  sriovnetworkv1.SriovNetworkNicSelector{},
-		}
-		Expect(k8sClient.Create(goctx.TODO(), defaultPolicy)).Should(Succeed())
-	})
-	AfterEach(func() {
-		defaultPolicy := &sriovnetworkv1.SriovNetworkNodePolicy{}
-		defaultPolicy.SetNamespace(vars.Namespace)
-		defaultPolicy.SetName(constants.DefaultPolicyName)
-		Expect(k8sClient.Delete(goctx.TODO(), defaultPolicy)).Should(Succeed())
-	})
-	// BeforeEach(func() {
-	// 	config = &sriovnetworkv1.SriovOperatorConfig{}
-	// 	config.SetNamespace(testNamespace)
-	// 	config.SetName(DEFAULT_CONFIG_NAME)
-	// 	config.Spec = sriovnetworkv1.SriovOperatorConfigSpec{
-	// 		EnableInjector:           func() *bool { b := true; return &b }(),
-	// 		EnableOperatorWebhook:    func() *bool { b := true; return &b }(),
-	// 		ConfigDaemonNodeSelector: map[string]string{},
-	// 		LogLevel:                 2,
-	// 	}
-	// 	Expect(k8sClient.Create(goctx.TODO(), config)).Should(Succeed())
-	// })
-	// AfterEach(func() {
-	// 	config := &sriovnetworkv1.SriovOperatorConfig{}
-	// 	config.SetNamespace(testNamespace)
-	// 	config.SetName(DEFAULT_CONFIG_NAME)
-	// 	Expect(k8sClient.Delete(goctx.TODO(), config)).Should(Succeed())
-	// })
-
 	Context("When is up", func() {
 		JustBeforeEach(func() {
-			config = &sriovnetworkv1.SriovOperatorConfig{}
+			config := &sriovnetworkv1.SriovOperatorConfig{}
 			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
 			config.Spec = sriovnetworkv1.SriovOperatorConfigSpec{

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -193,6 +193,16 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(k8sClient.Create(context.TODO(), config)).Should(Succeed())
 
+	defaultPolicy := &sriovnetworkv1.SriovNetworkNodePolicy{}
+	defaultPolicy.SetNamespace(testNamespace)
+	defaultPolicy.SetName(constants.DefaultPolicyName)
+	defaultPolicy.Spec = sriovnetworkv1.SriovNetworkNodePolicySpec{
+		NumVfs:       0,
+		NodeSelector: make(map[string]string),
+		NicSelector:  sriovnetworkv1.SriovNetworkNicSelector{},
+	}
+	Expect(k8sClient.Create(context.TODO(), defaultPolicy)).Should(Succeed())
+
 	infra := &openshiftconfigv1.Infrastructure{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",


### PR DESCRIPTION
This is required to fix the following problem:
SriovOperatorConfigReconciler starts in the BeforeSuite handler, the default OperatorConfig is also created in BeforeSuite. That means the SriovOperatorConfigReconciler will be triggered with the first test in the controller suite.

SriovOperatorConfigReconciler will fail (return an error) until DefaultPolicy is created by the BeforeEach function in sriovoperatorconfig_controller_test.go.

The problem is that tests in sriovoperatorconfig_controller_test.go starts after the test in some other *_test.go files in the controller package.  At the time when tests from sriovoperatorconfig_controller_test.go are eventually executed, SriovOperatorConfigReconciler controller is already failed multiple times in a row (because there was no default policy) and is waiting with a backoff delay (already quite large) before reconcilation retry.

