### PR TITLE
feat: Update controller logic to handle stale SriovNetworkNodeState CRs with delay

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller_test.go
+++ b/controllers/sriovnetworknodepolicy_controller_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"sync"
 	"testing"
 	"time"
@@ -11,18 +12,17 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/google/go-cmp/cmp"
+	dptypes "github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	dptypes "github.com/k8snetworkplumbingwg/sriov-network-device-plugin/pkg/types"
-
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
-	v1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/featuregate"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
@@ -48,7 +48,7 @@ func TestRenderDevicePluginConfigData(t *testing.T) {
 		{
 			tname: "testVirtioVdpaVirtio",
 			policy: sriovnetworkv1.SriovNetworkNodePolicy{
-				Spec: v1.SriovNetworkNodePolicySpec{
+				Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
 					ResourceName: "resourceName",
 					DeviceType:   consts.DeviceTypeNetDevice,
 					VdpaType:     consts.VdpaTypeVirtio,
@@ -67,7 +67,7 @@ func TestRenderDevicePluginConfigData(t *testing.T) {
 		}, {
 			tname: "testVhostVdpaVirtio",
 			policy: sriovnetworkv1.SriovNetworkNodePolicy{
-				Spec: v1.SriovNetworkNodePolicySpec{
+				Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
 					ResourceName: "resourceName",
 					DeviceType:   consts.DeviceTypeNetDevice,
 					VdpaType:     consts.VdpaTypeVhost,
@@ -87,7 +87,7 @@ func TestRenderDevicePluginConfigData(t *testing.T) {
 		{
 			tname: "testExcludeTopology",
 			policy: sriovnetworkv1.SriovNetworkNodePolicy{
-				Spec: v1.SriovNetworkNodePolicySpec{
+				Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
 					ResourceName:    "resourceName",
 					ExcludeTopology: true,
 				},
@@ -138,6 +138,10 @@ var _ = Describe("SriovnetworkNodePolicy controller", Ordered, func() {
 	var ctx context.Context
 
 	BeforeAll(func() {
+		// disable stale state cleanup delay to check that the controller can cleanup state objects
+		DeferCleanup(os.Setenv, "STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", os.Getenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES"))
+		os.Setenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", "0")
+
 		By("Create SriovOperatorConfig controller k8s objs")
 		config := makeDefaultSriovOpConfig()
 		Expect(k8sClient.Create(context.Background(), config)).Should(Succeed())
@@ -258,6 +262,68 @@ var _ = Describe("SriovnetworkNodePolicy controller", Ordered, func() {
 				Expect(err).To(HaveOccurred())
 				Expect(errors.IsNotFound(err)).To(BeTrue())
 			}, time.Minute, time.Second).Should(Succeed())
+		})
+	})
+})
+
+var _ = Describe("SriovNetworkNodePolicyReconciler", Ordered, func() {
+	Context("handleStaleNodeState", func() {
+		var (
+			ctx       context.Context
+			r         *SriovNetworkNodePolicyReconciler
+			nodeState *sriovnetworkv1.SriovNetworkNodeState
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme := runtime.NewScheme()
+			utilruntime.Must(sriovnetworkv1.AddToScheme(scheme))
+			nodeState = &sriovnetworkv1.SriovNetworkNodeState{ObjectMeta: metav1.ObjectMeta{Name: "node1"}}
+			r = &SriovNetworkNodePolicyReconciler{Client: fake.NewClientBuilder().WithObjects(nodeState).Build()}
+		})
+		It("should set default delay", func() {
+			nodeState := nodeState.DeepCopy()
+			Expect(r.handleStaleNodeState(ctx, nodeState)).NotTo(HaveOccurred())
+			Expect(r.Get(ctx, types.NamespacedName{Name: nodeState.Name}, nodeState)).NotTo(HaveOccurred())
+			Expect(time.Now().UTC().Before(nodeState.GetKeepUntilTime())).To(BeTrue())
+		})
+		It("should remove CR if wait time expired", func() {
+			nodeState := nodeState.DeepCopy()
+			nodeState.SetKeepUntilTime(time.Now().UTC().Add(-time.Minute))
+			Expect(r.handleStaleNodeState(ctx, nodeState)).NotTo(HaveOccurred())
+			Expect(errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: nodeState.Name}, nodeState))).To(BeTrue())
+		})
+		It("should keep existing wait time if already set", func() {
+			nodeState := nodeState.DeepCopy()
+			nodeState.SetKeepUntilTime(time.Now().UTC().Add(time.Minute))
+			testTime := nodeState.GetKeepUntilTime()
+			r.Update(ctx, nodeState)
+			Expect(r.handleStaleNodeState(ctx, nodeState)).NotTo(HaveOccurred())
+			Expect(r.Get(ctx, types.NamespacedName{Name: nodeState.Name}, nodeState)).NotTo(HaveOccurred())
+			Expect(nodeState.GetKeepUntilTime()).To(Equal(testTime))
+		})
+		It("non default dealy", func() {
+			DeferCleanup(os.Setenv, "STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", os.Getenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES"))
+			os.Setenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", "60")
+			nodeState := nodeState.DeepCopy()
+			Expect(r.handleStaleNodeState(ctx, nodeState)).NotTo(HaveOccurred())
+			Expect(r.Get(ctx, types.NamespacedName{Name: nodeState.Name}, nodeState)).NotTo(HaveOccurred())
+			Expect(time.Until(nodeState.GetKeepUntilTime()) > 30*time.Minute).To(BeTrue())
+		})
+		It("invalid non default delay - should use default", func() {
+			DeferCleanup(os.Setenv, "STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", os.Getenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES"))
+			os.Setenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", "-20")
+			nodeState := nodeState.DeepCopy()
+			Expect(r.handleStaleNodeState(ctx, nodeState)).NotTo(HaveOccurred())
+			Expect(r.Get(ctx, types.NamespacedName{Name: nodeState.Name}, nodeState)).NotTo(HaveOccurred())
+			Expect(time.Until(nodeState.GetKeepUntilTime()) > 20*time.Minute).To(BeTrue())
+		})
+		It("should remove CR if delay is zero", func() {
+			DeferCleanup(os.Setenv, "STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", os.Getenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES"))
+			os.Setenv("STALE_NODE_STATE_CLEANUP_DELAY_MINUTES", "0")
+			nodeState := nodeState.DeepCopy()
+			Expect(r.handleStaleNodeState(ctx, nodeState)).NotTo(HaveOccurred())
+			Expect(errors.IsNotFound(r.Get(ctx, types.NamespacedName{Name: nodeState.Name}, nodeState))).To(BeTrue())
 		})
 	})
 })

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -112,6 +112,8 @@ spec:
               value: {{ .Values.operator.cniBinPath }}
             - name: CLUSTER_TYPE
               value: {{ .Values.operator.clusterType }}
+            - name: STALE_NODE_STATE_CLEANUP_DELAY_MINUTES
+              value: "{{ .Values.operator.staleNodeStateCleanupDelayMinutes }}"
         {{- if .Values.operator.admissionControllers.enabled }}
             - name: ADMISSION_CONTROLLERS_CERTIFICATES_OPERATOR_SECRET_NAME
               value: {{ .Values.operator.admissionControllers.certificates.secretNames.operator }}

--- a/deployment/sriov-network-operator-chart/values.yaml
+++ b/deployment/sriov-network-operator-chart/values.yaml
@@ -27,6 +27,10 @@ operator:
   resourcePrefix: "openshift.io"
   cniBinPath: "/opt/cni/bin"
   clusterType: "kubernetes"
+  # minimal amount of time (in minutes) the operator will wait before removing
+  # stale SriovNetworkNodeState objects (objects that doesn't match node with the daemon)
+  # "0" means no extra delay, in this case the CR will be removed by the next reconcilation cycle (may take up to 5 minutes)
+  staleNodeStateCleanupDelayMinutes: "30"
   metricsExporter:
     port: "9110"
     certificates:

--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -93,6 +93,14 @@ const (
 	MCPPauseAnnotationState = "sriovnetwork.openshift.io/state"
 	MCPPauseAnnotationTime  = "sriovnetwork.openshift.io/time"
 
+	// NodeStateKeepUntilAnnotation contains name of the "keep until time" annotation for SriovNetworkNodeState object.
+	// The "keep until time" specifies the earliest time at which the state object can be removed
+	// if the daemon's pod is not found on the node.
+	NodeStateKeepUntilAnnotation = "sriovnetwork.openshift.io/keep-state-until"
+	// DefaultNodeStateCleanupDelayMinutes contains default delay before removing stale SriovNetworkNodeState CRs
+	// (the CRs that no longer have a corresponding node with the daemon).
+	DefaultNodeStateCleanupDelayMinutes = 30
+
 	CheckpointFileName = "sno-initial-node-state.json"
 	Unknown            = "Unknown"
 


### PR DESCRIPTION
Update controller logic to handle stale SriovNetworkNodeState CRs with delay

- Changed the logic in the sriov-network-operator controller to handle stale SriovNetworkNodeState CRs (those with no matching Nodes with daemon).
- Introduced a delay (30 minutes by default) before removing stale state CRs to manage scenarios where the user temporarily removes the daemon from the node but does not want to lose the state stored in the SriovNetworkNodeState.
- Added the `STALE_NODE_STATE_CLEANUP_DELAY_MINUTES` environment variable to configure the required delay in minutes (default is 30 minutes).

This functionality especially useful when the OFED container is in use. As the OFED driver loads on the host, the sriov-config-daemon is removed from this node (achieved using configDaemon nodeselector). Since loading the driver can take a considerable amount of time, we want to ensure that the SriovNetworkNodeState is not lost during this process.