### PR TITLE
logging: Reduce device discovering verbosity

### DIFF
--- a/pkg/host/internal/network/network.go
+++ b/pkg/host/internal/network/network.go
@@ -75,7 +75,7 @@ func (n *network) TryToGetVirtualInterfaceName(pciAddr string) string {
 func (n *network) TryGetInterfaceName(pciAddr string) string {
 	names, err := n.dputilsLib.GetNetNames(pciAddr)
 	if err != nil || len(names) < 1 {
-		log.Log.Error(err, "TryGetInterfaceName(): failed to get interface name")
+		log.Log.Error(err, "TryGetInterfaceName(): failed to get interface name", "pciAddress", pciAddr)
 		return ""
 	}
 	netDevName := names[0]

--- a/pkg/host/internal/vdpa/vdpa.go
+++ b/pkg/host/internal/vdpa/vdpa.go
@@ -94,11 +94,9 @@ func (v *vdpa) DeleteVDPADevice(pciAddr string) error {
 func (v *vdpa) DiscoverVDPAType(pciAddr string) string {
 	expectedVDPAName := generateVDPADevName(pciAddr)
 	funcLog := log.Log.WithValues("device", pciAddr, "name", expectedVDPAName)
-	funcLog.V(2).Info("DiscoverVDPAType() discover device type")
 	_, err := v.netlinkLib.VDPAGetDevByName(expectedVDPAName)
 	if err != nil {
 		if errors.Is(err, syscall.ENODEV) {
-			funcLog.V(2).Info("DiscoverVDPAType(): VDPA device for VF not found")
 			return ""
 		}
 		if errors.Is(err, syscall.ENOENT) {


### PR DESCRIPTION
The `DiscoverSriovDevices` routine produces a huge amount of log entries, making debugging problems hard.

Remove log entries that can produce a log line for each configured VF and which does not produce any change in the environment.

The following data comes from a lab I debugged recently:


Analysing a 51 Megabytes rotated log file:
```
$ ls -lh config-daemon.log
-rw-r--r--. 1 apanatto apanatto 51M Oct 18 12:26 config-daemon.log

$ wc -l config-daemon.log
267148 config-daemon.log
```

for 2h32m of idle application
```
$ tail -n 1 config-daemon.log
2024-09-23T12:40:30.620250456Z     INFO    daemon/writer.go:147    setNodeStateStatus(): status    {"sync-status": "Succeeded", "last-sync-error": ""}

$ head -n 1 config-daemon.log
2024-09-23T10:08:47.308287975Z     LEVEL(-2)       daemon/daemon.go:220    get item from queue     {"item": 2}
```

```
$ grep "DiscoverVDPAType() discover device type" config-daemon.log | wc -l
84736

$ grep "DiscoverVDPAType(): VDPA device for VF not found" config-daemon.log | wc -l
84736

grep "sriov/sriov.go:127     TryGetInterfaceName()" config-daemon.log | wc -l
84736
```

Which is 95% of the whole file.