### PR TITLE
Fix indentation for --parallel-nic-config flag in the daemon manifest

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -103,7 +103,7 @@ spec:
           - --disable-plugins={{.}}
         {{- end }}
         {{- if .ParallelNicConfig }}
-        - --parallel-nic-config
+          - --parallel-nic-config
         {{- end }}
         env:
           - name: NODE_NAME


### PR DESCRIPTION
Fix indentation for --parallel-nic-config flag in the daemon manifest.
Without the fix template produces invalid YAML if `parallelNicConfig` feature gate is enabled.

cc @e0ne 