### PR TITLE
support switching resource injector webhook to Fail

### DIFF
--- a/bindata/manifests/webhook/003-webhook.yaml
+++ b/bindata/manifests/webhook/003-webhook.yaml
@@ -15,7 +15,14 @@ webhooks:
   - name: network-resources-injector-config.k8s.io
     sideEffects: None
     admissionReviewVersions: ["v1", "v1beta1"]
+    {{- if .resourceInjectorMatchCondition}}
+    failurePolicy: Fail
+    matchConditions:
+      - name: 'include-networks-annotation'
+        expression: '"k8s.v1.cni.cncf.io/networks" in object.metadata.annotations'
+    {{- else }}
     failurePolicy: Ignore
+    {{- end}}
     clientConfig:
       service:
         name: network-resources-injector-service

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -247,6 +247,12 @@ func (r *SriovOperatorConfigReconciler) syncWebhookObjs(ctx context.Context, dc 
 			data.Data["ExternalControlPlane"] = external
 		}
 
+		// check for ResourceInjectorMatchConditionFeatureGate feature gate
+		data.Data[consts.ResourceInjectorMatchConditionFeatureGate] = false
+		if resourceInjector, ok := dc.Spec.FeatureGates[consts.ResourceInjectorMatchConditionFeatureGate]; ok {
+			data.Data[consts.ResourceInjectorMatchConditionFeatureGate] = resourceInjector
+		}
+
 		objs, err := render.RenderDir(path, &data)
 		if err != nil {
 			logger.Error(err, "Fail to render webhook manifests")

--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -113,7 +113,13 @@ const (
 	KernelArgIntelIommu = "intel_iommu=on"
 	KernelArgIommuPt    = "iommu=pt"
 
+	// Feature gates
+	// ParallelNicConfigFeatureGate: allow to configure nics in parallel
 	ParallelNicConfigFeatureGate = "parallelNicConfig"
+
+	// ResourceInjectorMatchConditionFeatureGate: switch injector to fail policy and add mactch condition
+	// this will make the mutating webhook to be called only when a pod has 'k8s.v1.cni.cncf.io/networks' annotation
+	ResourceInjectorMatchConditionFeatureGate = "resourceInjectorMatchCondition"
 )
 
 const (


### PR DESCRIPTION
Using MatchConditions in the mutating webhook allow us to only call the webhook for pods with annotation  `k8s.v1.cni.cncf.io/networks`

Adding this feature under a featureGate as the MatchConditions was introduced in newer k8s version (beta on 1.28)