### PR TITLE
e2e: Don't allocate TTY when executing commands

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -937,7 +937,7 @@ var _ = Describe("[sriov] operator", func() {
 				waitForNetAttachDef(sriovNetworkName, namespaces.Test)
 
 				testPod := createTestPod(node, []string{sriovNetworkName})
-				stdout, _, err := pod.ExecCommand(clients, testPod, "more", "/proc/sys/net/ipv4/conf/net1/accept_redirects")
+				stdout, _, err := pod.ExecCommand(clients, testPod, "cat", "/proc/sys/net/ipv4/conf/net1/accept_redirects")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(strings.TrimSpace(stdout)).To(Equal("1"))

--- a/test/util/pod/pod.go
+++ b/test/util/pod/pod.go
@@ -117,7 +117,6 @@ func ExecCommand(cs *testclient.ClientSet, pod *corev1.Pod, command ...string) (
 			Command:   command,
 			Stdout:    true,
 			Stderr:    true,
-			TTY:       true,
 		}, scheme.ParameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(cs.Config, "POST", req.URL())
@@ -125,10 +124,9 @@ func ExecCommand(cs *testclient.ClientSet, pod *corev1.Pod, command ...string) (
 		return buf.String(), errbuf.String(), err
 	}
 
-	err = exec.Stream(remotecommand.StreamOptions{
+	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
 		Stdout: &buf,
 		Stderr: &errbuf,
-		Tty:    true,
 	})
 	if err != nil {
 		return buf.String(), errbuf.String(), err


### PR DESCRIPTION
Executing commands on pods allocating TTY may produce additional, unwanted characters like:
```
\x1b[1;31m2024-12-06T20:33:56.630784Z:
```

We saw this in some CI run like
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.18-e2e-telco5g-sno-cnftests/1865094117650862080/artifacts/e2e-telco5g-sno-cnftests/telco5g-cnf-tests/artifacts/test_results.html

Avoid allocating TTY in the automated test suite.