### PR TITLE
[software-bridges 5/x] Enable software-bridge implementation

### DIFF
--- a/cmd/sriov-network-config-daemon/service.go
+++ b/cmd/sriov-network-config-daemon/service.go
@@ -93,6 +93,7 @@ func runServiceCmd(cmd *cobra.Command, args []string) error {
 	setupLog.V(2).Info("sriov-config-service", "config", sriovConf)
 	vars.DevMode = sriovConf.UnsupportedNics
 	vars.ManageSoftwareBridges = sriovConf.ManageSoftwareBridges
+	vars.OVSDBSocketPath = sriovConf.OVSDBSocketPath
 
 	if err := initSupportedNics(); err != nil {
 		return updateSriovResultErr(setupLog, phaseArg, fmt.Errorf("failed to initialize list of supported NIC ids: %v", err))
@@ -181,7 +182,7 @@ func callPlugin(setupLog logr.Logger, phase string, conf *systemd.SriovConfig, h
 		return nil
 	}
 
-	nodeState, err := getNetworkNodeState(setupLog, conf, hostHelpers)
+	nodeState, err := getNetworkNodeState(setupLog, conf, phase, hostHelpers)
 	if err != nil {
 		return err
 	}
@@ -207,7 +208,9 @@ func getPlugin(setupLog logr.Logger, phase string,
 	case consts.Baremetal:
 		switch phase {
 		case PhasePre:
-			configPlugin, err = newGenericPluginFunc(hostHelpers, generic.WithSkipVFConfiguration())
+			configPlugin, err = newGenericPluginFunc(hostHelpers,
+				generic.WithSkipVFConfiguration(),
+				generic.WithSkipBridgeConfiguration())
 		case PhasePost:
 			configPlugin, err = newGenericPluginFunc(hostHelpers)
 		}
@@ -229,10 +232,11 @@ func getPlugin(setupLog logr.Logger, phase string,
 	return configPlugin, nil
 }
 
-func getNetworkNodeState(setupLog logr.Logger, conf *systemd.SriovConfig,
+func getNetworkNodeState(setupLog logr.Logger, conf *systemd.SriovConfig, phase string,
 	hostHelpers helper.HostHelpersInterface) (*sriovv1.SriovNetworkNodeState, error) {
 	var (
 		ifaceStatuses []sriovv1.InterfaceExt
+		bridges       sriovv1.Bridges
 		err           error
 	)
 	switch conf.PlatformType {
@@ -240,6 +244,13 @@ func getNetworkNodeState(setupLog logr.Logger, conf *systemd.SriovConfig,
 		ifaceStatuses, err = hostHelpers.DiscoverSriovDevices(hostHelpers)
 		if err != nil {
 			return nil, fmt.Errorf("failed to discover sriov devices on the host:  %v", err)
+		}
+		if phase != PhasePre && vars.ManageSoftwareBridges {
+			// openvswitch is not available during the pre phase
+			bridges, err = hostHelpers.DiscoverBridges()
+			if err != nil {
+				return nil, fmt.Errorf("failed to discover managed bridges on the host:  %v", err)
+			}
 		}
 	case consts.VirtualOpenStack:
 		platformHelper, err := newPlatformHelperFunc()
@@ -257,7 +268,7 @@ func getNetworkNodeState(setupLog logr.Logger, conf *systemd.SriovConfig,
 	}
 	return &sriovv1.SriovNetworkNodeState{
 		Spec:   conf.Spec,
-		Status: sriovv1.SriovNetworkNodeStateStatus{Interfaces: ifaceStatuses},
+		Status: sriovv1.SriovNetworkNodeStateStatus{Interfaces: ifaceStatuses, Bridges: bridges},
 	}, nil
 }
 

--- a/cmd/sriov-network-config-daemon/service_test.go
+++ b/cmd/sriov-network-config-daemon/service_test.go
@@ -38,7 +38,6 @@ func restoreOrigFuncs() {
 
 func getTestSriovInterfaceConfig(platform int) []byte {
 	return []byte(fmt.Sprintf(`spec:
-    dpconfigversion: ""
     interfaces:
         - pciaddress: 0000:d8:00.0
           numvfs: 4
@@ -57,6 +56,7 @@ func getTestSriovInterfaceConfig(platform int) []byte {
           externallymanaged: false
 unsupportedNics: false
 platformType: %d
+manageSoftwareBridges: true
 `, platform))
 }
 
@@ -239,6 +239,7 @@ var _ = Describe("Service", func() {
 		hostHelpers.EXPECT().DiscoverSriovDevices(hostHelpers).Return([]sriovnetworkv1.InterfaceExt{{
 			Name: "enp216s0f0np0",
 		}}, nil)
+		hostHelpers.EXPECT().DiscoverBridges().Return(sriovnetworkv1.Bridges{}, nil)
 		genericPlugin.EXPECT().OnNodeStateChange(newNodeStateContainsDeviceMatcher("enp216s0f0np0")).Return(true, false, nil)
 		genericPlugin.EXPECT().Apply().Return(nil)
 		Expect(runServiceCmd(&cobra.Command{}, []string{})).NotTo(HaveOccurred())

--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -87,6 +87,7 @@ var (
 		disabledPlugins       stringList
 		parallelNicConfig     bool
 		manageSoftwareBridges bool
+		ovsSocketPath         string
 	}
 )
 
@@ -98,6 +99,7 @@ func init() {
 	startCmd.PersistentFlags().VarP(&startOpts.disabledPlugins, "disable-plugins", "", "comma-separated list of plugins to disable")
 	startCmd.PersistentFlags().BoolVar(&startOpts.parallelNicConfig, "parallel-nic-config", false, "perform NIC configuration in parallel")
 	startCmd.PersistentFlags().BoolVar(&startOpts.manageSoftwareBridges, "manage-software-bridges", false, "enable management of software bridges")
+	startCmd.PersistentFlags().StringVar(&startOpts.ovsSocketPath, "ovs-socket-path", vars.OVSDBSocketPath, "path for OVSDB socket")
 }
 
 func runStartCmd(cmd *cobra.Command, args []string) error {
@@ -113,6 +115,7 @@ func runStartCmd(cmd *cobra.Command, args []string) error {
 
 	vars.ParallelNicConfig = startOpts.parallelNicConfig
 	vars.ManageSoftwareBridges = startOpts.manageSoftwareBridges
+	vars.OVSDBSocketPath = startOpts.ovsSocketPath
 
 	if startOpts.nodeName == "" {
 		name, ok := os.LookupEnv("NODE_NAME")

--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -209,6 +209,20 @@ func (mr *MockHostHelpersInterfaceMockRecorder) ConfigSriovInterfaces(storeManag
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSriovInterfaces", reflect.TypeOf((*MockHostHelpersInterface)(nil).ConfigSriovInterfaces), storeManager, interfaces, ifaceStatuses, skipVFConfiguration)
 }
 
+// ConfigureBridges mocks base method.
+func (m *MockHostHelpersInterface) ConfigureBridges(bridgesSpec, bridgesStatus v1.Bridges) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConfigureBridges", bridgesSpec, bridgesStatus)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConfigureBridges indicates an expected call of ConfigureBridges.
+func (mr *MockHostHelpersInterfaceMockRecorder) ConfigureBridges(bridgesSpec, bridgesStatus interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureBridges", reflect.TypeOf((*MockHostHelpersInterface)(nil).ConfigureBridges), bridgesSpec, bridgesStatus)
+}
+
 // ConfigureVfGUID mocks base method.
 func (m *MockHostHelpersInterface) ConfigureVfGUID(vfAddr, pfAddr string, vfID int, pfLink netlink.Link) error {
 	m.ctrl.T.Helper()
@@ -249,6 +263,35 @@ func (m *MockHostHelpersInterface) DeleteVDPADevice(pciAddr string) error {
 func (mr *MockHostHelpersInterfaceMockRecorder) DeleteVDPADevice(pciAddr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVDPADevice", reflect.TypeOf((*MockHostHelpersInterface)(nil).DeleteVDPADevice), pciAddr)
+}
+
+// DetachInterfaceFromManagedBridge mocks base method.
+func (m *MockHostHelpersInterface) DetachInterfaceFromManagedBridge(pciAddr string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachInterfaceFromManagedBridge", pciAddr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachInterfaceFromManagedBridge indicates an expected call of DetachInterfaceFromManagedBridge.
+func (mr *MockHostHelpersInterfaceMockRecorder) DetachInterfaceFromManagedBridge(pciAddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInterfaceFromManagedBridge", reflect.TypeOf((*MockHostHelpersInterface)(nil).DetachInterfaceFromManagedBridge), pciAddr)
+}
+
+// DiscoverBridges mocks base method.
+func (m *MockHostHelpersInterface) DiscoverBridges() (v1.Bridges, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiscoverBridges")
+	ret0, _ := ret[0].(v1.Bridges)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DiscoverBridges indicates an expected call of DiscoverBridges.
+func (mr *MockHostHelpersInterfaceMockRecorder) DiscoverBridges() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverBridges", reflect.TypeOf((*MockHostHelpersInterface)(nil).DiscoverBridges))
 }
 
 // DiscoverSriovDevices mocks base method.

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -49,7 +49,7 @@ var _ = Describe("SRIOV", func() {
 		hostMock = hostMockPkg.NewMockHostManagerInterface(testCtrl)
 		storeManagerMode = hostStoreMockPkg.NewMockManagerInterface(testCtrl)
 
-		s = New(nil, hostMock, hostMock, hostMock, hostMock, hostMock, netlinkLibMock, dputilsLibMock, sriovnetLibMock, ghwLibMock)
+		s = New(nil, hostMock, hostMock, hostMock, hostMock, hostMock, netlinkLibMock, dputilsLibMock, sriovnetLibMock, ghwLibMock, hostMock)
 	})
 
 	AfterEach(func() {

--- a/pkg/host/manager.go
+++ b/pkg/host/manager.go
@@ -1,6 +1,7 @@
 package host
 
 import (
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/bridge"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/infiniband"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/kernel"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/lib/dputils"
@@ -28,6 +29,7 @@ type HostManagerInterface interface {
 	types.SriovInterface
 	types.VdpaInterface
 	types.InfinibandInterface
+	types.BridgeInterface
 }
 
 type hostManager struct {
@@ -39,6 +41,7 @@ type hostManager struct {
 	types.SriovInterface
 	types.VdpaInterface
 	types.InfinibandInterface
+	types.BridgeInterface
 }
 
 func NewHostManager(utilsInterface utils.CmdInterface) (HostManagerInterface, error) {
@@ -56,8 +59,8 @@ func NewHostManager(utilsInterface utils.CmdInterface) (HostManagerInterface, er
 	if err != nil {
 		return nil, err
 	}
-	sr := sriov.New(utilsInterface, k, n, u, v, ib, netlinkLib, dpUtils, sriovnetLib, ghwLib)
-
+	br := bridge.New()
+	sr := sriov.New(utilsInterface, k, n, u, v, ib, netlinkLib, dpUtils, sriovnetLib, ghwLib, br)
 	return &hostManager{
 		utilsInterface,
 		k,
@@ -67,5 +70,6 @@ func NewHostManager(utilsInterface utils.CmdInterface) (HostManagerInterface, er
 		sr,
 		v,
 		ib,
+		br,
 	}, nil
 }

--- a/pkg/host/mock/mock_host.go
+++ b/pkg/host/mock/mock_host.go
@@ -179,6 +179,20 @@ func (mr *MockHostManagerInterfaceMockRecorder) ConfigSriovInterfaces(storeManag
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigSriovInterfaces", reflect.TypeOf((*MockHostManagerInterface)(nil).ConfigSriovInterfaces), storeManager, interfaces, ifaceStatuses, skipVFConfiguration)
 }
 
+// ConfigureBridges mocks base method.
+func (m *MockHostManagerInterface) ConfigureBridges(bridgesSpec, bridgesStatus v1.Bridges) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConfigureBridges", bridgesSpec, bridgesStatus)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ConfigureBridges indicates an expected call of ConfigureBridges.
+func (mr *MockHostManagerInterfaceMockRecorder) ConfigureBridges(bridgesSpec, bridgesStatus interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConfigureBridges", reflect.TypeOf((*MockHostManagerInterface)(nil).ConfigureBridges), bridgesSpec, bridgesStatus)
+}
+
 // ConfigureVfGUID mocks base method.
 func (m *MockHostManagerInterface) ConfigureVfGUID(vfAddr, pfAddr string, vfID int, pfLink netlink.Link) error {
 	m.ctrl.T.Helper()
@@ -219,6 +233,35 @@ func (m *MockHostManagerInterface) DeleteVDPADevice(pciAddr string) error {
 func (mr *MockHostManagerInterfaceMockRecorder) DeleteVDPADevice(pciAddr interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVDPADevice", reflect.TypeOf((*MockHostManagerInterface)(nil).DeleteVDPADevice), pciAddr)
+}
+
+// DetachInterfaceFromManagedBridge mocks base method.
+func (m *MockHostManagerInterface) DetachInterfaceFromManagedBridge(pciAddr string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachInterfaceFromManagedBridge", pciAddr)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachInterfaceFromManagedBridge indicates an expected call of DetachInterfaceFromManagedBridge.
+func (mr *MockHostManagerInterfaceMockRecorder) DetachInterfaceFromManagedBridge(pciAddr interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInterfaceFromManagedBridge", reflect.TypeOf((*MockHostManagerInterface)(nil).DetachInterfaceFromManagedBridge), pciAddr)
+}
+
+// DiscoverBridges mocks base method.
+func (m *MockHostManagerInterface) DiscoverBridges() (v1.Bridges, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DiscoverBridges")
+	ret0, _ := ret[0].(v1.Bridges)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DiscoverBridges indicates an expected call of DiscoverBridges.
+func (mr *MockHostManagerInterfaceMockRecorder) DiscoverBridges() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DiscoverBridges", reflect.TypeOf((*MockHostManagerInterface)(nil).DiscoverBridges))
 }
 
 // DiscoverSriovDevices mocks base method.

--- a/pkg/systemd/systemd.go
+++ b/pkg/systemd/systemd.go
@@ -47,6 +47,7 @@ type SriovConfig struct {
 	UnsupportedNics       bool                                     `yaml:"unsupportedNics"`
 	PlatformType          consts.PlatformTypes                     `yaml:"platformType"`
 	ManageSoftwareBridges bool                                     `yaml:"manageSoftwareBridges"`
+	OVSDBSocketPath       string                                   `yaml:"ovsdbSocketPath"`
 }
 
 type SriovResult struct {
@@ -72,6 +73,7 @@ func WriteConfFile(newState *sriovnetworkv1.SriovNetworkNodeState) (bool, error)
 		vars.DevMode,
 		vars.PlatformType,
 		vars.ManageSoftwareBridges,
+		vars.OVSDBSocketPath,
 	}
 
 	_, err := os.Stat(utils.GetHostExtensionPath(SriovSystemdConfigPath))


### PR DESCRIPTION
This PR enables all required code for software-bridges features. 
I will submit documentation for the feature in the next PR. I created https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/749 to track documentation update.

How to test the  feature:

* deploy the operator
* enable `manageSoftwareBridges` feature gate
```kubectl patch sriovoperatorconfigs.sriovnetwork.openshift.io -n network-operator default --patch '{ "spec": { "featureGates": { "manageSoftwareBridges": true  } } }' --type='merge'```
* create policy with the OVS config
```
kind: SriovNetworkNodePolicy
metadata:
  name: connectx6dx-switchdev
  namespace: network-operator
spec:
  eSwitchMode: switchdev
  mtu: 1500
  nicSelector:
    deviceID: 101d
    vendor: 15b3
  nodeSelector:
    node-role.kubernetes.io/worker: ""
  numVfs: 4
  resourceName: switchdev
  bridge:
    ovs: {}
```

* create OVSNetwork CR
```
apiVersion: sriovnetwork.openshift.io/v1
kind: OVSNetwork
metadata:
  name: ovs
  namespace: network-operator
spec:
  networkNamespace: default
  ipam: |
    {
      "type": "nv-ipam",
      "poolName": "pool1"
    }
  resourceName: switchdev
  vlan: 200
```