### PR TITLE
openstack: Fix `nil` HostManager in `openstackContext`

### DIFF
--- a/pkg/platforms/openstack/openstack.go
+++ b/pkg/platforms/openstack/openstack.go
@@ -102,8 +102,10 @@ type OSPDeviceInfo struct {
 	NetworkID  string
 }
 
-func New() OpenstackInterface {
-	return &openstackContext{}
+func New(hostManager host.HostManagerInterface) OpenstackInterface {
+	return &openstackContext{
+		hostManager: hostManager,
+	}
 }
 
 // GetOpenstackData gets the metadata and network_data

--- a/pkg/platforms/platforms.go
+++ b/pkg/platforms/platforms.go
@@ -1,8 +1,10 @@
 package platforms
 
 import (
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms/openshift"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms/openstack"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils"
 )
 
 //go:generate ../../bin/mockgen -destination mock/mock_platforms.go -source platforms.go
@@ -21,8 +23,9 @@ func NewDefaultPlatformHelper() (Interface, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	openstackContext := openstack.New()
+	utilsHelper := utils.New()
+	hostManager := host.NewHostManager(utilsHelper)
+	openstackContext := openstack.New(hostManager)
 
 	return &platformHelper{
 		openshiftContext,


### PR DESCRIPTION
Refactoring in [1] left the openstackContext uninitialized, making the config-daemon crash on OpenStack deployments.

This error has been caught in Openshift downstream CI [2] 


[1] https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/553
[2] https://github.com/openshift/sriov-network-operator/pull/882#issuecomment-1921340066

cc @SchSeba, @EmilienM 