### PR TITLE
e2e: dump multus namespace

### DIFF
--- a/hack/run-e2e-conformance-virtual-ocp.sh
+++ b/hack/run-e2e-conformance-virtual-ocp.sh
@@ -183,6 +183,7 @@ export ADMISSION_CONTROLLERS_ENABLED=true
 export SKIP_VAR_SET=""
 export NAMESPACE="openshift-sriov-network-operator"
 export OPERATOR_NAMESPACE=$NAMESPACE
+export MULTUS_NAMESPACE="openshift-multus"
 export OPERATOR_EXEC=kubectl
 export CLUSTER_TYPE=openshift
 export DEV_MODE=TRUE
@@ -300,7 +301,7 @@ if [ -z $SKIP_TEST ]; then
   set -e
 
   if [[ -v TEST_REPORT_PATH ]]; then
-    kubectl cluster-info dump --namespaces ${NAMESPACE} --output-directory "${root}/${TEST_REPORT_PATH}/cluster-info"
+    kubectl cluster-info dump --namespaces ${NAMESPACE},${MULTUS_NAMESPACE} --output-directory "${root}/${TEST_REPORT_PATH}/cluster-info"
   fi
 
   if [[ $TEST_EXITE_CODE -ne 0 ]]; then


### PR DESCRIPTION
Test case `[sriov] operator Generic SriovNetworkNodePolicy CNI Logging level [It] Debug logging should be visible in multus pod` is still flaking:

https://github.com/k8snetworkplumbingwg/sriov-network-operator/actions/runs/7783518576/job/21222320719
```
[sriov] operator Generic SriovNetworkNodePolicy CNI Logging level Debug logging should be visible in multus pod
/root/opr-ocp-2/data/sriov-network-operator/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1006
  [FAILED] in [It] - /root/opr-ocp-2/data/sriov-network-operator/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1022 @ 02/05/24 06:46:14.351
• [FAILED] [8.370 seconds]
[sriov] operator Generic SriovNetworkNodePolicy CNI Logging level [It] Debug logging should be visible in multus pod
/root/opr-ocp-2/data/sriov-network-operator/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1006

  [FAILED] Expected
      <[]string | len:1, cap:1>: [""]
  to contain element matching
      <*matchers.AndMatcher | 0xc0007ae090>: {
          Matchers: [
              <*matchers.ContainSubstringMatcher | 0xc000d27f50>{
                  Substr: "level=\"debug\"",
                  Args: nil,
              },
              <*matchers.ContainSubstringMatcher | 0xc000d27f80>{
                  Substr: "msg=\"function called\"",
                  Args: nil,
              },
              <*matchers.ContainSubstringMatcher | 0xc000d27fb0>{
                  Substr: "func=\"cmdAdd\"",
                  Args: nil,
              },
              <*matchers.ContainSubstringMatcher | 0xc0007ae030>{
                  Substr: "cniName=\"sriov-cni\"",
                  Args: nil,
              },
              <*matchers.ContainSubstringMatcher | 0xc0007ae060>{
                  Substr: "ifname=\"net1\"",
                  Args: nil,
              },
          ],
          firstFailedMatcher: <*matchers.ContainSubstringMatcher | 0xc000d27f50>{
              Substr: "level=\"debug\"",
              Args: nil,
          },
      }
  In [It] at: /root/opr-ocp-2/data/sriov-network-operator/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:1022 @ 02/05/24 06:46:14.351
```

This PR adds multus namespace to the `kubectl cluster-info dump ...` command, so we can have more information about these failures.