### PR TITLE
Fixing pre-delete-webhook template for missing imagePullSecrets

### DIFF
--- a/deployment/sriov-network-operator-chart/templates/pre-delete-webooks.yaml
+++ b/deployment/sriov-network-operator-chart/templates/pre-delete-webooks.yaml
@@ -14,6 +14,12 @@ spec:
   template:
     spec:
       serviceAccountName: {{ include "sriov-network-operator.fullname" . }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.imagePullSecrets }}
+      - name: {{ . }}
+      {{- end }}
+      {{- end }}      
       containers:
         - name: cleanup
           image: {{ .Values.images.operator }}


### PR DESCRIPTION
Fixing `pre-delete-webhook` template for missing imagePullSecrets