### PR TITLE
[Remove Default Objs  4/4] Update Webhook

### DIFF
--- a/pkg/webhook/mutate.go
+++ b/pkg/webhook/mutate.go
@@ -23,6 +23,8 @@ func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1.AdmissionRespo
 	reviewResponse.Allowed = true
 
 	name := cr["metadata"].(map[string]interface{})["name"]
+	// Note(adrianc): the "default" policy is deprecated, we keep this skip below
+	// in case we encounter it in the cluster.
 	if name == constants.DefaultPolicyName {
 		// skip the default policy
 		return &reviewResponse, nil

--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -35,12 +35,12 @@ func validateSriovOperatorConfig(cr *sriovnetworkv1.SriovOperatorConfig, operati
 	log.Log.V(2).Info("validateSriovOperatorConfig", "object", cr)
 	var warnings []string
 
-	if cr.GetName() != consts.DefaultConfigName {
-		return false, warnings, fmt.Errorf("only default SriovOperatorConfig is used")
+	if operation == v1.Delete {
+		return true, warnings, nil
 	}
 
-	if operation == v1.Delete {
-		warnings = append(warnings, "default SriovOperatorConfig shouldn't be deleted")
+	if cr.GetName() != consts.DefaultConfigName || cr.GetNamespace() != vars.Namespace {
+		return false, warnings, fmt.Errorf("only default SriovOperatorConfig in %s namespace is used", vars.Namespace)
 	}
 
 	if cr.Spec.DisableDrain {
@@ -96,11 +96,7 @@ func validateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy, o
 	var warnings []string
 
 	if cr.GetName() == consts.DefaultPolicyName && cr.GetNamespace() == os.Getenv("NAMESPACE") {
-		if operation == v1.Delete {
-			warnings = append(warnings, "default SriovNetworkNodePolicy shouldn't be deleted")
-		}
-
-		// skip validating default policy
+		// skip validating (deprecated) default policy
 		return true, warnings, nil
 	}
 

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -13,6 +13,7 @@ import (
 
 	. "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
 
 	fakesnclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/fake"
 )
@@ -136,7 +137,8 @@ func NewNode() *corev1.Node {
 func newDefaultOperatorConfig() *SriovOperatorConfig {
 	return &SriovOperatorConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "default",
+			Name:      "default",
+			Namespace: vars.Namespace,
 		},
 		Spec: SriovOperatorConfigSpec{
 			ConfigDaemonNodeSelector: map[string]string{},
@@ -157,7 +159,7 @@ func TestValidateSriovOperatorConfigWithDefaultOperatorConfig(t *testing.T) {
 	ok, w, err := validateSriovOperatorConfig(config, "DELETE")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ok).To(Equal(true))
-	g.Expect(w[0]).To(ContainSubstring("default SriovOperatorConfig shouldn't be deleted"))
+	g.Expect(w).To(BeEmpty())
 
 	ok, _, err = validateSriovOperatorConfig(config, "UPDATE")
 	g.Expect(err).NotTo(HaveOccurred())
@@ -226,7 +228,7 @@ func TestValidateSriovNetworkNodePolicyWithDefaultPolicy(t *testing.T) {
 	ok, w, err := validateSriovNetworkNodePolicy(policy, "DELETE")
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(ok).To(Equal(true))
-	g.Expect(w[0]).To(ContainSubstring("default SriovNetworkNodePolicy shouldn't be deleted"))
+	g.Expect(w).To(BeEmpty())
 
 	ok, _, err = validateSriovNetworkNodePolicy(policy, "UPDATE")
 	g.Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
As the operator no longer creates default
SriovOperatorConfig and SriovNetworkNodePolicy
the webhook is updated in the following Manner:

Validating:
- Allow deletion of default config/policy.
- Block create/update of non default config CR

Mutating:
- keep skipping default but add a comment to mark as deprecated.

NOTE for reviewers: should be merged after #622 