### PR TITLE
Add waitForDevicesInitialization to systemd service

### DIFF
--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -1224,6 +1224,20 @@ func (mr *MockHostHelpersInterfaceMockRecorder) VFIsReady(pciAddr interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VFIsReady", reflect.TypeOf((*MockHostHelpersInterface)(nil).VFIsReady), pciAddr)
 }
 
+// WaitUdevEventsProcessed mocks base method.
+func (m *MockHostHelpersInterface) WaitUdevEventsProcessed(timeout int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUdevEventsProcessed", timeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUdevEventsProcessed indicates an expected call of WaitUdevEventsProcessed.
+func (mr *MockHostHelpersInterfaceMockRecorder) WaitUdevEventsProcessed(timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUdevEventsProcessed", reflect.TypeOf((*MockHostHelpersInterface)(nil).WaitUdevEventsProcessed), timeout)
+}
+
 // WriteCheckpointFile mocks base method.
 func (m *MockHostHelpersInterface) WriteCheckpointFile(arg0 *v1.SriovNetworkNodeState) error {
 	m.ctrl.T.Helper()

--- a/pkg/host/internal/udev/udev.go
+++ b/pkg/host/internal/udev/udev.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -121,6 +122,18 @@ func (u *udev) LoadUdevRules() error {
 	_, stderr, err = u.utilsHelper.RunCommand(udevAdmTool, "trigger", "--action", "add", "--attr-match", "subsystem=net")
 	if err != nil {
 		log.Log.Error(err, "LoadUdevRules(): failed to trigger rules", "error", stderr)
+		return err
+	}
+	return nil
+}
+
+// WaitUdevEventsProcessed calls `udevadm settle“ with provided timeout
+// The command watches the udev event queue, and exits if all current events are handled.
+func (u *udev) WaitUdevEventsProcessed(timeout int) error {
+	log.Log.V(2).Info("WaitUdevEventsProcessed()")
+	_, stderr, err := u.utilsHelper.RunCommand("udevadm", "settle", "-t", strconv.Itoa(timeout))
+	if err != nil {
+		log.Log.Error(err, "WaitUdevEventsProcessed(): failed to wait for udev rules to process", "error", stderr, "timeout", timeout)
 		return err
 	}
 	return nil

--- a/pkg/host/internal/udev/udev_test.go
+++ b/pkg/host/internal/udev/udev_test.go
@@ -210,4 +210,14 @@ var _ = Describe("UDEV", func() {
 			Expect(s.LoadUdevRules()).To(MatchError(testError))
 		})
 	})
+	Context("WaitUdevEventsProcessed", func() {
+		It("Succeed", func() {
+			utilsMock.EXPECT().RunCommand("udevadm", "settle", "-t", "10").Return("", "", nil)
+			Expect(s.WaitUdevEventsProcessed(10)).NotTo(HaveOccurred())
+		})
+		It("Command Failed", func() {
+			utilsMock.EXPECT().RunCommand("udevadm", "settle", "-t", "20").Return("", "", testError)
+			Expect(s.WaitUdevEventsProcessed(20)).To(MatchError(testError))
+		})
+	})
 })

--- a/pkg/host/mock/mock_host.go
+++ b/pkg/host/mock/mock_host.go
@@ -1038,3 +1038,17 @@ func (mr *MockHostManagerInterfaceMockRecorder) VFIsReady(pciAddr interface{}) *
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VFIsReady", reflect.TypeOf((*MockHostManagerInterface)(nil).VFIsReady), pciAddr)
 }
+
+// WaitUdevEventsProcessed mocks base method.
+func (m *MockHostManagerInterface) WaitUdevEventsProcessed(timeout int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUdevEventsProcessed", timeout)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUdevEventsProcessed indicates an expected call of WaitUdevEventsProcessed.
+func (mr *MockHostManagerInterfaceMockRecorder) WaitUdevEventsProcessed(timeout interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUdevEventsProcessed", reflect.TypeOf((*MockHostManagerInterface)(nil).WaitUdevEventsProcessed), timeout)
+}

--- a/pkg/host/types/interfaces.go
+++ b/pkg/host/types/interfaces.go
@@ -164,6 +164,9 @@ type UdevInterface interface {
 	RemoveVfRepresentorUdevRule(pfPciAddress string) error
 	// LoadUdevRules triggers udev rules for network subsystem
 	LoadUdevRules() error
+	// WaitUdevEventsProcessed calls `udevadm settle“ with provided timeout
+	// The command watches the udev event queue, and exits if all current events are handled.
+	WaitUdevEventsProcessed(timeout int) error
 }
 
 type VdpaInterface interface {


### PR DESCRIPTION
Add waitForDevicesInitialization to systemd service.

This function ensures that the network devices specified in the configuration are registered and handled by UDEV. Sometimes, the initialization of network devices might take a significant amount of time, and the sriov-config systemd service may start before the devices are fully processed, leading to failure.