### PR TITLE
[switchdev 8/x] Add support for switchdev configuration to sriov pkg

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -234,6 +234,22 @@ func FindInterface(interfaces Interfaces, name string) (iface Interface, err err
 	return Interface{}, fmt.Errorf("unable to find interface: %v", name)
 }
 
+// GetEswitchModeFromSpec returns ESwitchMode from the interface spec, returns legacy if not set
+func GetEswitchModeFromSpec(ifaceSpec *Interface) string {
+	if ifaceSpec.EswitchMode == "" {
+		return ESwithModeLegacy
+	}
+	return ifaceSpec.EswitchMode
+}
+
+// GetEswitchModeFromStatus returns ESwitchMode from the interface status, returns legacy if not set
+func GetEswitchModeFromStatus(ifaceStatus *InterfaceExt) string {
+	if ifaceStatus.EswitchMode == "" {
+		return ESwithModeLegacy
+	}
+	return ifaceStatus.EswitchMode
+}
+
 func NeedToUpdateSriov(ifaceSpec *Interface, ifaceStatus *InterfaceExt) bool {
 	if ifaceSpec.Mtu > 0 {
 		mtu := ifaceSpec.Mtu

--- a/api/v1/helper_test.go
+++ b/api/v1/helper_test.go
@@ -802,3 +802,67 @@ func TestVhostVdpaNodePolicyApply(t *testing.T) {
 		})
 	}
 }
+
+func TestGetEswitchModeFromSpec(t *testing.T) {
+	testtable := []struct {
+		tname          string
+		spec           *v1.Interface
+		expectedResult string
+	}{
+		{
+			tname:          "set to legacy",
+			spec:           &v1.Interface{EswitchMode: v1.ESwithModeLegacy},
+			expectedResult: v1.ESwithModeLegacy,
+		},
+		{
+			tname:          "set to switchdev",
+			spec:           &v1.Interface{EswitchMode: v1.ESwithModeSwitchDev},
+			expectedResult: v1.ESwithModeSwitchDev,
+		},
+		{
+			tname:          "not set",
+			spec:           &v1.Interface{},
+			expectedResult: v1.ESwithModeLegacy,
+		},
+	}
+	for _, tc := range testtable {
+		t.Run(tc.tname, func(t *testing.T) {
+			result := v1.GetEswitchModeFromSpec(tc.spec)
+			if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetEswitchModeFromStatus(t *testing.T) {
+	testtable := []struct {
+		tname          string
+		spec           *v1.InterfaceExt
+		expectedResult string
+	}{
+		{
+			tname:          "set to legacy",
+			spec:           &v1.InterfaceExt{EswitchMode: v1.ESwithModeLegacy},
+			expectedResult: v1.ESwithModeLegacy,
+		},
+		{
+			tname:          "set to switchdev",
+			spec:           &v1.InterfaceExt{EswitchMode: v1.ESwithModeSwitchDev},
+			expectedResult: v1.ESwithModeSwitchDev,
+		},
+		{
+			tname:          "not set",
+			spec:           &v1.InterfaceExt{},
+			expectedResult: v1.ESwithModeLegacy,
+		},
+	}
+	for _, tc := range testtable {
+		t.Run(tc.tname, func(t *testing.T) {
+			result := v1.GetEswitchModeFromStatus(tc.spec)
+			if diff := cmp.Diff(tc.expectedResult, result); diff != "" {
+				t.Errorf("unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -41,7 +41,7 @@ var _ = Describe("SRIOV", func() {
 		hostMock = hostMockPkg.NewMockHostManagerInterface(testCtrl)
 		storeManagerMode = hostStoreMockPkg.NewMockManagerInterface(testCtrl)
 
-		s = New(nil, hostMock, hostMock, hostMock, netlinkLibMock, dputilsLibMock)
+		s = New(nil, hostMock, hostMock, hostMock, hostMock, netlinkLibMock, dputilsLibMock)
 	})
 
 	AfterEach(func() {
@@ -80,7 +80,7 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(nil, syscall.ENODEV)
 			mode, err := s.GetNicSriovMode("0000:d8:00.0")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(mode).To(BeEmpty())
+			Expect(mode).To(Equal("legacy"))
 		})
 	})
 
@@ -113,6 +113,8 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().IsKernelLockdownMode().Return(false)
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().AddUdevRule("0000:d8:00.0").Return(nil)
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
@@ -176,6 +178,8 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().IsKernelLockdownMode().Return(false)
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil)
 			hostMock.EXPECT().AddUdevRule("0000:d8:00.0").Return(nil)
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil)
 			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
@@ -184,9 +188,9 @@ var _ = Describe("SRIOV", func() {
 			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
 
 			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test").Times(2)
 			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", true).Return(nil)
-			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
 			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
 			vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
@@ -208,6 +212,70 @@ var _ = Describe("SRIOV", func() {
 							PolicyName:   "test-policy0",
 							Mtu:          2000,
 							IsRdma:       true,
+						}},
+				}},
+				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
+				map[string]bool{}, false)).NotTo(HaveOccurred())
+			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
+		})
+
+		It("should configure switchdev", func() {
+			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0"},
+				Files: map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
+			})
+
+			hostMock.EXPECT().IsKernelLockdownMode().Return(false)
+			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
+			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			hostMock.EXPECT().AddUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
+			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("", syscall.EINVAL)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).Times(2)
+			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
+			pfLinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{OperState: netlink.OperDown})
+			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)
+			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
+
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
+			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", true).Return(nil)
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
+			hostMock.EXPECT().TryGetInterfaceName("0000:d8:00.2").Return("enp216s0f0_0")
+			vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			vf0Mac, _ := net.ParseMAC("02:42:19:51:2f:af")
+			vf0LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{HardwareAddr: vf0Mac})
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0_0").Return(vf0LinkMock, nil)
+			netlinkLibMock.EXPECT().LinkSetVfHardwareAddr(vf0LinkMock, 0, vf0Mac).Return(nil)
+			hostMock.EXPECT().GetPhysPortName("enp216s0f0np0").Return("p0", nil)
+			hostMock.EXPECT().GetPhysSwitchID("enp216s0f0np0").Return("7cfe90ff2cc0", nil)
+			hostMock.EXPECT().AddVfRepresentorUdevRule("0000:d8:00.0", "enp216s0f0np0", "7cfe90ff2cc0", "p0").Return(nil)
+			hostMock.EXPECT().CreateVDPADevice("0000:d8:00.2", "vhost_vdpa")
+
+			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
+
+			Expect(s.ConfigSriovInterfaces(storeManagerMode,
+				[]sriovnetworkv1.Interface{{
+					Name:        "enp216s0f0np0",
+					PciAddress:  "0000:d8:00.0",
+					NumVfs:      1,
+					LinkType:    "ETH",
+					EswitchMode: "switchdev",
+					VfGroups: []sriovnetworkv1.VfGroup{
+						{
+							VfRange:      "0-0",
+							ResourceName: "test-resource0",
+							PolicyName:   "test-policy0",
+							Mtu:          2000,
+							IsRdma:       true,
+							VdpaType:     "vhost_vdpa",
 						}},
 				}},
 				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
@@ -240,6 +308,9 @@ var _ = Describe("SRIOV", func() {
 		It("externally managed - wrong MTU", func() {
 			hostMock.EXPECT().IsKernelLockdownMode().Return(false)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(1)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
+				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
+				nil)
 			hostMock.EXPECT().GetNetdevMTU("0000:d8:00.0")
 			Expect(s.ConfigSriovInterfaces(storeManagerMode,
 				[]sriovnetworkv1.Interface{{
@@ -272,7 +343,12 @@ var _ = Describe("SRIOV", func() {
 				PciAddress: "0000:d8:00.0",
 				NumVfs:     2,
 			}, true, nil)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
+				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
+				nil)
 			hostMock.EXPECT().RemoveUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.0", 1500).Return(nil)
 
 			Expect(s.ConfigSriovInterfaces(storeManagerMode,
 				[]sriovnetworkv1.Interface{},
@@ -280,6 +356,7 @@ var _ = Describe("SRIOV", func() {
 					{
 						Name:       "enp216s0f0np0",
 						PciAddress: "0000:d8:00.0",
+						LinkType:   "ETH",
 						NumVfs:     2,
 						TotalVfs:   2,
 					}},
@@ -314,6 +391,9 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().IsKernelLockdownMode().Return(false)
 			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(2)
 			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(
+				&netlink.DevlinkDevice{Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}},
+				nil)
 			hostMock.EXPECT().AddUdevRule("0000:d8:00.0").Return(nil)
 			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2", "0000:d8:00.3"}, nil)
 			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)

--- a/pkg/host/internal/vdpa/vdpa.go
+++ b/pkg/host/internal/vdpa/vdpa.go
@@ -78,6 +78,10 @@ func (v *vdpa) DeleteVDPADevice(pciAddr string) error {
 			funcLog.V(2).Info("DeleteVDPADevice(): VDPA device not found")
 			return nil
 		}
+		if errors.Is(err, syscall.ENOENT) {
+			funcLog.V(2).Info("DeleteVDPADevice(): VDPA module is not loaded")
+			return nil
+		}
 		funcLog.Error(err, "DeleteVDPADevice(): fail to remove VDPA device")
 		return err
 	}
@@ -95,6 +99,10 @@ func (v *vdpa) DiscoverVDPAType(pciAddr string) string {
 	if err != nil {
 		if errors.Is(err, syscall.ENODEV) {
 			funcLog.V(2).Info("DiscoverVDPAType(): VDPA device for VF not found")
+			return ""
+		}
+		if errors.Is(err, syscall.ENOENT) {
+			funcLog.V(2).Info("DiscoverVDPAType(): VDPA module is not loaded")
 			return ""
 		}
 		funcLog.Error(err, "DiscoverVDPAType(): unable to get VF VDPA devices")

--- a/pkg/host/manager.go
+++ b/pkg/host/manager.go
@@ -44,8 +44,8 @@ func NewHostManager(utilsInterface utils.CmdInterface) HostManagerInterface {
 	n := network.New(utilsInterface, dpUtils, netlinkLib, ethtoolLib)
 	sv := service.New(utilsInterface)
 	u := udev.New(utilsInterface)
-	sr := sriov.New(utilsInterface, k, n, u, netlinkLib, dpUtils)
 	v := vdpa.New(k, netlinkLib)
+	sr := sriov.New(utilsInterface, k, n, u, v, netlinkLib, dpUtils)
 
 	return &hostManager{
 		utilsInterface,


### PR DESCRIPTION
Add support for switchdev configuration to sriov pkg

This PR introduce required logic to handle switchdev configuration by the sriov pkg.

This code is a "dead" code at the moment and will never run (except tests), because all switchdev devices are filtered by the upper layer.

Depends on #633 and #628.

Only two last commits are relevant to the PR.

cc @adrianchiris @SchSeba @zeeke 