### PR TITLE
Require reboot if drain is needed for systemd mode

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -573,7 +573,8 @@ func (dn *Daemon) nodeStateSyncHandler() error {
 			}
 		}
 		reqDrain = reqDrain || systemdConfModified
-		reqReboot = reqReboot || systemdConfModified
+		// require reboot if drain needed for systemd mode
+		reqReboot = reqReboot || systemdConfModified || reqDrain
 		log.Log.V(0).Info("nodeStateSyncHandler(): systemd mode WriteConfFile results",
 			"drain-required", reqDrain, "reboot-required", reqReboot, "disable-drain", dn.disableDrain)
 


### PR DESCRIPTION
We need to reboot the node in a systemd mode if any changes are required to be applied to re-stert sriov config service.