### PR TITLE
Update `config/` folder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,16 @@ jobs:
     - name: check go modules are up to date
       run: make check-deps
 
+  manifests:
+    name: check manifests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: check if the config/ folder is up to date
+      run: make check-manifests
+
   golangci:
     name: Golangci-lint
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,11 @@ manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) webhook paths="./..." output:crd:artifacts:config=$(CRD_BASES)
 	cp ./config/crd/bases/* ./deployment/sriov-network-operator/crds/
 
+check-manifests: manifests
+	@set +e; git diff --quiet config; \
+	if [ $$? -eq 1 ]; \
+	then echo -e "\n`config` folder is out of date. Please run `make manifests` and commit your changes"; \
+	exit 1; fi
 
 sync-manifests-%: manifests
 	@mkdir -p manifests/$*

--- a/config/crd/bases/sriovnetwork.openshift.io_ovsnetworks.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_ovsnetworks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: ovsnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -21,14 +20,19 @@ spec:
         description: OVSNetwork is the Schema for the ovsnetworks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,12 +40,14 @@ spec:
             description: OVSNetworkSpec defines the desired state of OVSNetwork
             properties:
               bridge:
-                description: name of the OVS bridge, if not set OVS will automatically
-                  select bridge based on VF PCI address
+                description: |-
+                  name of the OVS bridge, if not set OVS will automatically select bridge
+                  based on VF PCI address
                 type: string
               capabilities:
-                description: 'Capabilities to be configured for this network. Capabilities
-                  supported: (mac|ips), e.g. ''{"mac": true}'''
+                description: |-
+                  Capabilities to be configured for this network.
+                  Capabilities supported: (mac|ips), e.g. '{"mac": true}'
                 type: string
               interfaceType:
                 description: The type of interface on ovs.

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovibnetworks.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovibnetworks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovibnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -21,14 +20,19 @@ spec:
         description: SriovIBNetwork is the Schema for the sriovibnetworks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,8 +40,9 @@ spec:
             description: SriovIBNetworkSpec defines the desired state of SriovIBNetwork
             properties:
               capabilities:
-                description: 'Capabilities to be configured for this network. Capabilities
-                  supported: (infinibandGUID), e.g. ''{"infinibandGUID": true}'''
+                description: |-
+                  Capabilities to be configured for this network.
+                  Capabilities supported: (infinibandGUID), e.g. '{"infinibandGUID": true}'
                 type: string
               ipam:
                 description: IPAM configuration to be used for this network.
@@ -50,8 +55,9 @@ spec:
                 - disable
                 type: string
               metaPlugins:
-                description: MetaPluginsConfig configuration to be used in order to
-                  chain metaplugins to the sriov interface returned by the operator.
+                description: |-
+                  MetaPluginsConfig configuration to be used in order to chain metaplugins to the sriov interface returned
+                  by the operator.
                 type: string
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworknodepolicies.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -22,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -37,8 +41,9 @@ spec:
             description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
             properties:
               bridge:
-                description: contains bridge configuration for matching PFs, valid
-                  only for eSwitchMode==switchdev
+                description: |-
+                  contains bridge configuration for matching PFs,
+                  valid only for eSwitchMode==switchdev
                 properties:
                   ovs:
                     description: contains configuration for the OVS bridge,

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworknodestates.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -35,14 +34,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -81,8 +85,9 @@ spec:
                           description: name of the bridge
                           type: string
                         uplinks:
-                          description: uplink-level bridge configuration for each
-                            uplink(PF). currently must contain only one element
+                          description: |-
+                            uplink-level bridge configuration for each uplink(PF).
+                            currently must contain only one element
                           items:
                             description: OVSUplinkConfigExt contains configuration
                               for the concrete OVS uplink(PF)
@@ -206,8 +211,9 @@ spec:
                           description: name of the bridge
                           type: string
                         uplinks:
-                          description: uplink-level bridge configuration for each
-                            uplink(PF). currently must contain only one element
+                          description: |-
+                            uplink-level bridge configuration for each uplink(PF).
+                            currently must contain only one element
                           items:
                             description: OVSUplinkConfigExt contains configuration
                               for the concrete OVS uplink(PF)

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworkpoolconfigs.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -22,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -40,13 +44,15 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: "maxUnavailable defines either an integer number or percentage
-                  of nodes in the pool that can go Unavailable during an update. \n
-                  A value larger than 1 will mean multiple nodes going unavailable
-                  during the update, which may affect your workload stress on the
-                  remaining nodes. Drain will respect Pod Disruption Budgets (PDBs)
-                  such as etcd quorum guards, even if maxUnavailable is greater than
-                  one."
+                description: |-
+                  maxUnavailable defines either an integer number or percentage
+                  of nodes in the pool that can go Unavailable during an update.
+
+
+                  A value larger than 1 will mean multiple nodes going unavailable during
+                  the update, which may affect your workload stress on the remaining nodes.
+                  Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum guards,
+                  even if maxUnavailable is greater than one.
                 x-kubernetes-int-or-string: true
               nodeSelector:
                 description: nodeSelector specifies a label selector for Nodes
@@ -55,24 +61,24 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -85,22 +91,24 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               ovsHardwareOffloadConfig:
                 description: OvsHardwareOffloadConfig describes the OVS HWOL configuration
                   for selected Nodes
                 properties:
                   name:
-                    description: 'Name is mandatory and must be unique. On Kubernetes:
-                      Name is the name of OvsHardwareOffloadConfig On OpenShift: Name
-                      is the name of MachineConfigPool to be enabled with OVS hardware
-                      offload'
+                    description: |-
+                      Name is mandatory and must be unique.
+                      On Kubernetes:
+                      Name is the name of OvsHardwareOffloadConfig
+                      On OpenShift:
+                      Name is the name of MachineConfigPool to be enabled with OVS hardware offload
                     type: string
                 type: object
             type: object

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworks.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -21,14 +20,19 @@ spec:
         description: SriovNetwork is the Schema for the sriovnetworks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,8 +40,9 @@ spec:
             description: SriovNetworkSpec defines the desired state of SriovNetwork
             properties:
               capabilities:
-                description: 'Capabilities to be configured for this network. Capabilities
-                  supported: (mac|ips), e.g. ''{"mac": true}'''
+                description: |-
+                  Capabilities to be configured for this network.
+                  Capabilities supported: (mac|ips), e.g. '{"mac": true}'
                 type: string
               ipam:
                 description: IPAM configuration to be used for this network.
@@ -50,15 +55,15 @@ spec:
                 - disable
                 type: string
               logFile:
-                description: LogFile sets the log file of the SRIOV CNI plugin logs.
-                  If unset (default), this will log to stderr and thus to multus and
-                  container runtime logs.
+                description: |-
+                  LogFile sets the log file of the SRIOV CNI plugin logs. If unset (default), this will log to stderr and thus
+                  to multus and container runtime logs.
                 type: string
               logLevel:
                 default: info
-                description: LogLevel sets the log level of the SRIOV CNI plugin -
-                  either of panic, error, warning, info, debug. Defaults to info if
-                  left blank.
+                description: |-
+                  LogLevel sets the log level of the SRIOV CNI plugin - either of panic, error, warning, info, debug. Defaults
+                  to info if left blank.
                 enum:
                 - panic
                 - error
@@ -73,8 +78,9 @@ spec:
                 minimum: 0
                 type: integer
               metaPlugins:
-                description: MetaPluginsConfig configuration to be used in order to
-                  chain metaplugins to the sriov interface returned by the operator.
+                description: |-
+                  MetaPluginsConfig configuration to be used in order to chain metaplugins to the sriov interface returned
+                  by the operator.
                 type: string
               minTxRate:
                 description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovoperatorconfigs.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -22,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,9 +46,9 @@ spec:
                 description: NodeSelector selects the nodes to be configured
                 type: object
               configurationMode:
-                description: 'Flag to enable the sriov-network-config-daemon to use
-                  a systemd service to configure SR-IOV devices on boot Default mode:
-                  daemon'
+                description: |-
+                  Flag to enable the sriov-network-config-daemon to use a systemd service to configure SR-IOV devices on boot
+                  Default mode: daemon
                 enum:
                 - daemon
                 - systemd

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_ovsnetworks.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_ovsnetworks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: ovsnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -21,14 +20,19 @@ spec:
         description: OVSNetwork is the Schema for the ovsnetworks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,12 +40,14 @@ spec:
             description: OVSNetworkSpec defines the desired state of OVSNetwork
             properties:
               bridge:
-                description: name of the OVS bridge, if not set OVS will automatically
-                  select bridge based on VF PCI address
+                description: |-
+                  name of the OVS bridge, if not set OVS will automatically select bridge
+                  based on VF PCI address
                 type: string
               capabilities:
-                description: 'Capabilities to be configured for this network. Capabilities
-                  supported: (mac|ips), e.g. ''{"mac": true}'''
+                description: |-
+                  Capabilities to be configured for this network.
+                  Capabilities supported: (mac|ips), e.g. '{"mac": true}'
                 type: string
               interfaceType:
                 description: The type of interface on ovs.

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovibnetworks.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovibnetworks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovibnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -21,14 +20,19 @@ spec:
         description: SriovIBNetwork is the Schema for the sriovibnetworks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,8 +40,9 @@ spec:
             description: SriovIBNetworkSpec defines the desired state of SriovIBNetwork
             properties:
               capabilities:
-                description: 'Capabilities to be configured for this network. Capabilities
-                  supported: (infinibandGUID), e.g. ''{"infinibandGUID": true}'''
+                description: |-
+                  Capabilities to be configured for this network.
+                  Capabilities supported: (infinibandGUID), e.g. '{"infinibandGUID": true}'
                 type: string
               ipam:
                 description: IPAM configuration to be used for this network.
@@ -50,8 +55,9 @@ spec:
                 - disable
                 type: string
               metaPlugins:
-                description: MetaPluginsConfig configuration to be used in order to
-                  chain metaplugins to the sriov interface returned by the operator.
+                description: |-
+                  MetaPluginsConfig configuration to be used in order to chain metaplugins to the sriov interface returned
+                  by the operator.
                 type: string
               networkNamespace:
                 description: Namespace of the NetworkAttachmentDefinition custom resource

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodepolicies.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworknodepolicies.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -22,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -37,8 +41,9 @@ spec:
             description: SriovNetworkNodePolicySpec defines the desired state of SriovNetworkNodePolicy
             properties:
               bridge:
-                description: contains bridge configuration for matching PFs, valid
-                  only for eSwitchMode==switchdev
+                description: |-
+                  contains bridge configuration for matching PFs,
+                  valid only for eSwitchMode==switchdev
                 properties:
                   ovs:
                     description: contains configuration for the OVS bridge,

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworknodestates.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworknodestates.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -35,14 +34,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -81,8 +85,9 @@ spec:
                           description: name of the bridge
                           type: string
                         uplinks:
-                          description: uplink-level bridge configuration for each
-                            uplink(PF). currently must contain only one element
+                          description: |-
+                            uplink-level bridge configuration for each uplink(PF).
+                            currently must contain only one element
                           items:
                             description: OVSUplinkConfigExt contains configuration
                               for the concrete OVS uplink(PF)
@@ -206,8 +211,9 @@ spec:
                           description: name of the bridge
                           type: string
                         uplinks:
-                          description: uplink-level bridge configuration for each
-                            uplink(PF). currently must contain only one element
+                          description: |-
+                            uplink-level bridge configuration for each uplink(PF).
+                            currently must contain only one element
                           items:
                             description: OVSUplinkConfigExt contains configuration
                               for the concrete OVS uplink(PF)

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworkpoolconfigs.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -22,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -40,13 +44,15 @@ spec:
                 anyOf:
                 - type: integer
                 - type: string
-                description: "maxUnavailable defines either an integer number or percentage
-                  of nodes in the pool that can go Unavailable during an update. \n
-                  A value larger than 1 will mean multiple nodes going unavailable
-                  during the update, which may affect your workload stress on the
-                  remaining nodes. Drain will respect Pod Disruption Budgets (PDBs)
-                  such as etcd quorum guards, even if maxUnavailable is greater than
-                  one."
+                description: |-
+                  maxUnavailable defines either an integer number or percentage
+                  of nodes in the pool that can go Unavailable during an update.
+
+
+                  A value larger than 1 will mean multiple nodes going unavailable during
+                  the update, which may affect your workload stress on the remaining nodes.
+                  Drain will respect Pod Disruption Budgets (PDBs) such as etcd quorum guards,
+                  even if maxUnavailable is greater than one.
                 x-kubernetes-int-or-string: true
               nodeSelector:
                 description: nodeSelector specifies a label selector for Nodes
@@ -55,24 +61,24 @@ spec:
                     description: matchExpressions is a list of label selector requirements.
                       The requirements are ANDed.
                     items:
-                      description: A label selector requirement is a selector that
-                        contains values, a key, and an operator that relates the key
-                        and values.
+                      description: |-
+                        A label selector requirement is a selector that contains values, a key, and an operator that
+                        relates the key and values.
                       properties:
                         key:
                           description: key is the label key that the selector applies
                             to.
                           type: string
                         operator:
-                          description: operator represents a key's relationship to
-                            a set of values. Valid operators are In, NotIn, Exists
-                            and DoesNotExist.
+                          description: |-
+                            operator represents a key's relationship to a set of values.
+                            Valid operators are In, NotIn, Exists and DoesNotExist.
                           type: string
                         values:
-                          description: values is an array of string values. If the
-                            operator is In or NotIn, the values array must be non-empty.
-                            If the operator is Exists or DoesNotExist, the values
-                            array must be empty. This array is replaced during a strategic
+                          description: |-
+                            values is an array of string values. If the operator is In or NotIn,
+                            the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                            the values array must be empty. This array is replaced during a strategic
                             merge patch.
                           items:
                             type: string
@@ -85,22 +91,24 @@ spec:
                   matchLabels:
                     additionalProperties:
                       type: string
-                    description: matchLabels is a map of {key,value} pairs. A single
-                      {key,value} in the matchLabels map is equivalent to an element
-                      of matchExpressions, whose key field is "key", the operator
-                      is "In", and the values array contains only "value". The requirements
-                      are ANDed.
+                    description: |-
+                      matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                      map is equivalent to an element of matchExpressions, whose key field is "key", the
+                      operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+                x-kubernetes-map-type: atomic
               ovsHardwareOffloadConfig:
                 description: OvsHardwareOffloadConfig describes the OVS HWOL configuration
                   for selected Nodes
                 properties:
                   name:
-                    description: 'Name is mandatory and must be unique. On Kubernetes:
-                      Name is the name of OvsHardwareOffloadConfig On OpenShift: Name
-                      is the name of MachineConfigPool to be enabled with OVS hardware
-                      offload'
+                    description: |-
+                      Name is mandatory and must be unique.
+                      On Kubernetes:
+                      Name is the name of OvsHardwareOffloadConfig
+                      On OpenShift:
+                      Name is the name of MachineConfigPool to be enabled with OVS hardware offload
                     type: string
                 type: object
             type: object

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovnetworks.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovnetworks.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -21,14 +20,19 @@ spec:
         description: SriovNetwork is the Schema for the sriovnetworks API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -36,8 +40,9 @@ spec:
             description: SriovNetworkSpec defines the desired state of SriovNetwork
             properties:
               capabilities:
-                description: 'Capabilities to be configured for this network. Capabilities
-                  supported: (mac|ips), e.g. ''{"mac": true}'''
+                description: |-
+                  Capabilities to be configured for this network.
+                  Capabilities supported: (mac|ips), e.g. '{"mac": true}'
                 type: string
               ipam:
                 description: IPAM configuration to be used for this network.
@@ -50,15 +55,15 @@ spec:
                 - disable
                 type: string
               logFile:
-                description: LogFile sets the log file of the SRIOV CNI plugin logs.
-                  If unset (default), this will log to stderr and thus to multus and
-                  container runtime logs.
+                description: |-
+                  LogFile sets the log file of the SRIOV CNI plugin logs. If unset (default), this will log to stderr and thus
+                  to multus and container runtime logs.
                 type: string
               logLevel:
                 default: info
-                description: LogLevel sets the log level of the SRIOV CNI plugin -
-                  either of panic, error, warning, info, debug. Defaults to info if
-                  left blank.
+                description: |-
+                  LogLevel sets the log level of the SRIOV CNI plugin - either of panic, error, warning, info, debug. Defaults
+                  to info if left blank.
                 enum:
                 - panic
                 - error
@@ -73,8 +78,9 @@ spec:
                 minimum: 0
                 type: integer
               metaPlugins:
-                description: MetaPluginsConfig configuration to be used in order to
-                  chain metaplugins to the sriov interface returned by the operator.
+                description: |-
+                  MetaPluginsConfig configuration to be used in order to chain metaplugins to the sriov interface returned
+                  by the operator.
                 type: string
               minTxRate:
                 description: Minimum tx rate, in Mbps, for the VF. Defaults to 0 (no

--- a/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
+++ b/deployment/sriov-network-operator/crds/sriovnetwork.openshift.io_sriovoperatorconfigs.yaml
@@ -3,8 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.0
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.14.0
   name: sriovoperatorconfigs.sriovnetwork.openshift.io
 spec:
   group: sriovnetwork.openshift.io
@@ -22,14 +21,19 @@ spec:
           API
         properties:
           apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
             type: string
           kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
             type: string
           metadata:
             type: object
@@ -42,9 +46,9 @@ spec:
                 description: NodeSelector selects the nodes to be configured
                 type: object
               configurationMode:
-                description: 'Flag to enable the sriov-network-config-daemon to use
-                  a systemd service to configure SR-IOV devices on boot Default mode:
-                  daemon'
+                description: |-
+                  Flag to enable the sriov-network-config-daemon to use a systemd service to configure SR-IOV devices on boot
+                  Default mode: daemon
                 enum:
                 - daemon
                 - systemd


### PR DESCRIPTION
`config/` folder contains information related to the operator-sdk, mostly used by the [openshift/sriov-network-operator fork](https://github.com/openshift/sriov-network-operator) to create operator's bundles. 

This PR aims to keep the folder up to date