### PR TITLE
Fix `IsKernelLockdownMode`

### DIFF
--- a/pkg/host/internal/kernel/kernel.go
+++ b/pkg/host/internal/kernel/kernel.go
@@ -579,7 +579,7 @@ func (k *kernel) IsKernelLockdownMode() bool {
 	path := utils.GetHostExtension()
 	path = filepath.Join(path, "/sys/kernel/security/lockdown")
 
-	stdout, stderr, err := k.utilsHelper.RunCommand("/bin/sh", "-c", "cat", path)
+	stdout, stderr, err := k.utilsHelper.RunCommand("cat", path)
 	log.Log.V(2).Info("IsKernelLockdownMode()", "output", stdout, "error", err)
 	if err != nil {
 		log.Log.Error(err, "IsKernelLockdownMode(): failed to check for lockdown file", "stderr", stderr)

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,6 +1,8 @@
 package utils_test
 
 import (
+	"testing"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -75,3 +77,8 @@ var _ = Describe("HashConfigMap", func() {
 		Expect(hash1).To(Equal(hash2))
 	})
 })
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Suite")
+}


### PR DESCRIPTION
Passing `/bin/sh -c xxx` to `RunCommand` requires xxx to be a single string
representing a full command. Multiple arguments shifts the executed command
from:
```
/bin/sh -c "cat file.txt"
```
to:
```
/bin/sh -c cat file.txt
```

This regression has been introduced by:
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/553