### PR TITLE
e2e: Dump multus namespace on failures

### DIFF
--- a/test/util/k8sreporter/reporter.go
+++ b/test/util/k8sreporter/reporter.go
@@ -26,6 +26,8 @@ func New(reportPath string) (*kniK8sReporter.KubernetesReporter, error) {
 		operatorNamespace = "openshift-sriov-network-operator"
 	}
 
+	multusNamespace := os.Getenv("MULTUS_NAMESPACE")
+
 	dumpNamespace := func(ns string) bool {
 		switch {
 		case ns == namespaces.Test:
@@ -33,6 +35,8 @@ func New(reportPath string) (*kniK8sReporter.KubernetesReporter, error) {
 		case ns == operatorNamespace:
 			return true
 		case strings.HasPrefix(ns, "sriov-"):
+			return true
+		case multusNamespace != "" && ns == multusNamespace:
 			return true
 		}
 		return false


### PR DESCRIPTION
Cluster info gathered at the end of the test run might not contain all the needed information, as nodes
might  have been reboot and logs are gone.
The `k8sreporter` runs as a Gomega Failure Handler and can help debugging the flaking test:

```
[sriov] operator Generic SriovNetworkNodePolicy CNI Logging level [It] Debug logging should be visible in multus pod
```