### PR TITLE
Fix resource injector for pods wihtout annotation

### DIFF
--- a/bindata/manifests/webhook/003-webhook.yaml
+++ b/bindata/manifests/webhook/003-webhook.yaml
@@ -19,7 +19,7 @@ webhooks:
     failurePolicy: Fail
     matchConditions:
       - name: 'include-networks-annotation'
-        expression: '"k8s.v1.cni.cncf.io/networks" in object.metadata.annotations'
+        expression: 'has(object.metadata.annotations) && "k8s.v1.cni.cncf.io/networks" in object.metadata.annotations'
     {{- else }}
     failurePolicy: Ignore
     {{- end}}


### PR DESCRIPTION
This is to fix a problem when pods doesn't have annotations at all

Warning  FailedCreate  0s (x11 over 5s)  replicaset-controller  Error creating: pods is forbidden: expression '"k8s.v1.cni.cncf.io/networks" in object.metadata.annotations' resulted in error: no such key: annotations