### PR TITLE
feat: support extraDeploy field in helm chart

### DIFF
--- a/deployment/sriov-network-operator-chart/README.md
+++ b/deployment/sriov-network-operator-chart/README.md
@@ -144,3 +144,13 @@ This section contains general parameters that apply to both the operator and dae
 | `images.webhook` | Operator Webhook image |
 | `images.metricsExporter` | Network Metrics Exporter image |
 | `images.metricsExporterKubeRbacProxy` | Kube RBAC Proxy image used for metrics exporter |
+
+### Extra objects parameters
+
+**Disclaimer**:
+
+Please note that any resources deployed using the `extraDeploy` in this Helm chart are the sole responsibility of the user. It is important to review and understand the implications of these deployed resources. The maintainers of this Helm chart take no responsibility for any issues or damages caused by the deployment or operation of these resources.
+
+| Name | description |
+| ---- | ------------|
+|`extraDeploy`| Array of extra objects to deploy with the release |

--- a/deployment/sriov-network-operator-chart/templates/extra-list.yaml
+++ b/deployment/sriov-network-operator-chart/templates/extra-list.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraDeploy }}
+---
+{{- if typeIs "string" . }}
+  {{- tpl . $ }}
+{{- else }}
+  {{- tpl (. | toYaml) $ }}
+{{- end }}
+{{- end }}

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -70,8 +70,6 @@ spec:
               value: {{ .Values.images.webhook }}
             - name: METRICS_EXPORTER_IMAGE
               value: {{ .Values.images.metricsExporter }}
-            - name: METRICS_EXPORTER_SECRET_NAME
-              value: {{ .Values.operator.admissionControllers.certificates.secretNames.metricsExporter }}
             - name: METRICS_EXPORTER_PORT
               value: {{ .Values.operator.metricsExporter.port }}
             - name: METRICS_EXPORTER_SECRET_NAME

--- a/deployment/sriov-network-operator-chart/values.yaml
+++ b/deployment/sriov-network-operator-chart/values.yaml
@@ -21,7 +21,7 @@ operator:
             matchExpressions:
               - key: "node-role.kubernetes.io/control-plane"
                 operator: In
-                values: [ "" ]
+                values: [""]
   nameOverride: ""
   fullnameOverride: ""
   resourcePrefix: "openshift.io"
@@ -110,3 +110,4 @@ images:
   metricsExporterKubeRbacProxy: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
 
 imagePullSecrets: []
+extraDeploy: []


### PR DESCRIPTION
This PR made the following changes:

1. Remove duplicate environment variable `METRICS_EXPORTER_SECRET_NAME` ~~and correct the `METRICS_EXPORTER_PORT` environment variable~~.

2. Support adding additional deployment objects in the Helm chart, such as `SriovNetworkNodePolicy` and `SriovNetwork`, along with the release.