### PR TITLE
Use helm values to expand the supported NICs

### DIFF
--- a/deployment/sriov-network-operator/README.md
+++ b/deployment/sriov-network-operator/README.md
@@ -59,6 +59,7 @@ We have introduced the following Chart parameters.
 | Name | Type | Default | description |
 | ---- |------|---------|-------------|
 | `imagePullSecrets` | list | `[]` | An optional list of references to secrets to use for pulling any of the SR-IOV Network Operator image |
+| `supportedExtraNICs` | list | `[]` | An optional list of whitelisted NICs |
 
 ### Operator parameters
 

--- a/deployment/sriov-network-operator/templates/configmap.yaml
+++ b/deployment/sriov-network-operator/templates/configmap.yaml
@@ -38,3 +38,6 @@ data:
   Marvell_OCTEON_Fusion_CNF95XX: "177d b600 b603"
   Marvell_OCTEON10_CN10XXX: "177d b900 b903"
   Marvell_OCTEON_Fusion_CNF105XX: "177d ba00 ba03"
+  {{- range .Values.supportedExtraNICs }}
+  {{ . }}
+  {{- end }}

--- a/deployment/sriov-network-operator/values.yaml
+++ b/deployment/sriov-network-operator/values.yaml
@@ -89,6 +89,9 @@ sriovOperatorConfig:
   # sriov-network-config-daemon configuration mode. either "daemon" or "systemd"
   configurationMode: daemon
 
+# Example for supportedExtraNICs values ['MyNIC: "8086 1521 1520"']
+supportedExtraNICs: []
+
 # Image URIs for sriov-network-operator components
 images:
   operator: ghcr.io/k8snetworkplumbingwg/sriov-network-operator


### PR DESCRIPTION
The `supported-nic-ids` ConfigMap is a whitelist that includes details of some NICs. However, the user might want to add other NICs to that list so that the sriov operator works in his env.

The only way to do it right now is deploying the sriov-operator, editing that configmap and then restarting some of the sriov-operator components so that the new config is consumed.

This PR adds a new way to do it which can be easily automated: use a values.yaml parameter in the helm chart to include extra NICs. We can add the extra NICs when installing the sriov-operator, thus not requiring to restart any of the components