### PR TITLE
feat: implement MlxResetFW to reset the FW on VF changes

### DIFF
--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -5,7 +5,9 @@ RUN make _build-sriov-network-config-daemon BIN_PATH=build/_output/cmd
 
 FROM quay.io/centos/centos:stream9
 ARG MSTFLINT=mstflint
-RUN ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && yum -y install hwdata $ARCH_DEP_PKGS && yum clean all
+# We have to ensure that pciutils is installed. This package is needed for mstfwreset to succeed.
+# xref pkg/vendors/mellanox/mellanox.go#L150
+RUN ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then echo -n ${MSTFLINT} ; fi) && yum -y install hwdata pciutils $ARCH_DEP_PKGS && yum clean all
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/

--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -139,6 +139,9 @@ const (
 	// ManageSoftwareBridgesFeatureGate: enables management of software bridges by the operator
 	ManageSoftwareBridgesFeatureGate = "manageSoftwareBridges"
 
+	// MellanoxFirmwareResetFeatureGate: enables the firmware reset via mstfwreset before a reboot
+	MellanoxFirmwareResetFeatureGate = "mellanoxFirmwareReset"
+
 	// The path to the file on the host filesystem that contains the IB GUID distribution for IB VFs
 	InfinibandGUIDConfigFilePath = SriovConfBasePath + "/infiniband/guids"
 )

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os/exec"
+	"reflect"
 	"sync"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	snclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned"
 	sninformer "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/informers/externalversions"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/featuregate"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/helper"
 	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms"
@@ -82,6 +84,8 @@ type Daemon struct {
 	workqueue workqueue.RateLimitingInterface
 
 	eventRecorder *EventRecorder
+
+	featureGate featuregate.FeatureGate
 }
 
 func New(
@@ -95,6 +99,7 @@ func New(
 	syncCh <-chan struct{},
 	refreshCh chan<- Message,
 	er *EventRecorder,
+	featureGates featuregate.FeatureGate,
 	disabledPlugins []string,
 ) *Daemon {
 	return &Daemon{
@@ -113,6 +118,7 @@ func New(
 			&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(updateDelay), 1)},
 			workqueue.NewItemExponentialFailureRateLimiter(1*time.Second, maxUpdateBackoff)), "SriovNetworkNodeState"),
 		eventRecorder:   er,
+		featureGate:     featureGates,
 		disabledPlugins: disabledPlugins,
 	}
 }
@@ -286,6 +292,7 @@ func (dn *Daemon) operatorConfigAddHandler(obj interface{}) {
 }
 
 func (dn *Daemon) operatorConfigChangeHandler(old, new interface{}) {
+	oldCfg := old.(*sriovnetworkv1.SriovOperatorConfig)
 	newCfg := new.(*sriovnetworkv1.SriovOperatorConfig)
 	if newCfg.Namespace != vars.Namespace || newCfg.Name != consts.DefaultConfigName {
 		log.Log.V(2).Info("unsupported SriovOperatorConfig", "namespace", newCfg.Namespace, "name", newCfg.Name)
@@ -299,6 +306,13 @@ func (dn *Daemon) operatorConfigChangeHandler(old, new interface{}) {
 		dn.disableDrain = newDisableDrain
 		log.Log.Info("Set Disable Drain", "value", dn.disableDrain)
 	}
+
+	if !reflect.DeepEqual(oldCfg.Spec.FeatureGates, newCfg.Spec.FeatureGates) {
+		dn.featureGate.Init(newCfg.Spec.FeatureGates)
+		log.Log.Info("Updated featureGates", "featureGates", dn.featureGate.String())
+	}
+
+	vars.MlxPluginFwReset = dn.featureGate.IsEnabled(consts.MellanoxFirmwareResetFeatureGate)
 }
 
 func (dn *Daemon) nodeStateSyncHandler() error {

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -18,18 +18,18 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
-	mock_platforms "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms/mock"
-	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/fakefilesystem"
-
 	snclient "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned"
 	snclientset "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/client/clientset/versioned/fake"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/featuregate"
 	mock_helper "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/helper/mock"
+	mock_platforms "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms/mock"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/platforms/openshift"
 	plugin "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins/fake"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins/generic"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/fakefilesystem"
 )
 
 func TestConfigDaemon(t *testing.T) {
@@ -151,6 +151,8 @@ var _ = Describe("Config Daemon", func() {
 		vendorHelper.EXPECT().PrepareNMUdevRule([]string{"0x1014", "0x154c"}).Return(nil).AnyTimes()
 		vendorHelper.EXPECT().PrepareVFRepUdevRule().Return(nil).AnyTimes()
 
+		featureGates := featuregate.New()
+
 		sut = New(
 			kClient,
 			snclient,
@@ -162,6 +164,7 @@ var _ = Describe("Config Daemon", func() {
 			syncCh,
 			refreshCh,
 			er,
+			featureGates,
 			nil,
 		)
 

--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -811,6 +811,20 @@ func (mr *MockHostHelpersInterfaceMockRecorder) MlxConfigFW(attributesToChange i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxConfigFW", reflect.TypeOf((*MockHostHelpersInterface)(nil).MlxConfigFW), attributesToChange)
 }
 
+// MlxResetFW mocks base method.
+func (m *MockHostHelpersInterface) MlxResetFW(pciAddresses []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MlxResetFW", pciAddresses)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MlxResetFW indicates an expected call of MlxResetFW.
+func (mr *MockHostHelpersInterfaceMockRecorder) MlxResetFW(pciAddresses interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxResetFW", reflect.TypeOf((*MockHostHelpersInterface)(nil).MlxResetFW), pciAddresses)
+}
+
 // MstConfigReadData mocks base method.
 func (m *MockHostHelpersInterface) MstConfigReadData(arg0 string) (string, string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -9,6 +9,7 @@ import (
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/helper"
 	plugin "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/plugins"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
 	mlx "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vendors/mellanox"
 )
 
@@ -211,7 +212,10 @@ func (p *MellanoxPlugin) Apply() error {
 	if err := p.helpers.MlxConfigFW(attributesToChange); err != nil {
 		return err
 	}
-	return p.helpers.MlxResetFW(pciAddressesToReset)
+	if vars.MlxPluginFwReset {
+		return p.helpers.MlxResetFW(pciAddressesToReset)
+	}
+	return nil
 }
 
 // nicHasExternallyManagedPFs returns true if one of the ports(interface) of the NIC is marked as externally managed

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -20,6 +20,7 @@ type MellanoxPlugin struct {
 	helpers     helper.HostHelpersInterface
 }
 
+var pciAddressesToReset []string
 var attributesToChange map[string]mlx.MlxNic
 var mellanoxNicsStatus map[string]map[string]sriovnetworkv1.InterfaceExt
 var mellanoxNicsSpec map[string]sriovnetworkv1.Interface
@@ -52,6 +53,7 @@ func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeS
 	needDrain = false
 	needReboot = false
 	err = nil
+	pciAddressesToReset = []string{}
 	attributesToChange = map[string]mlx.MlxNic{}
 	mellanoxNicsStatus = map[string]map[string]sriovnetworkv1.InterfaceExt{}
 	mellanoxNicsSpec = map[string]sriovnetworkv1.Interface{}
@@ -132,6 +134,10 @@ func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeS
 		if needReboot || changeWithoutReboot {
 			attributesToChange[ifaceSpec.PciAddress] = *attrs
 		}
+
+		if needReboot {
+			pciAddressesToReset = append(pciAddressesToReset, ifaceSpec.PciAddress)
+		}
 	}
 
 	// Set total VFs to 0 for mellanox interfaces with no spec
@@ -202,7 +208,10 @@ func (p *MellanoxPlugin) Apply() error {
 		return nil
 	}
 	log.Log.Info("mellanox plugin Apply()")
-	return p.helpers.MlxConfigFW(attributesToChange)
+	if err := p.helpers.MlxConfigFW(attributesToChange); err != nil {
+		return err
+	}
+	return p.helpers.MlxResetFW(pciAddressesToReset)
 }
 
 // nicHasExternallyManagedPFs returns true if one of the ports(interface) of the NIC is marked as externally managed

--- a/pkg/vars/vars.go
+++ b/pkg/vars/vars.go
@@ -54,6 +54,9 @@ var (
 	// ManageSoftwareBridges global variable which reflects state of manageSoftwareBridges feature
 	ManageSoftwareBridges = false
 
+	// MlxPluginFwReset global variable enables mstfwreset before rebooting a node on VF changes
+	MlxPluginFwReset = false
+
 	// FilesystemRoot used by test to mock interactions with filesystem
 	FilesystemRoot = ""
 

--- a/pkg/vendors/mellanox/mock/mock_mellanox.go
+++ b/pkg/vendors/mellanox/mock/mock_mellanox.go
@@ -79,6 +79,20 @@ func (mr *MockMellanoxInterfaceMockRecorder) MlxConfigFW(attributesToChange inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxConfigFW", reflect.TypeOf((*MockMellanoxInterface)(nil).MlxConfigFW), attributesToChange)
 }
 
+// MlxResetFW mocks base method.
+func (m *MockMellanoxInterface) MlxResetFW(pciAddresses []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MlxResetFW", pciAddresses)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MlxResetFW indicates an expected call of MlxResetFW.
+func (mr *MockMellanoxInterfaceMockRecorder) MlxResetFW(pciAddresses interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxResetFW", reflect.TypeOf((*MockMellanoxInterface)(nil).MlxResetFW), pciAddresses)
+}
+
 // MstConfigReadData mocks base method.
 func (m *MockMellanoxInterface) MstConfigReadData(arg0 string) (string, string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Todos:
- [x] implement new method to `mstfwreset`
- [x] add feature flag to opt-in/opt-out
- [x] add unit test
- [x] test it manually or via e2e test job (preferred)
- [ ] add docs (will be added with https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/756)

Manual test shows that the implementation is working:

```
sriov-network-config-daemon 2024-07-11T14:39:36.793959572Z    INFO    mellanox/mellanox_plugin.go:190 mellanox-plugin: resetFW()      {"cmd-args": ["-d", "0000:03:00.0", "-l", "3", "-y", "reset"]}
```
```
foo@bar:~$ sudo mlxconfig -d /dev/mst/mt4119_pciconf0 q | grep -e SRIOV_EN -e NUM_OF_VFS
        NUM_OF_VFS                                  4
        SRIOV_EN                                    True(1)
```