### PR TITLE
Let "depoly-setup.sh" and "undeploy.sh" fail on error

### DIFF
--- a/hack/deploy-setup.sh
+++ b/hack/deploy-setup.sh
@@ -3,7 +3,7 @@
 # to deploy.  It assumes it is capable of login as a
 # user who has the cluster-admin role
 
-# set -euxo pipefail
+set -eo pipefail
 
 source "$(dirname $0)/common"
 

--- a/hack/undeploy.sh
+++ b/hack/undeploy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-#set -euxo pipefail
+
+set -eo pipefail
 
 source "$(dirname $0)/common"
 


### PR DESCRIPTION
Ignoring errors seems not best. It can make it harder to find problems with the script.

If a command in the script is known to fail for valid reasons, then that should be treated specially (for example, with `|| :`). By default, treat any unexpected failure as fatal and propagate the failure to the caller.

Fixes: 88441502023d ('Add RBAC for cluster resource')

CC: @pliurh