### PR TITLE
extend func-test timeout

### DIFF
--- a/hack/run-e2e-conformance.sh
+++ b/hack/run-e2e-conformance.sh
@@ -7,4 +7,4 @@ GOPATH="${GOPATH:-$HOME/go}"
 JUNIT_OUTPUT="${JUNIT_OUTPUT:-/tmp/artifacts}"
 export PATH=$PATH:$GOPATH/bin
 
-${root}/bin/ginkgo -output-dir=$JUNIT_OUTPUT --junit-report "unit_report.xml" -v "$SUITE" -- -report=$JUNIT_OUTPUT
+${root}/bin/ginkgo --timeout=3h -output-dir=$JUNIT_OUTPUT --junit-report "unit_report.xml" -v "$SUITE" -- -report=$JUNIT_OUTPUT


### PR DESCRIPTION
with the introduction of rdma system mode change on baremetal systems it takes more than 1h that is the default for ginkgo