### PR TITLE
Set netdevice as default in the CRD

### DIFF
--- a/api/v1/sriovnetworknodepolicy_types.go
+++ b/api/v1/sriovnetworknodepolicy_types.go
@@ -42,6 +42,7 @@ type SriovNetworkNodePolicySpec struct {
 	// NicSelector selects the NICs to be configured
 	NicSelector SriovNetworkNicSelector `json:"nicSelector"`
 	// +kubebuilder:validation:Enum=netdevice;vfio-pci
+	// +kubebuilder:default=netdevice
 	// The driver type for configured VFs. Allowed value "netdevice", "vfio-pci". Defaults to netdevice.
 	DeviceType string `json:"deviceType,omitempty"`
 	// RDMA mode. Defaults to false.

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -37,6 +37,7 @@ spec:
             description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
             properties:
               deviceType:
+                default: netdevice
                 description: The driver type for configured VFs. Allowed value "netdevice",
                   "vfio-pci". Defaults to netdevice.
                 enum:

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -37,6 +37,7 @@ spec:
             description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
             properties:
               deviceType:
+                default: netdevice
                 description: The driver type for configured VFs. Allowed value "netdevice",
                   "vfio-pci". Defaults to netdevice.
                 enum:

--- a/pkg/webhook/mutate.go
+++ b/pkg/webhook/mutate.go
@@ -11,10 +11,9 @@ import (
 )
 
 var (
-	defaultPriorityPatch   = map[string]interface{}{"op": "add", "path": "/spec/priority", "value": 99}
-	defaultDeviceTypePatch = map[string]interface{}{"op": "add", "path": "/spec/deviceType", "value": "netdevice"}
-	defaultIsRdmaPatch     = map[string]interface{}{"op": "add", "path": "/spec/isRdma", "value": false}
-	InfiniBandIsRdmaPatch  = map[string]interface{}{"op": "add", "path": "/spec/isRdma", "value": true}
+	defaultPriorityPatch  = map[string]interface{}{"op": "add", "path": "/spec/priority", "value": 99}
+	defaultIsRdmaPatch    = map[string]interface{}{"op": "add", "path": "/spec/isRdma", "value": false}
+	InfiniBandIsRdmaPatch = map[string]interface{}{"op": "add", "path": "/spec/isRdma", "value": true}
 )
 
 func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1.AdmissionResponse, error) {
@@ -35,10 +34,6 @@ func mutateSriovNetworkNodePolicy(cr map[string]interface{}) (*v1.AdmissionRespo
 	if _, ok := spec.(map[string]interface{})["priority"]; !ok {
 		log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set default priority to lowest for", "policy-name", name)
 		patchs = append(patchs, defaultPriorityPatch)
-	}
-	if _, ok := spec.(map[string]interface{})["deviceType"]; !ok {
-		log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set default deviceType to netdevice for policy", "policy-name", name)
-		patchs = append(patchs, defaultDeviceTypePatch)
 	}
 	if _, ok := spec.(map[string]interface{})["isRdma"]; !ok {
 		log.Log.V(2).Info("mutateSriovNetworkNodePolicy(): set default isRdma to false for policy", "policy-name", name)


### PR DESCRIPTION
This sets netdevice as default in the CRD to not depend on the mutating webhook.

Fixes https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/632