### PR TITLE
Round up MaxUnavailable to 1 node instead of 0

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -921,5 +921,10 @@ func (s *SriovNetworkPoolConfig) MaxUnavailable(numOfNodes int) (int, error) {
 		return 0, fmt.Errorf("negative number is not allowed")
 	}
 
+	if maxunavail == 0 {
+		// Round up MaxUnavailable to 1 node
+		return 1, nil
+	}
+
 	return maxunavail, nil
 }

--- a/api/v1/helper_test.go
+++ b/api/v1/helper_test.go
@@ -1021,11 +1021,11 @@ func TestSriovNetworkPoolConfig_MaxUnavailable(t *testing.T) {
 			expectedErr: false,
 		},
 		{
-			tname:       "zero",
+			tname:       "small cluster",
 			maxUn:       intstrutil.FromString("30%"),
 			maxUnNil:    false,
-			numOfNodes:  1,
-			expectedNum: 0,
+			numOfNodes:  2,
+			expectedNum: 1,
 			expectedErr: false,
 		},
 	}


### PR DESCRIPTION
When MaxUnavailable is configured as percent and cluster is too small we need to roundup MaxUnavailable count to 1 instead of 0 to get draining working.