### PR TITLE
Fix merge annotation function

### DIFF
--- a/pkg/apply/merge.go
+++ b/pkg/apply/merge.go
@@ -220,7 +220,7 @@ func mergeAnnotations(current, updated *uns.Unstructured) {
 	for k, v := range updatedAnnotations {
 		curAnnotations[k] = v
 	}
-	if len(curAnnotations) > 1 {
+	if len(curAnnotations) > 0 {
 		updated.SetAnnotations(curAnnotations)
 	}
 }
@@ -238,7 +238,7 @@ func mergeLabels(current, updated *uns.Unstructured) {
 	for k, v := range updatedLabels {
 		curLabels[k] = v
 	}
-	if len(curLabels) > 1 {
+	if len(curLabels) > 0 {
 		updated.SetLabels(curLabels)
 	}
 }

--- a/pkg/apply/merge_test.go
+++ b/pkg/apply/merge_test.go
@@ -107,6 +107,38 @@ metadata:
 	}))
 }
 
+func TestMergeOne(t *testing.T) {
+	g := NewGomegaWithT(t)
+
+	cur := UnstructuredFromYaml(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: d1
+  labels:
+    label-c: cur
+  annotations:
+    annotation-c: cur`)
+
+	upd := UnstructuredFromYaml(t, `
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: d1`)
+
+	// this mutates updated
+	err := MergeObjectForUpdate(cur, upd)
+	g.Expect(err).NotTo(HaveOccurred())
+
+	g.Expect(upd.GetLabels()).To(Equal(map[string]string{
+		"label-c": "cur",
+	}))
+
+	g.Expect(upd.GetAnnotations()).To(Equal(map[string]string{
+		"annotation-c": "cur",
+	}))
+}
+
 func TestMergeNilCur(t *testing.T) {
 	g := NewGomegaWithT(t)
 


### PR DESCRIPTION
if the current obj as annotation and the updated doesn't we still want to add the ones from the current object