### PR TITLE
fix: Device Plugin daemonset keep restarting

### DIFF
--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -326,7 +326,7 @@ func nodeSelectorTermsForPolicyList(policies []sriovnetworkv1.SriovNetworkNodePo
 				return expressionA.Key < expressionB.Key
 			}
 			if expressionA.Values[0] != expressionB.Values[0] {
-				return expressionA.Values[0] != expressionB.Values[0]
+				return expressionA.Values[0] < expressionB.Values[0]
 			}
 		}
 		return true

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -311,6 +311,27 @@ func nodeSelectorTermsForPolicyList(policies []sriovnetworkv1.SriovNetworkNodePo
 		terms = append(terms, nodeSelector)
 	}
 
+	// sorting is needed to keep the daemon spec stable.
+	// the policies can come in a random order
+	sort.Slice(terms, func(i, j int) bool {
+		expressionsA := terms[i].MatchExpressions
+		expressionsB := terms[j].MatchExpressions
+		if len(expressionsA) != len(expressionsB) {
+			return len(expressionsA) < len(expressionsB)
+		}
+		for k := range expressionsA {
+			expressionA := expressionsA[k]
+			expressionB := expressionsB[k]
+			if expressionA.Key != expressionB.Key {
+				return expressionA.Key < expressionB.Key
+			}
+			if expressionA.Values[0] != expressionB.Values[0] {
+				return expressionA.Values[0] != expressionB.Values[0]
+			}
+		}
+		return true
+	})
+
 	return terms
 }
 

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -64,8 +64,8 @@ func TestNodeSelectorMerge(t *testing.T) {
 					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
 							Operator: corev1.NodeSelectorOpIn,
-							Key:      "foo",
-							Values:   []string{"bar"},
+							Key:      "bb",
+							Values:   []string{"cc"},
 						},
 					},
 				},
@@ -73,8 +73,8 @@ func TestNodeSelectorMerge(t *testing.T) {
 					MatchExpressions: []corev1.NodeSelectorRequirement{
 						{
 							Operator: corev1.NodeSelectorOpIn,
-							Key:      "bb",
-							Values:   []string{"cc"},
+							Key:      "foo",
+							Values:   []string{"bar"},
 						},
 					},
 				},

--- a/controllers/helper_test.go
+++ b/controllers/helper_test.go
@@ -148,6 +148,61 @@ func TestNodeSelectorMerge(t *testing.T) {
 			},
 			expected: []corev1.NodeSelectorTerm{},
 		},
+		{
+			tname: "testordersamekey",
+			policies: []sriovnetworkv1.SriovNetworkNodePolicy{
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"env": "production",
+						},
+					},
+				},
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"env": "staging",
+						},
+					},
+				},
+				{
+					Spec: sriovnetworkv1.SriovNetworkNodePolicySpec{
+						NodeSelector: map[string]string{
+							"env": "dev",
+						},
+					},
+				},
+			},
+			expected: []corev1.NodeSelectorTerm{
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "env",
+							Values:   []string{"dev"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "env",
+							Values:   []string{"production"},
+						},
+					},
+				},
+				{
+					MatchExpressions: []corev1.NodeSelectorRequirement{
+						{
+							Operator: corev1.NodeSelectorOpIn,
+							Key:      "env",
+							Values:   []string{"staging"},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range table {


### PR DESCRIPTION
Define an ordering of the NodeSelectorRequirement in the daemonset to avoid the daemonset to be unstable when policies come in different order.

Fixes #804