### PR TITLE
e2e: Use `helm` to deploy on k8s cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,12 @@ skopeo:
 fakechroot:
 	if ! which fakechroot; then if [ -f /etc/redhat-release ]; then dnf -y install fakechroot; elif [ -f /etc/lsb-release ]; then sudo apt-get -y update; sudo apt-get -y install fakechroot; fi; fi
 
+$(BIN_DIR)/helm helm:
+	mkdir -p $(BIN_DIR)
+	curl -fsSL -o $(BIN_DIR)/get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3
+	chmod 700 $(BIN_DIR)/get_helm.sh
+	HELM_INSTALL_DIR=$(BIN_DIR) $(BIN_DIR)/get_helm.sh
+
 deploy-setup: export ADMISSION_CONTROLLERS_ENABLED?=false
 deploy-setup: skopeo install
 	hack/deploy-setup.sh $(NAMESPACE)

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -73,7 +73,7 @@ spec:
             - name: METRICS_EXPORTER_SECRET_NAME
               value: {{ .Values.operator.admissionControllers.certificates.secretNames.metricsExporter }}
             - name: METRICS_EXPORTER_PORT
-              value: {{ .Values.operator.metricsExporter.port }}
+              value: "{{ .Values.operator.metricsExporter.port }}"
             - name: METRICS_EXPORTER_SECRET_NAME
               value: {{ .Values.operator.metricsExporter.certificates.secretName }}
             - name: METRICS_EXPORTER_KUBE_RBAC_PROXY_IMAGE

--- a/hack/run-e2e-conformance-virtual-cluster.sh
+++ b/hack/run-e2e-conformance-virtual-cluster.sh
@@ -365,6 +365,8 @@ do
 done
 
 
+source hack/env.sh
+
 export ADMISSION_CONTROLLERS_ENABLED=true
 export ADMISSION_CONTROLLERS_CERTIFICATES_CERT_MANAGER_ENABLED=true
 export SKIP_VAR_SET=""
@@ -372,12 +374,26 @@ export NAMESPACE="sriov-network-operator"
 export OPERATOR_NAMESPACE="sriov-network-operator"
 export CNI_BIN_PATH=/opt/cni/bin
 export OPERATOR_EXEC=kubectl
-export CLUSTER_TYPE=kubernetes
-export DEV_MODE=TRUE
 export CLUSTER_HAS_EMULATED_PF=TRUE
 
-echo "## deploy namespace"
-envsubst< $root/deploy/namespace.yaml | ${OPERATOR_EXEC} apply -f -
+
+HELM_VALUES_OPTS="\
+  --set images.operator=${SRIOV_NETWORK_OPERATOR_IMAGE} \
+  --set images.sriovConfigDaemon=${SRIOV_NETWORK_CONFIG_DAEMON_IMAGE} \
+  --set images.sriovCni=${SRIOV_CNI_IMAGE} \
+  --set images.sriovDevicePlugin=${SRIOV_DEVICE_PLUGIN_IMAGE} \
+  --set images.resourcesInjector=${NETWORK_RESOURCES_INJECTOR_IMAGE} \
+  --set images.webhook=${SRIOV_NETWORK_WEBHOOK_IMAGE} \
+  --set operator.admissionControllers.enabled=${ADMISSION_CONTROLLERS_ENABLED} \
+  --set operator.admissionControllers.certificates.certManager.enabled=${ADMISSION_CONTROLLERS_CERTIFICATES_CERT_MANAGER_ENABLED} \
+  --set sriovOperatorConfig.deploy=true"
+
+PATH=$PATH:${root}/bin
+make helm
+helm  install -n ${NAMESPACE} --create-namespace \
+  $HELM_VALUES_OPTS \
+  --wait sriov-network-operator ./deployment/sriov-network-operator-chart
+
 
 echo "## create certificates for webhook"
 cat <<EOF | kubectl apply -f -
@@ -436,12 +452,6 @@ spec:
   secretName: metrics-exporter-cert
 EOF
 
-
-echo "## apply CRDs"
-kubectl apply -k $root/config/crd
-
-echo "## deploying SRIOV Network Operator"
-hack/deploy-setup.sh $NAMESPACE
 
 function cluster_info {
   if [[ -v TEST_REPORT_PATH ]]; then


### PR DESCRIPTION
Using `helm` to deploy the operator in vanilla k8s CI lanes helps avoid error in helm charts changes.
Instead of adding a new helm e2e lane (as it would increase the CI load), we can keep the already in place lanes as:
- OpenShift: use the `hack/deploy-setup.sh` script
- K8s: use helm chart