### PR TITLE
deploy: relax Operator node affinity

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,14 +20,22 @@ spec:
     spec:
       affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-            - matchExpressions:
-              - key: node-role.kubernetes.io/master
-                operator: Exists
-            - matchExpressions:
-                - key: node-role.kubernetes.io/control-plane
-                  operator: Exists
+          # In the context of Hypershift, the SR-IOV network
+          # Operator is deployed on Nodepools which are labeled
+          # as workers. So we relax the node affinity to prefer
+          # masters/control-plane when possible otherwise we
+          # schedule where it's possible.
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "node-role.kubernetes.io/master"
+                    operator: Exists
+            - weight: 1
+              preference:
+                matchExpressions:
+                  - key: "node-role.kubernetes.io/control-plane"
+                    operator: Exists
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master


### PR DESCRIPTION
In the context of Hypershift (Hosted Clusters with OpenShift), where a Nodepool
(terminology for a worker Node in HCP) is not a control-plane or
a master Node but a worker, we can't force the Operator to be deployed
on a master node that doesn't exist. Instead, we want to deploy it on a
worker.

The proposal here is to relax the rule and use
`preferredDuringSchedulingIgnoredDuringExecution` instead so the scheduler
will try to find a master node or fallback on other nodes if not found.
