### PR TITLE
Fix: GetDevlinkDeviceParam to handle edge-cases correctly

### DIFF
--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -376,6 +376,11 @@ func (s *sriov) configureHWOptionsForSwitchdev(iface *sriovnetworkv1.Interface) 
 		log.Log.Error(err, "configureHWOptionsForSwitchdev(): fail to read current flow steering mode for the device", "device", iface.PciAddress)
 		return err
 	}
+	if currentFlowSteeringMode == "" {
+		log.Log.V(2).Info("configureHWOptionsForSwitchdev(): can't detect current flow_steering_mode mode for the device, skip",
+			"device", iface.PciAddress)
+		return nil
+	}
 	if currentFlowSteeringMode == desiredFlowSteeringMode {
 		return nil
 	}


### PR DESCRIPTION
On some kernels `GetDevlinkDeviceParam` may return empty values for some kernel parameters. The netlink library is able to handle this, but the code in `GetDevlinkDeviceParam` function may panic if unexpected value received. 
Add extra checks to avoid panics.

The problem was discovered on an old kernel (5.15.0-25-generic) for Ubuntu 22.04.
The parameter has no value:
```
devlink dev param show pci/0000:08:00.0 name flow_steering_mode
pci/0000:08:00.0:
  name flow_steering_mode type driver-specific
    values:
```
segfault happens when trying to set the value
```
devlink dev param set pci/0000:08:00.0 name flow_steering_mode value smfs  cmode runtime
Segmentation fault (core dumped)
```
In the recent kernels everything works as expected. This change is primarily intended to enhance the operator's robustness, rather than to address any current issues.