### PR TITLE
Make OVS_CNI_IMAGE truly optional

### DIFF
--- a/hack/env.sh
+++ b/hack/env.sh
@@ -9,10 +9,10 @@ if [ -z $SKIP_VAR_SET ]; then
         export SRIOV_NETWORK_WEBHOOK_IMAGE=${SRIOV_NETWORK_WEBHOOK_IMAGE:-ghcr.io/k8snetworkplumbingwg/sriov-network-operator-webhook}
         export SRIOV_NETWORK_OPERATOR_IMAGE=${SRIOV_NETWORK_OPERATOR_IMAGE:-ghcr.io/k8snetworkplumbingwg/sriov-network-operator}
 else
+        # ensure that OVS_CNI_IMAGE is set, empty string is a valid value
+        OVS_CNI_IMAGE=${OVS_CNI_IMAGE:-}
         [ -z $SRIOV_CNI_IMAGE ] && echo "SRIOV_CNI_IMAGE is empty but SKIP_VAR_SET is set" && exit 1
         [ -z $SRIOV_INFINIBAND_CNI_IMAGE ] && echo "SRIOV_INFINIBAND_CNI_IMAGE is empty but SKIP_VAR_SET is set" && exit 1
-        # check that OVS_CNI_IMAGE is set to any value, empty string is a valid value
-        [ -z ${OVS_CNI_IMAGE+set} ] && echo "OVS_CNI_IMAGE is empty but SKIP_VAR_SET is set" && exit 1
         [ -z $SRIOV_DEVICE_PLUGIN_IMAGE ] && echo "SRIOV_DEVICE_PLUGIN_IMAGE is empty but SKIP_VAR_SET is set" && exit 1
         [ -z $NETWORK_RESOURCES_INJECTOR_IMAGE ] && echo "NETWORK_RESOURCES_INJECTOR_IMAGE is empty but SKIP_VAR_SET is set" && exit 1
         [ -z $SRIOV_NETWORK_CONFIG_DAEMON_IMAGE ] && echo "SRIOV_NETWORK_CONFIG_DAEMON_IMAGE is empty but SKIP_VAR_SET is set" && exit 1


### PR DESCRIPTION
The `hack/env.sh` script expected that `OVS_CNI_IMAGE` is set, and exited with an error when it was not. There is no good reason for erroring out on missing variable for an optional image. Instead, set the variable to empty string when it is unset.

When `SKIP_VAR_SET` is set, the default for `OVS_CNI_IMAGE` remains a valid image.