### PR TITLE
e2e: Avoid setting wrong routes for `host-local` IPAM

### DIFF
--- a/test/conformance/tests/test_networkpool.go
+++ b/test/conformance/tests/test_networkpool.go
@@ -181,7 +181,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 				},
 				Spec: sriovv1.SriovNetworkSpec{
 					ResourceName:      resourceName,
-					IPAM:              `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+					IPAM:              `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 					NetworkNamespace:  namespaces.Test,
 					MetaPluginsConfig: `{"type": "rdma"}`,
 				}}
@@ -197,7 +197,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 				},
 				Spec: sriovv1.SriovNetworkSpec{
 					ResourceName:     resourceName,
-					IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+					IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 					NetworkNamespace: namespaces.Test,
 				}}
 
@@ -318,7 +318,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 				},
 				Spec: sriovv1.SriovNetworkSpec{
 					ResourceName:     resourceName,
-					IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+					IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 					NetworkNamespace: namespaces.Test,
 				}}
 

--- a/test/conformance/tests/test_policy_configuration.go
+++ b/test/conformance/tests/test_policy_configuration.go
@@ -90,7 +90,7 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 						},
 						Spec: sriovv1.SriovNetworkSpec{
 							ResourceName:     resourceName,
-							IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+							IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 							NetworkNamespace: namespaces.Test,
 						}}
 
@@ -483,9 +483,7 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 						"type":"host-local",
 						"subnet":"10.10.10.0/24",
 						"rangeStart":"10.10.10.171",
-						"rangeEnd":"10.10.10.181",
-						"routes":[{"dst":"0.0.0.0/0"}],
-						"gateway":"10.10.10.1"
+						"rangeEnd":"10.10.10.181"
 						}`
 
 					err = network.CreateSriovNetwork(clients, unusedSriovDevice, sriovNetworkName, namespaces.Test, operatorNamespace, resourceName, ipam)
@@ -600,7 +598,7 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 						},
 						Spec: sriovv1.SriovNetworkSpec{
 							ResourceName:     resourceName,
-							IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+							IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 							NetworkNamespace: namespaces.Test,
 						}}
 

--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -388,7 +388,7 @@ var _ = Describe("[sriov] operator", func() {
 					},
 					Spec: sriovv1.SriovNetworkSpec{
 						ResourceName:     resourceName,
-						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 						NetworkNamespace: namespaces.Test,
 					}}
 				err := clients.Create(context.Background(), sriovNetwork)
@@ -441,7 +441,7 @@ var _ = Describe("[sriov] operator", func() {
 					},
 					Spec: sriovv1.SriovNetworkSpec{
 						ResourceName:     resourceName,
-						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 						NetworkNamespace: namespaces.Test,
 					}}
 				err := clients.Create(context.Background(), sriovNetwork)
@@ -563,9 +563,7 @@ var _ = Describe("[sriov] operator", func() {
 						IPAM: `{"type":"host-local",
 								"subnet":"10.10.10.0/24",
 								"rangeStart":"10.10.10.171",
-								"rangeEnd":"10.10.10.181",
-								"routes":[{"dst":"0.0.0.0/0"}],
-								"gateway":"10.10.10.1"}`,
+								"rangeEnd":"10.10.10.181"}`,
 						NetworkNamespace: namespaces.Test,
 					}}
 
@@ -608,9 +606,7 @@ var _ = Describe("[sriov] operator", func() {
 						IPAM: `{"type":"host-local",
 								"subnet":"10.10.10.0/24",
 								"rangeStart":"10.10.10.171",
-								"rangeEnd":"10.10.10.181",
-								"routes":[{"dst":"0.0.0.0/0"}],
-								"gateway":"10.10.10.1"}`,
+								"rangeEnd":"10.10.10.181"}`,
 						NetworkNamespace: namespaces.Test,
 					}}
 
@@ -657,9 +653,7 @@ var _ = Describe("[sriov] operator", func() {
 						IPAM: `{"type":"host-local",
 								"subnet":"10.10.10.0/24",
 								"rangeStart":"10.10.10.171",
-								"rangeEnd":"10.10.10.181",
-								"routes":[{"dst":"0.0.0.0/0"}],
-								"gateway":"10.10.10.1"}`,
+								"rangeEnd":"10.10.10.181"}`,
 						NetworkNamespace: namespaces.Test,
 					}}
 
@@ -730,9 +724,7 @@ var _ = Describe("[sriov] operator", func() {
 							IPAM: `{"type":"host-local",
 								"subnet":"10.10.10.0/24",
 								"rangeStart":"10.10.10.171",
-								"rangeEnd":"10.10.10.181",
-								"routes":[{"dst":"0.0.0.0/0"}],
-								"gateway":"10.10.10.1"}`,
+								"rangeEnd":"10.10.10.181"}`,
 							MaxTxRate:        &maxTxRate,
 							MinTxRate:        &minTxRate,
 							NetworkNamespace: namespaces.Test,
@@ -766,9 +758,7 @@ var _ = Describe("[sriov] operator", func() {
 							IPAM: `{"type":"host-local",
 								"subnet":"10.10.10.0/24",
 								"rangeStart":"10.10.10.171",
-								"rangeEnd":"10.10.10.181",
-								"routes":[{"dst":"0.0.0.0/0"}],
-								"gateway":"10.10.10.1"}`,
+								"rangeEnd":"10.10.10.181"}`,
 							Vlan:             1,
 							VlanQoS:          2,
 							NetworkNamespace: namespaces.Test,
@@ -1310,7 +1300,7 @@ var _ = Describe("[sriov] operator", func() {
 					},
 					Spec: sriovv1.SriovNetworkSpec{
 						ResourceName:     resourceName,
-						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 						NetworkNamespace: namespaces.Test,
 					}}
 
@@ -1602,7 +1592,7 @@ var _ = Describe("[sriov] operator", func() {
 					},
 					Spec: sriovv1.SriovNetworkSpec{
 						ResourceName:     resourceName,
-						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181","routes":[{"dst":"0.0.0.0/0"}],"gateway":"10.10.10.1"}`,
+						IPAM:             `{"type":"host-local","subnet":"10.10.10.0/24","rangeStart":"10.10.10.171","rangeEnd":"10.10.10.181"}`,
 						NetworkNamespace: namespaces.Test,
 					}}
 

--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -1846,9 +1846,17 @@ func findUnusedSriovDevices(testNode string, sriovDevices []*sriovv1.InterfaceEx
 		if isDefaultRouteInterface(device.Name, routes) {
 			continue
 		}
-		stdout, _, err = pod.ExecCommand(clients, createdPod, "ip", "link", "show", device.Name)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(stdout)).Should(Not(Equal(0)), "Unable to query link state")
+		stdout, stderr, err := pod.ExecCommand(clients, createdPod, "ip", "link", "show", device.Name)
+		if err != nil {
+			fmt.Printf("Can't query link state for device [%s]: %s", device.Name, err.Error())
+			continue
+		}
+
+		if len(stdout) == 0 {
+			fmt.Printf("Can't query link state for device [%s]: stderr:[%s]", device.Name, stderr)
+			continue
+		}
+
 		if strings.Contains(stdout, "master ovs-system") {
 			continue // The interface is not active
 		}


### PR DESCRIPTION
The IPAM configuration:

```
{
"type":"host-local",
"subnet":"10.10.10.0{"type":"host-local",
"subnet":"10.10.10.0/24",
"rangeStart":"10.10.10.171",
"rangeEnd":"10.10.10.181",
"routes":[{"dst":"0.0.0.0/0"}],
"gateway":"10.10.10.1"
}
```

Can lead to the following pod `ip route` configuration:
```
default via 10.10.10.1 dev net1
default via 10.128.0.1 dev eth0
10.10.10.0/24 dev net1 proto kernel scope link src 10.10.10.172
10.128.0.0/23 dev eth0 proto kernel scope link src 10.128.0.135
10.128.0.0/14 via 10.128.0.1 dev eth0
```

which causes connectivity issues.

Avoid setting default routes to unknown gateways.