### PR TITLE
refactor: DiscoverSriovDevices imporvements

### DIFF
--- a/pkg/host/internal/lib/netlink/mock/mock_netlink.go
+++ b/pkg/host/internal/lib/netlink/mock/mock_netlink.go
@@ -131,6 +131,20 @@ func (mr *MockNetlinkLibMockRecorder) LinkByName(name interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkByName", reflect.TypeOf((*MockNetlinkLib)(nil).LinkByName), name)
 }
 
+// LinkSetMTU mocks base method.
+func (m *MockNetlinkLib) LinkSetMTU(link netlink.Link, mtu int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkSetMTU", link, mtu)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// LinkSetMTU indicates an expected call of LinkSetMTU.
+func (mr *MockNetlinkLibMockRecorder) LinkSetMTU(link, mtu interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkSetMTU", reflect.TypeOf((*MockNetlinkLib)(nil).LinkSetMTU), link, mtu)
+}
+
 // LinkSetUp mocks base method.
 func (m *MockNetlinkLib) LinkSetUp(link netlink.Link) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/internal/lib/netlink/netlink.go
+++ b/pkg/host/internal/lib/netlink/netlink.go
@@ -30,6 +30,9 @@ type NetlinkLib interface {
 	// LinkSetUp enables the link device.
 	// Equivalent to: `ip link set $link up`
 	LinkSetUp(link Link) error
+	// LinkSetMTU sets the mtu of the link device.
+	// Equivalent to: `ip link set $link mtu $mtu`
+	LinkSetMTU(link Link, mtu int) error
 	// DevlinkGetDeviceByName provides a pointer to devlink device and nil error,
 	// otherwise returns an error code.
 	DevLinkGetDeviceByName(bus string, device string) (*netlink.DevlinkDevice, error)
@@ -69,6 +72,12 @@ func (w *libWrapper) LinkSetVfHardwareAddr(link Link, vf int, hwaddr net.Hardwar
 // Equivalent to: `ip link set $link up`
 func (w *libWrapper) LinkSetUp(link Link) error {
 	return netlink.LinkSetUp(link)
+}
+
+// LinkSetMTU sets the mtu of the link device.
+// Equivalent to: `ip link set $link mtu $mtu`
+func (w *libWrapper) LinkSetMTU(link Link, mtu int) error {
+	return netlink.LinkSetMTU(link, mtu)
 }
 
 // DevlinkGetDeviceByName provides a pointer to devlink device and nil error,

--- a/pkg/host/manager.go
+++ b/pkg/host/manager.go
@@ -38,11 +38,12 @@ type hostManager struct {
 
 func NewHostManager(utilsInterface utils.CmdInterface) HostManagerInterface {
 	dpUtils := dputils.New()
+	nl := netlink.New()
 	k := kernel.New(utilsInterface)
-	n := network.New(utilsInterface, dpUtils)
+	n := network.New(utilsInterface, dpUtils, nl)
 	sv := service.New(utilsInterface)
 	u := udev.New(utilsInterface)
-	sr := sriov.New(utilsInterface, k, n, u, netlink.New(), dpUtils)
+	sr := sriov.New(utilsInterface, k, n, u, nl, dpUtils)
 	v := vdpa.New(k, govdpa.New())
 
 	return &hostManager{


### PR DESCRIPTION
- Move check for supported model earlier in the loop to exit early  in case of unsupported device

- Use Netlink Link object to get some PF information instead of sysfs

- Use Netlink Link object to get some VF information instead of sysfs