### PR TITLE
add link state enable on test

### DIFF
--- a/test/conformance/tests/test_policy_configuration.go
+++ b/test/conformance/tests/test_policy_configuration.go
@@ -602,6 +602,11 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 							NetworkNamespace: namespaces.Test,
 						}}
 
+					// for real BM env we enable link state
+					if !cluster.VirtualCluster() {
+						sriovNetwork.Spec.LinkState = "enable"
+					}
+
 					// We need this to be able to run the connectivity checks on Mellanox cards
 					if intf.DeviceID == "1015" {
 						sriovNetwork.Spec.SpoofChk = off


### PR DESCRIPTION
if we run on a system where the PF is not connected to the network we can still use it for tests but we need the link state to not be auto.