### PR TITLE
Flaky Coveralls failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ test-bindata-scripts: fakechroot
 	fakechroot ./test/scripts/kargs_test.sh
 
 test-%: generate manifests envtest
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir=/tmp -p path)" HOME="$(shell pwd)" go test ./$*/... -coverprofile cover-$*.out -coverpkg ./... -v
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir=/tmp -p path)" HOME="$(shell pwd)" go test ./$*/... -coverprofile cover-$*-$(CLUSTER_TYPE).out -coverpkg ./... -v
 
 GOCOVMERGE = $(BIN_DIR)/gocovmerge
 gocovmerge: ## Download gocovmerge locally if necessary.


### PR DESCRIPTION
- [Unit test for RdmaMode](https://github.com/k8snetworkplumbingwg/sriov-network-operator/commit/8b2d83f0674a2447c6b1bfa9a564200277ec0dd9)
- [Avoid overwriting coverage files for different CLUSTER_TYPEs](https://github.com/k8snetworkplumbingwg/sriov-network-operator/commit/77df5f87dd38b91ff94ad37af3c8649c4affe9b6)

This PR wants to solve the failures of the Coveralls actions: sometimes, the function `findNodePoolConfig(...)` results in low coverage. This is probably because of some test flakiness.

Also, the CI invokes `make test-controllers` and `CLUSTER_TYPE=openshift make test-controllers`. Both steps overrides
`cover-controllers.out` and the proposed changes avoid this problem.

see following sample builds:
- low: [coverage helper.go](https://coveralls.io/builds/71207026/source?filename=controllers%2Fhelper.go#L336)
- high: [coverage helper.go](https://coveralls.io/builds/71078584/source?filename=controllers%2Fhelper.go#L336)