### PR TITLE
[Infiniband] Fix unbinding of physical functions when configuring Infiniband virtual functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ GOLANGCI_LINT = $(BIN_DIR)/golangci-lint
 # golangci-lint version should be updated periodically
 # we keep it fixed to avoid it from unexpectedly failing on the project
 # in case of a version bump
-GOLANGCI_LINT_VER = v1.55.2
+GOLANGCI_LINT_VER = v1.61.0
 
 
 .PHONY: all build clean gendeepcopy test test-e2e test-e2e-k8s run image fmt sync-manifests test-e2e-conformance manifests update-codegen

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -479,7 +479,7 @@ func (s *sriov) configSriovVFDevices(iface *sriovnetworkv1.Interface) error {
 					if err := s.infinibandHelper.ConfigureVfGUID(addr, iface.PciAddress, vfID, pfLink); err != nil {
 						return err
 					}
-					if err := s.kernelHelper.Unbind(iface.PciAddress); err != nil {
+					if err := s.kernelHelper.Unbind(addr); err != nil {
 						return err
 					}
 				} else {


### PR DESCRIPTION
This PR fixes a bug in the config daemon that unbinds physical functions instead of virtual functions when configuring Infiniband virtual functions.