### PR TITLE
[Remove Default Objs  1/4] Dont create default SriovOperatorConfig

### DIFF
--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -134,11 +134,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 		It("should be able to turn network-resources-injector on/off", func() {
 			By("set disable to enableInjector")
 			config := &sriovnetworkv1.SriovOperatorConfig{}
-			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
 
 			config.Spec.EnableInjector = false
-			err = k8sClient.Update(ctx, config)
+			err := k8sClient.Update(ctx, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			daemonSet := &appsv1.DaemonSet{}
@@ -170,11 +169,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 
 			By("set disable to enableOperatorWebhook")
 			config := &sriovnetworkv1.SriovOperatorConfig{}
-			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
 
 			config.Spec.EnableOperatorWebhook = false
-			err = k8sClient.Update(ctx, config)
+			err := k8sClient.Update(ctx, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			daemonSet := &appsv1.DaemonSet{}
@@ -190,8 +188,7 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("set disable to enableOperatorWebhook")
-			err = util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
 
 			config.Spec.EnableOperatorWebhook = true
 			err = k8sClient.Update(ctx, config)
@@ -213,10 +210,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 		It("should be able to update the node selector of sriov-network-config-daemon", func() {
 			By("specify the configDaemonNodeSelector")
 			config := &sriovnetworkv1.SriovOperatorConfig{}
-			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
+
 			config.Spec.ConfigDaemonNodeSelector = map[string]string{"node-role.kubernetes.io/worker": ""}
-			err = k8sClient.Update(ctx, config)
+			err := k8sClient.Update(ctx, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			daemonSet := &appsv1.DaemonSet{}
@@ -233,10 +230,9 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 		It("should be able to do multiple updates to the node selector of sriov-network-config-daemon", func() {
 			By("changing the configDaemonNodeSelector")
 			config := &sriovnetworkv1.SriovOperatorConfig{}
-			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
 			config.Spec.ConfigDaemonNodeSelector = map[string]string{"labelA": "", "labelB": "", "labelC": ""}
-			err = k8sClient.Update(ctx, config)
+			err := k8sClient.Update(ctx, config)
 			Expect(err).NotTo(HaveOccurred())
 			config.Spec.ConfigDaemonNodeSelector = map[string]string{"labelA": "", "labelB": ""}
 			err = k8sClient.Update(ctx, config)
@@ -254,8 +250,7 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 
 		It("should not render disable-plugins cmdline flag of sriov-network-config-daemon if disablePlugin not provided in spec", func() {
 			config := &sriovnetworkv1.SriovOperatorConfig{}
-			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
 
 			Eventually(func() string {
 				daemonSet := &appsv1.DaemonSet{}
@@ -269,11 +264,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 
 		It("should render disable-plugins cmdline flag of sriov-network-config-daemon if disablePlugin provided in spec", func() {
 			config := &sriovnetworkv1.SriovOperatorConfig{}
-			err := util.WaitForNamespacedObject(config, k8sClient, testNamespace, "default", util.RetryInterval, util.APITimeout)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
 
 			config.Spec.DisablePlugins = sriovnetworkv1.PluginNameSlice{"mellanox"}
-			err = k8sClient.Update(ctx, config)
+			err := k8sClient.Update(ctx, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			Eventually(func() string {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -122,7 +122,6 @@ var _ = BeforeSuite(func() {
 	By("setting up env variables for tests")
 	os.Setenv("RESOURCE_PREFIX", "openshift.io")
 	os.Setenv("NAMESPACE", "openshift-sriov-network-operator")
-	os.Setenv("ADMISSION_CONTROLLERS_ENABLED", "true")
 	os.Setenv("ADMISSION_CONTROLLERS_CERTIFICATES_OPERATOR_SECRET_NAME", "operator-webhook-cert")
 	os.Setenv("ADMISSION_CONTROLLERS_CERTIFICATES_INJECTOR_SECRET_NAME", "network-resources-injector-cert")
 	os.Setenv("SRIOV_CNI_IMAGE", "mock-image")

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -66,8 +66,6 @@ spec:
               value: $SRIOV_NETWORK_WEBHOOK_IMAGE
             - name: RESOURCE_PREFIX
               value: $RESOURCE_PREFIX
-            - name: ADMISSION_CONTROLLERS_ENABLED
-              value: "$ADMISSION_CONTROLLERS_ENABLED"
             - name: DEV_MODE
               value: "$DEV_MODE"
             - name: NAMESPACE

--- a/deploy/sriovoperatorconfig.yaml
+++ b/deploy/sriovoperatorconfig.yaml
@@ -1,0 +1,11 @@
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+spec:
+  enableInjector: $ADMISSION_CONTROLLERS_ENABLED
+  enableOperatorWebhook: $ADMISSION_CONTROLLERS_ENABLED
+  configDaemonNodeSelector: {}
+  logLevel: 2
+  disableDrain: false
+  configurationMode: daemon

--- a/deployment/sriov-network-operator/README.md
+++ b/deployment/sriov-network-operator/README.md
@@ -104,6 +104,18 @@ controllers, which can be found in the table below. In a nutshell, the modes tha
 | `operator.admissionControllers.certificates.custom.injector.tlsCrt` | string | `` | The public part of the certificate to be used by the Network Resources Injector's admission controller |
 | `operator.admissionControllers.certificates.custom.injector.tlsKey` | string | `` | The private part of the certificate to be used by the Network Resources Injector's admission controller |
 
+### SR-IOV Operator Configuration Parameters
+
+This section contains general parameters that apply to both the operator and daemon componets of SR-IOV Network Operator.
+
+| Name | Type | Default | description |
+| ---- | ---- | ------- | ----------- |
+| `sriovOperatorConfig.deploy` | bool | `false` | deploy SriovOperatorConfig custom resource |
+| `sriovOperatorConfig.configDaemonNodeSelector` | map[string]string | `{}` | node slectors for sriov-network-config-daemon |
+| `sriovOperatorConfig.logLevel` | int | `2` | log level for both operator and sriov-network-config-daemon |
+| `sriovOperatorConfig.disableDrain` | bool | `false` | disable node draining when configuring SR-IOV, set to true in case of a single node cluster or any other justifiable reason |
+| `sriovOperatorConfig.configurationMode` | string | `daemon` | sriov-network-config-daemon configuration mode. either `daemon` or `systemd` |
+
 ### Images parameters
 
 | Name | description |

--- a/deployment/sriov-network-operator/templates/operator.yaml
+++ b/deployment/sriov-network-operator/templates/operator.yaml
@@ -88,8 +88,6 @@ spec:
               value: {{ .Values.operator.cniBinPath }}
             - name: CLUSTER_TYPE
               value: {{ .Values.operator.clusterType }}
-            - name: ADMISSION_CONTROLLERS_ENABLED
-              value: {{ .Values.operator.admissionControllers.enabled | quote }}
         {{- if .Values.operator.admissionControllers.enabled }}
             - name: ADMISSION_CONTROLLERS_CERTIFICATES_OPERATOR_SECRET_NAME
               value: {{ .Values.operator.admissionControllers.certificates.secretNames.operator }}

--- a/deployment/sriov-network-operator/templates/sriovoperatorconfig.yaml
+++ b/deployment/sriov-network-operator/templates/sriovoperatorconfig.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.sriovOperatorConfig.deploy }}
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: {{ .Release.Namespace }}
+spec:
+  enableInjector: {{ .Values.operator.admissionControllers.enabled }}
+  enableOperatorWebhook: {{ .Values.operator.admissionControllers.enabled }}
+  {{- with .Values.sriovOperatorConfig.configDaemonNodeSelector }}
+  configDaemonNodeSelector:
+    {{- range $k, $v := .}}{{printf "%s: %s" $k $v | nindent 4 }}{{ end }}
+  {{- end }}
+  logLevel: {{ .Values.sriovOperatorConfig.logLevel }}
+  disableDrain: {{ .Values.sriovOperatorConfig.disableDrain }}
+  configurationMode: {{ .Values.sriovOperatorConfig.configurationMode }}
+{{ end }}

--- a/deployment/sriov-network-operator/values.yaml
+++ b/deployment/sriov-network-operator/values.yaml
@@ -76,6 +76,19 @@ operator:
     #       ...
     #      -----END EC PRIVATE KEY-----
 
+sriovOperatorConfig:
+  # deploy sriovOperatorConfig CR with the below values
+  deploy: false
+  # node slectors for sriov-network-config-daemon
+  configDaemonNodeSelector: {}
+  # log level for both operator and sriov-network-config-daemon
+  logLevel: 2
+  # disable node draining when configuring SR-IOV, set to true in case of a single node
+  # cluster or any other justifiable reason
+  disableDrain: false
+  # sriov-network-config-daemon configuration mode. either "daemon" or "systemd"
+  configurationMode: daemon
+
 # Image URIs for sriov-network-operator components
 images:
   operator: ghcr.io/k8snetworkplumbingwg/sriov-network-operator

--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -20,7 +20,7 @@ load_manifest() {
       
       envsubst< namespace.yaml | ${OPERATOR_EXEC} apply -f -
     fi
-    files="service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml operator.yaml"
+    files="service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml sriovoperatorconfig.yaml operator.yaml"
     for m in ${files}; do
       if [ "$(echo ${EXCLUSIONS[@]} | grep -o ${m} | wc -w | xargs)" == "0" ] ; then
         envsubst< ${m} | ${OPERATOR_EXEC} apply ${namespace:-} --validate=false -f -

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -10,7 +10,7 @@ if [ -n "${namespace}" ] ; then
 fi
 
 pushd ${repo_dir}/deploy
-files="operator.yaml service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml"
+files="operator.yaml sriovoperatorconfig.yaml service_account.yaml role.yaml role_binding.yaml clusterrole.yaml clusterrolebinding.yaml configmap.yaml"
 for file in ${files}; do
   envsubst< ${file} | ${OPERATOR_EXEC} delete --ignore-not-found ${namespace} -f -
 done

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -399,6 +399,11 @@ func (dn *Daemon) operatorConfigAddHandler(obj interface{}) {
 
 func (dn *Daemon) operatorConfigChangeHandler(old, new interface{}) {
 	newCfg := new.(*sriovnetworkv1.SriovOperatorConfig)
+	if newCfg.Namespace != vars.Namespace || newCfg.Name != consts.DefaultConfigName {
+		log.Log.V(2).Info("unsupported SriovOperatorConfig", "namespace", newCfg.Namespace, "name", newCfg.Name)
+		return
+	}
+
 	snolog.SetLogLevel(newCfg.Spec.LogLevel)
 
 	newDisableDrain := newCfg.Spec.DisableDrain

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -19,9 +19,6 @@ var (
 	// developer mode allows the operator to use un-supported network devices
 	DevMode bool
 
-	// EnableAdmissionController allows the user to disable the operator webhooks
-	EnableAdmissionController bool
-
 	// NodeName initialize and used by the config-daemon to identify the node it's running on
 	NodeName = ""
 
@@ -78,12 +75,6 @@ func init() {
 	destdir := os.Getenv("DEST_DIR")
 	if destdir != "" {
 		Destdir = destdir
-	}
-
-	EnableAdmissionController = false
-	enableAdmissionController := os.Getenv("ADMISSION_CONTROLLERS_ENABLED")
-	if enableAdmissionController == "True" {
-		EnableAdmissionController = true
 	}
 
 	Namespace = os.Getenv("NAMESPACE")


### PR DESCRIPTION
Different deployment may have different configurations for SriovOperatorConfig.

if for example `SriovOperatorConfig.spec.disablePlugins` contains a list of plugins to disable, the creation of the default SriovOperatorConfig object may have undesirable effects on the cluster (as a plugin that was suppose to be disabled, would be enabled by default until configuration has updated).

This PR removes the creation of SriovOperatorConfig object by the operator and leaves the end user to decide the desired configuration.

To preserve a similar UX, we move the creation of SriovOperatorConfig CR to helm with same defaults as created by the operator.
upgrade of existing deployments would simply use the existing SriovOperatorConfig CR.
Deployments that dont install the operator via Helm (e.g if installed via OLM) the end user is expected to create SriovOperatorConfig CR post installation.

