### PR TITLE
Fix configDaemonNodeSelector in SriovOperatorConfig in helm chart

### DIFF
--- a/deployment/sriov-network-operator/templates/sriovoperatorconfig.yaml
+++ b/deployment/sriov-network-operator/templates/sriovoperatorconfig.yaml
@@ -9,7 +9,7 @@ spec:
   enableOperatorWebhook: {{ .Values.operator.admissionControllers.enabled }}
   {{- with .Values.sriovOperatorConfig.configDaemonNodeSelector }}
   configDaemonNodeSelector:
-    {{- range $k, $v := .}}{{printf "%s: %s" $k $v | nindent 4 }}{{ end }}
+    {{- range $k, $v := .}}{{printf "%s: \"%s\"" $k $v | nindent 4 }}{{ end }}
   {{- end }}
   logLevel: {{ .Values.sriovOperatorConfig.logLevel }}
   disableDrain: {{ .Values.sriovOperatorConfig.disableDrain }}


### PR DESCRIPTION
Use quotes for values  in `configDaemonNodeSelector` selector to be compatible with values like: "123", "true".

cc @e0ne 


