### PR TITLE
Set owner reference for all objects deployed by operator

### DIFF
--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -361,13 +361,8 @@ func (r *SriovOperatorConfigReconciler) deleteK8sResource(ctx context.Context, i
 }
 
 func (r *SriovOperatorConfigReconciler) syncK8sResource(ctx context.Context, cr *sriovnetworkv1.SriovOperatorConfig, in *uns.Unstructured) error {
-	switch in.GetKind() {
-	case clusterRoleResourceName, clusterRoleBindingResourceName, mutatingWebhookConfigurationCRDName, validatingWebhookConfigurationCRDName, machineConfigCRDName:
-	default:
-		// set owner-reference only for namespaced objects
-		if err := controllerutil.SetControllerReference(cr, in, r.Scheme); err != nil {
-			return err
-		}
+	if err := controllerutil.SetControllerReference(cr, in, r.Scheme); err != nil {
+		return err
 	}
 	if err := apply.ApplyObject(ctx, r.Client, in); err != nil {
 		return fmt.Errorf("failed to apply object %v with err: %v", in, err)


### PR DESCRIPTION
We need to set owner reference for cluster-wide objects too to cleanup everything during operator uninstall procedure.

Originally this change was made as a part of "Upgrade to opertor-sdk v0.15.1" [1] commit.

[1] https://github.com/k8snetworkplumbingwg/sriov-network-operator/commit/ada7e92feae2cfc5b0e946e952735931cc9dc8f0#diff-e2b986deac1ca0cc19847ec39fecb01d7ae6253efcf018723e78555fb7c63ea1R406