### PR TITLE
Update Helm chart version

### DIFF
--- a/deployment/sriov-network-operator/Chart.yaml
+++ b/deployment/sriov-network-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: sriov-network-operator
-version: 0.1.0
+version: 1.2.0
 kubeVersion: '>= 1.16.0-0'
 appVersion: 1.2.0
 description: SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster


### PR DESCRIPTION
This pull request (PR) is aimed at enhancing the clarity and functionality of the Helm chart by updating its version to `1.2.0`, aligning it with the appVersion. According to Helm's documentation, the version property denotes the version of the Helm chart, while the appVersion signifies the version of the application (or image) it represents (Ref: [Helm Documentation](https://helm.sh/docs/topics/charts/#the-chartyaml-file)).

The current situation, where the chart version remains stagnant at `0.1.0`, poses a potential issue. Users deploying the same chart version might receive silent updates, primarily due to changes in the underlying images. Such behavior deviates from the intended functionality of Helm charts. Ideally, any modification to the chart should result in an increment of the chart version. On the other hand, the appVersion should only be incremented when there are changes to the underlying image.

In summary, updating the Helm chart version to reflect changes accurately enhances transparency, facilitates effective version control, and aligns with best practices and community standards in Helm chart development and deployment.