### PR TITLE
Fix issue preventing lowering of PF's MTU

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -257,7 +257,7 @@ func GetEswitchModeFromStatus(ifaceStatus *InterfaceExt) string {
 func NeedToUpdateSriov(ifaceSpec *Interface, ifaceStatus *InterfaceExt) bool {
 	if ifaceSpec.Mtu > 0 {
 		mtu := ifaceSpec.Mtu
-		if mtu != ifaceStatus.Mtu {
+		if mtu > ifaceStatus.Mtu {
 			log.V(2).Info("NeedToUpdateSriov(): MTU needs update", "desired", mtu, "current", ifaceStatus.Mtu)
 			return true
 		}


### PR DESCRIPTION
When the MTU set in the SRIOV Network Node Policy is lower than the actual MTU of the PF, it cannot be changed due to a condition in question. This triggers the reconcile loop for the Node state indefinitely, preventing the configuration from completing.