### PR TITLE
SCC-pinning for openshift workloads

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -23,6 +23,7 @@ spec:
         openshift.io/component: network
       annotations:
         kubectl.kubernetes.io/default-container: sriov-network-config-daemon
+        openshift.io/required-scc: privileged
     spec:
       hostNetwork: true
       hostPID: true

--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -22,6 +22,8 @@ spec:
     metadata:
       labels:
         app: operator-webhook
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       securityContext:
         runAsNonRoot: true

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -25,6 +25,8 @@ spec:
         component: network
         type: infra
         openshift.io/component: network
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       securityContext:
         runAsNonRoot: true

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -21,6 +21,8 @@ spec:
     metadata:
       labels:
         control-plane: controller-manager
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       securityContext:
         runAsNonRoot: true

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,6 +15,8 @@ spec:
     metadata:
       labels:
         name: sriov-network-operator
+      annotations:
+        openshift.io/required-scc: restricted-v2
     spec:
       affinity:
         nodeAffinity:

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -15,6 +15,8 @@ spec:
       maxUnavailable: 33%
   template:
     metadata:
+      annotations:
+        openshift.io/required-scc: restricted-v2
       labels:
         name: sriov-network-operator
     spec:


### PR DESCRIPTION
This PR explicitly sets the required SCC to be used to admit pods. The SCC chosen is the one that the pods are already getting admitted with, which means that this brings no change to the SCC used.

In some cases, custom SCCs can have higher priority than default SCCs, which means that they will be chosen over the default ones. This can lead to unexpected results; in order to protect openshift workloads from this, we must explicitly pin the required SCC to all our workloads in order to make sure that the expected one will be used.