### PR TITLE
Refactor some conformance tests to use `SRIOV_NODE_AND_DEVICE_NAME_FILTER`

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -1060,9 +1060,11 @@ var _ = Describe("[sriov] operator", func() {
 
 			findSriovDevice := func(vendorID, deviceID string) (string, sriovv1.InterfaceExt) {
 				for _, node := range sriovInfos.Nodes {
-					for _, nic := range sriovInfos.States[node].Status.Interfaces {
+					devices, err := sriovInfos.FindSriovDevices(node)
+					Expect(err).ToNot(HaveOccurred())
+					for _, nic := range devices {
 						if vendorID != "" && deviceID != "" && nic.Vendor == vendorID && nic.DeviceID == deviceID {
-							return node, nic
+							return node, *nic
 						}
 					}
 				}

--- a/test/util/cluster/cluster.go
+++ b/test/util/cluster/cluster.go
@@ -203,9 +203,14 @@ func (n *EnabledNodes) FindOneSriovNodeAndDevice() (string, *sriovv1.InterfaceEx
 // FindOneVfioSriovDevice retrieves a node with a valid sriov device for vfio
 func (n *EnabledNodes) FindOneVfioSriovDevice() (string, sriovv1.InterfaceExt) {
 	for _, node := range n.Nodes {
-		for _, nic := range n.States[node].Status.Interfaces {
+		devices, err := n.FindSriovDevices(node)
+		if err != nil {
+			return "", sriovv1.InterfaceExt{}
+		}
+
+		for _, nic := range devices {
 			if nic.Vendor == intelVendorID && sriovv1.IsSupportedModel(nic.Vendor, nic.DeviceID) && nic.TotalVfs != 0 {
-				return node, nic
+				return node, *nic
 			}
 		}
 	}


### PR DESCRIPTION
This commit updates several conformance tests to make use of the SRIOV_NODE_AND_DEVICE_NAME_FILTER variable. By integrating this variable, the tests can now better target specific nodes and devices, improving test precision and reducing potential errors. This change enhances the flexibility and maintainability of the test suite.

cc @evgenLevin