### PR TITLE
ci: sent ci-triggers comment only once on PR open or reopen

### DIFF
--- a/.github/workflows/pr-ci-triggers.yml
+++ b/.github/workflows/pr-ci-triggers.yml
@@ -1,5 +1,6 @@
 on:
   pull_request_target:
+    types: [opened, reopened]
 
 jobs:
   vendors-ci-triggers-list:


### PR DESCRIPTION
If we specify a type we can stop the Github Actions bot from resending the
ci-triggers list to open PRs on every HEAD change.

> [...] if no activity types are specified, the workflow runs when a pull request
is opened or reopened or when the head branch of the pull request is updated.

source: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target