### PR TITLE
ovs: add internal interface

### DIFF
--- a/pkg/host/internal/bridge/ovs/ovs.go
+++ b/pkg/host/internal/bridge/ovs/ovs.go
@@ -148,6 +148,15 @@ func (o *ovs) CreateOVSBridge(ctx context.Context, conf *sriovnetworkv1.OVSConfi
 		funcLog.Error(err, "CreateOVSBridge(): failed to get bridge after creation")
 		return err
 	}
+	funcLog.V(2).Info("CreateOVSBridge(): add internal interface to the bridge")
+	if err := o.addInterface(ctx, dbClient, bridge, &InterfaceEntry{
+		Name: bridge.Name,
+		UUID: uuid.NewString(),
+		Type: "internal",
+	}); err != nil {
+		funcLog.Error(err, "CreateOVSBridge(): failed to add internal interface to the bridge")
+		return err
+	}
 	funcLog.V(2).Info("CreateOVSBridge(): add uplink interface to the bridge")
 	if err := o.addInterface(ctx, dbClient, bridge, &InterfaceEntry{
 		Name:        conf.Uplinks[0].Name,


### PR DESCRIPTION
When creating a bridge with ovs-vsctl, an internal interface is added by default.
The same behavior is added in this commit

ovs-vsctl code ref:
https://github.com/openvswitch/ovs/blob/main/utilities/ovs-vsctl.c#L1597