### PR TITLE
Experiment: Remove stdin from the ExecCommand call in tests

### DIFF
--- a/test/util/pod/pod.go
+++ b/test/util/pod/pod.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -116,7 +115,6 @@ func ExecCommand(cs *testclient.ClientSet, pod *corev1.Pod, command ...string) (
 		VersionedParams(&corev1.PodExecOptions{
 			Container: pod.Spec.Containers[0].Name,
 			Command:   command,
-			Stdin:     true,
 			Stdout:    true,
 			Stderr:    true,
 			TTY:       true,
@@ -128,7 +126,6 @@ func ExecCommand(cs *testclient.ClientSet, pod *corev1.Pod, command ...string) (
 	}
 
 	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  os.Stdin,
 		Stdout: &buf,
 		Stderr: &errbuf,
 		Tty:    true,


### PR DESCRIPTION
We don't use stdin to path data, so there is no need to open the stream.
This should improve stability of the Exec call.

On my environment I noticed that sometimes ExecCommand returns empty output during the test.
Detaching of the stdin stream fixed this issue on my setup.