### PR TITLE
Skip kernel parameters configuration for Ubuntu

### DIFF
--- a/bindata/scripts/kargs.sh
+++ b/bindata/scripts/kargs.sh
@@ -7,6 +7,14 @@ declare -a kargs=( "$@" )
 ret=0
 args=$(chroot /host/ cat /proc/cmdline)
 
+IS_OS_UBUNTU=true; [[ "$(chroot /host/ grep -i ubuntu /etc/os-release -c)" == "0" ]] && IS_OS_UBUNTU=false
+
+# Kernel args configuration isn't supported for Ubuntu now, so we shouldn't do anything here
+if ${IS_OS_UBUNTU} ; then
+    echo $ret
+    exit 0
+fi
+
 if chroot /host/ test -f /run/ostree-booted ; then
     for t in "${kargs[@]}";do
         if [[ $command == "add" ]];then

--- a/test/scripts/kargs_test.sh
+++ b/test/scripts/kargs_test.sh
@@ -6,6 +6,7 @@ SUT_SCRIPT="${SCRIPTPATH}/../../bindata/scripts/kargs.sh"
 
 
 test_RpmOstree_Add_All_Arguments() {
+    echo "ID=\"rhel\"" > ${FAKE_HOST}/etc/os-release
     echo "a b c=d eee=fff" > ${FAKE_HOST}/proc/cmdline
     touch ${FAKE_HOST}/run/ostree-booted
 
@@ -19,6 +20,7 @@ test_RpmOstree_Add_All_Arguments() {
 
 
 test_RpmOstree_Add_Only_Missing_Arguments() {
+    echo "ID=\"rhel\"" > ${FAKE_HOST}/etc/os-release
     echo "a b c=d eee=fff K=L" > ${FAKE_HOST}/proc/cmdline
     touch ${FAKE_HOST}/run/ostree-booted
 
@@ -31,6 +33,7 @@ test_RpmOstree_Add_Only_Missing_Arguments() {
 }
 
 test_RpmOstree_Delete_All_Arguments() {
+    echo "ID=\"rhel\"" > ${FAKE_HOST}/etc/os-release
     echo "a b c=d eee=fff X=Y W=Z" > ${FAKE_HOST}/proc/cmdline
     touch ${FAKE_HOST}/run/ostree-booted
 
@@ -43,6 +46,7 @@ test_RpmOstree_Delete_All_Arguments() {
 }
 
 test_RpmOstree_Delete_Only_Exist_Arguments() {
+    echo "ID=\"rhel\"" > ${FAKE_HOST}/etc/os-release
     echo "a b c=d eee=fff X=Y" > ${FAKE_HOST}/proc/cmdline
     touch ${FAKE_HOST}/run/ostree-booted
 


### PR DESCRIPTION
It's enouph to configure ib_core module in /etc/moprobe.d/ for Ubuntu OS to change RDMA subsystem mode.

Also this commit fixes kargs.sh error because 'grubby' isn't available in official Ubuntu repositories.