### PR TITLE
Fix service CMD to return an error if device discovery failed

### DIFF
--- a/cmd/sriov-network-config-daemon/service.go
+++ b/cmd/sriov-network-config-daemon/service.go
@@ -182,7 +182,7 @@ func callPlugin(setupLog logr.Logger, phase string, conf *systemd.SriovConfig, h
 
 	nodeState, err := getNetworkNodeState(setupLog, conf, hostHelpers)
 	if err != nil {
-		return nil
+		return err
 	}
 	_, _, err = configPlugin.OnNodeStateChange(nodeState)
 	if err != nil {


### PR DESCRIPTION
The service should not silently ignore the discovery error.