### PR TITLE
e2e: fix `CNI Logging level` test case

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -1013,11 +1013,9 @@ var _ = Describe("[sriov] operator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				waitForNetAttachDef(sriovNetworkName, namespaces.Test)
 
-				podDeployTime := time.Now()
-
 				testPod := createTestPod(node, []string{sriovNetworkName})
 
-				recentMultusLogs := getMultusPodLogs(testPod.Spec.NodeName, podDeployTime)
+				recentMultusLogs := getMultusPodLogs(testPod.Spec.NodeName, testPod.ObjectMeta.CreationTimestamp.Time)
 
 				Expect(recentMultusLogs).To(
 					ContainElement(


### PR DESCRIPTION
It can happen that clock of the cluster nodes is not aligned to the clock of test runner. In such cases, asking a pod for logs since a given time might end in an empty response, as the requested time can be in the future (from the cluster perspective).

Use the pod's CreationTimestamp timestamp field to be sure to pass to the API server a meaningful value.