### PR TITLE
Avoid reconfiguring unmentioned DPDK VFs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ VF groups** (when #-notation is used in pfName field) are merged, otherwise only
 the highest priority policy is applied. In case of same-priority policies and
 overlapping VF groups, only the last processed policy is applied.
 
+When using #-notation to define VF group, no actions are taken on virtual functions that
+are not mentioned in any policy (e.g. if a policy defines a `vfio-pci` device group for a device, when 
+it is deleted the VF are not reset to the default driver).
+
 #### Externally Manage virtual functions
 
 When `ExternallyManage` is request on a policy the operator will only skip the virtual function creation.

--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -280,10 +280,8 @@ func NeedToUpdateSriov(ifaceSpec *Interface, ifaceStatus *InterfaceExt) bool {
 
 	if ifaceSpec.NumVfs > 0 {
 		for _, vfStatus := range ifaceStatus.VFs {
-			ingroup := false
 			for _, groupSpec := range ifaceSpec.VfGroups {
 				if IndexInRange(vfStatus.VfID, groupSpec.VfRange) {
-					ingroup = true
 					if vfStatus.Driver == "" {
 						log.V(2).Info("NeedToUpdateSriov(): Driver needs update - has no driver",
 							"desired", groupSpec.DeviceType)
@@ -331,12 +329,6 @@ func NeedToUpdateSriov(ifaceSpec *Interface, ifaceStatus *InterfaceExt) bool {
 					}
 					break
 				}
-			}
-			if !ingroup && (StringInArray(vfStatus.Driver, vars.DpdkDrivers) || vfStatus.VdpaType != "") {
-				// need to reset VF if it is not a part of a group and:
-				// a. has DPDK driver loaded
-				// b. has VDPA device
-				return true
 			}
 		}
 	}


### PR DESCRIPTION
If a Virtual Function is configured with a DPDK driver (e.g. `vfio-pci`) and it is not referred by any SriovNetworkNodePolicy, `NeedToUpdateSriov` function must not trigger a  reconfiguration. This may happen if a PF is configured by multiple policies (via PF partitioning) and a policy is deleted by the user. In these cases, the VF is not reconfigured [1] and a drain loop is started

refs:
[1] https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/5f3c4e903f789aa177fe54686efd6c18576b7ab1/pkg/host/internal/sriov/sriov.go#L457