### PR TITLE
e2e: Stick to a stable OCP version

### DIFF
--- a/hack/run-e2e-conformance-virtual-ocp.sh
+++ b/hack/run-e2e-conformance-virtual-ocp.sh
@@ -237,7 +237,11 @@ echo ${auth} > registry-login.conf
 internal_registry="image-registry.openshift-image-registry.svc:5000"
 pass=$( jq .\"image-registry.openshift-image-registry.svc:5000\".auth registry-login.conf  )
 pass=`echo ${pass:1:-1} | base64 -d`
-podman login -u serviceaccount -p ${pass:15} $registry --tls-verify=false
+
+# dockercfg password is in the form `<token>:password`. We need to trim the `<token>:` prefix
+pass=${pass#"<token>:"}
+
+podman login -u serviceaccount -p ${pass} $registry --tls-verify=false
 
 MAX_RETRIES=20
 DELAY_SECONDS=10

--- a/hack/run-e2e-conformance-virtual-ocp.sh
+++ b/hack/run-e2e-conformance-virtual-ocp.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xeo pipefail
 
-OCP_VERSION=${OCP_VERSION:-4.16.0-rc.2}
+OCP_VERSION=${OCP_VERSION:-4.16.0}
 cluster_name=${CLUSTER_NAME:-ocp-virt}
 domain_name=lab
 


### PR DESCRIPTION
A number of jobs in the OCP end-to-end lane are failing due to a failure in the operator deployment. 

Logs show an error during the pull of the image from the internal registry:

```
2024-06-26T12:39:09.9431067Z             "message": "Failed to pull image \"image-registry.openshift-image-registry.svc:5000/openshift-sriov-network-operator/sriov-network-operator:latest\": reading manifest latest in image-registry.openshift-image-registry.svc:5000/openshift-sriov-network-operator/sriov-network-operator: authentication required",
```

[job-logs.txt](https://github.com/user-attachments/files/15992256/job-logs.txt)

Sticking to a stable version of OCP can mitigate the risk of flaky lanes.

cc @SchSeba 