### PR TITLE
Cleanup Created object in controller tests

### DIFF
--- a/controllers/sriovibnetwork_controller_test.go
+++ b/controllers/sriovibnetwork_controller_test.go
@@ -223,11 +223,18 @@ var _ = Describe("SriovIBNetwork Controller", func() {
 			err = k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetName(), Namespace: "ib-ns-xxx"}, netAttDef)
 			Expect(err).To(HaveOccurred())
 
-			err = k8sClient.Create(goctx.TODO(), &corev1.Namespace{
+			// Create Namespace
+			nsObj := &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{Name: "ib-ns-xxx"},
-			})
+			}
+			err = k8sClient.Create(goctx.TODO(), nsObj)
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				err = k8sClient.Delete(goctx.TODO(), nsObj)
+				Expect(err).NotTo(HaveOccurred())
+			})
 
+			// Check that net-attach-def has been created
 			err = util.WaitForNamespacedObject(netAttDef, k8sClient, "ib-ns-xxx", cr.GetName(), util.RetryInterval, util.Timeout)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/sriovnetwork_controller_test.go
+++ b/controllers/sriovnetwork_controller_test.go
@@ -260,11 +260,18 @@ var _ = Describe("SriovNetwork Controller", func() {
 				err = k8sClient.Get(ctx, types.NamespacedName{Name: cr.GetName(), Namespace: "ns-xxx"}, netAttDef)
 				Expect(err).To(HaveOccurred())
 
-				err = k8sClient.Create(goctx.TODO(), &corev1.Namespace{
+				// Create Namespace
+				nsObj := &corev1.Namespace{
 					ObjectMeta: metav1.ObjectMeta{Name: "ns-xxx"},
-				})
+				}
+				err = k8sClient.Create(goctx.TODO(), nsObj)
 				Expect(err).NotTo(HaveOccurred())
+				DeferCleanup(func() {
+					err = k8sClient.Delete(goctx.TODO(), nsObj)
+					Expect(err).NotTo(HaveOccurred())
+				})
 
+				// Check that net-attach-def has been created
 				err = util.WaitForNamespacedObject(netAttDef, k8sClient, "ns-xxx", cr.GetName(), util.RetryInterval, util.Timeout)
 				Expect(err).NotTo(HaveOccurred())
 

--- a/controllers/sriovnetworkpoolconfig_controller_test.go
+++ b/controllers/sriovnetworkpoolconfig_controller_test.go
@@ -53,12 +53,21 @@ var _ = Describe("Operator", func() {
 			}
 			err = k8sClient.Create(goctx.TODO(), mcp)
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				err = k8sClient.Delete(goctx.TODO(), mcp)
+				Expect(err).ToNot(HaveOccurred())
+			})
 
 			config.Spec.OvsHardwareOffloadConfig = sriovnetworkv1.OvsHardwareOffloadConfig{
 				Name: mcpName,
 			}
 			err = k8sClient.Create(goctx.TODO(), config)
 			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() {
+				err = k8sClient.Delete(goctx.TODO(), config)
+				Expect(err).ToNot(HaveOccurred())
+			})
+
 			Eventually(func() error {
 				mc := &mcfgv1.MachineConfig{}
 				err := k8sClient.Get(goctx.TODO(), types.NamespacedName{Name: mcName, Namespace: testNamespace}, mc)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -182,6 +182,7 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(k8sClient.Create(context.TODO(), ns)).Should(Succeed())
 
+	// Create default SriovOperatorConfig
 	config := &sriovnetworkv1.SriovOperatorConfig{}
 	config.SetNamespace(testNamespace)
 	config.SetName(constants.DefaultConfigName)
@@ -193,6 +194,7 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(k8sClient.Create(context.TODO(), config)).Should(Succeed())
 
+	// Create default SriovNetworkNodePolicy
 	defaultPolicy := &sriovnetworkv1.SriovNetworkNodePolicy{}
 	defaultPolicy.SetNamespace(testNamespace)
 	defaultPolicy.SetName(constants.DefaultPolicyName)
@@ -203,6 +205,7 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(k8sClient.Create(context.TODO(), defaultPolicy)).Should(Succeed())
 
+	// Create openshift Infrastructure
 	infra := &openshiftconfigv1.Infrastructure{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
@@ -214,6 +217,7 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(k8sClient.Create(context.TODO(), infra)).Should(Succeed())
 
+	// Create default SriovNetworkPoolConfig
 	poolConfig := &sriovnetworkv1.SriovNetworkPoolConfig{}
 	poolConfig.SetNamespace(testNamespace)
 	poolConfig.SetName(constants.DefaultConfigName)

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -165,12 +165,6 @@ var _ = BeforeSuite(func() {
 
 	ctx, cancel = context.WithCancel(ctrl.SetupSignalHandler())
 
-	go func() {
-		defer GinkgoRecover()
-		err = k8sManager.Start(ctx)
-		Expect(err).ToNot(HaveOccurred())
-	}()
-
 	// Create test namespace
 	ns := &corev1.Namespace{
 		TypeMeta: metav1.TypeMeta{},
@@ -223,6 +217,12 @@ var _ = BeforeSuite(func() {
 	poolConfig.SetName(constants.DefaultConfigName)
 	poolConfig.Spec = sriovnetworkv1.SriovNetworkPoolConfigSpec{}
 	Expect(k8sClient.Create(context.TODO(), poolConfig)).Should(Succeed())
+
+	go func() {
+		defer GinkgoRecover()
+		err = k8sManager.Start(ctx)
+		Expect(err).ToNot(HaveOccurred())
+	}()
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
some controller tests were not cleaning up
created objects, add cleanup for those tests.

in addition, start manager at the end of the env prep (after default obj creation)