### PR TITLE
Change system dependencies for "post" systemd service

### DIFF
--- a/bindata/manifests/sriov-config-service/kubernetes/sriov-config-post-network-service.yaml
+++ b/bindata/manifests/sriov-config-service/kubernetes/sriov-config-post-network-service.yaml
@@ -1,8 +1,8 @@
 contents: |
   [Unit]
   Description=Configures SRIOV NIC - post network configuration
-  After=systemd-networkd-wait-online.service NetworkManager-wait-online.service
-  Before=network-online.target
+  After=systemd-networkd-wait-online.service NetworkManager-wait-online.service openvswitch-switch.service
+  Before=kubelet.service
 
   [Service]
   Type=oneshot
@@ -10,6 +10,6 @@ contents: |
   StandardOutput=journal+console
 
   [Install]
-  WantedBy=network-online.target
+  WantedBy=multi-user.target
 enabled: true
 name: sriov-config-post-network.service

--- a/bindata/manifests/sriov-config-service/openshift/sriov-config-service.yaml
+++ b/bindata/manifests/sriov-config-service/openshift/sriov-config-service.yaml
@@ -33,8 +33,8 @@ spec:
             # Removal of this file signals firstboot completion
             ConditionPathExists=!/etc/ignition-machine-config-encapsulated.json
             Description=Configures SRIOV NIC - post network configuration
-            After=systemd-networkd-wait-online.service NetworkManager-wait-online.service
-            Before=network-online.target
+            After=systemd-networkd-wait-online.service NetworkManager-wait-online.service openvswitch-switch.service
+            Before=kubelet.service
 
             [Service]
             Type=oneshot
@@ -42,6 +42,6 @@ spec:
             StandardOutput=journal+console
 
             [Install]
-            WantedBy=network-online.target
+            WantedBy=multi-user.target
           enabled: true
           name: "sriov-config-post-network.service"

--- a/pkg/host/internal/service/service.go
+++ b/pkg/host/internal/service/service.go
@@ -97,8 +97,11 @@ func (s *service) EnableService(service *types.Service) error {
 	}
 	defer exit()
 
-	// Enable service
-	_, _, err = s.utilsHelper.RunCommand("systemctl", "enable", service.Name)
+	// Enable the service
+	// we use reenable command (the command is a combination of disable+enable) to reset
+	// symlinks for the unit and make sure that only symlinks that are currently
+	// configured in the [Install] section exist for the service.
+	_, _, err = s.utilsHelper.RunCommand("systemctl", "reenable", service.Name)
 	return err
 }
 


### PR DESCRIPTION
This is required to be compatible with OVS installations that use SysV init scripts (wrapped with systemd-sysv-generator).
 On such systems, OVS depends on the network-online.target, so the start order of services changes (OVS will start after the "post" service). The proposed solution is to add the following explicit dependencies 

After: openvswitch-switch.service
Before: kubelet.service.

Note:  the dependency is ignored if the openvswitch-switch.service is not found.

cc @e0ne @SchSeba @zeeke 