### PR TITLE
set dev version for chart

### DIFF
--- a/deployment/sriov-network-operator-chart/Chart.yaml
+++ b/deployment/sriov-network-operator-chart/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: sriov-network-operator-chart
-version: 1.2.0
+version: 0.0.0-dev
 kubeVersion: '>= 1.16.0-0'
-appVersion: 1.2.0
+appVersion: v0.0.0-dev
 description: SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster
 type: application
 keywords:

--- a/deployment/sriov-network-operator-chart/Chart.yaml
+++ b/deployment/sriov-network-operator-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: sriov-network-operator-chart
 version: 0.0.0-dev
-kubeVersion: '>= 1.16.0-0'
+kubeVersion: '>= 1.24.0-0'
 appVersion: v0.0.0-dev
 description: SR-IOV network operator configures and manages SR-IOV networks in the kubernetes cluster
 type: application


### PR DESCRIPTION
chart in the repo should be set to an arbitrary dev version as we deploy latest components by default.

during release workflow relevant values are replaced when release chart is built.