### PR TITLE
add support for draining single nodes

### DIFF
--- a/api/v1/sriovnetworkpoolconfig_types.go
+++ b/api/v1/sriovnetworkpoolconfig_types.go
@@ -22,6 +22,13 @@ type SriovNetworkPoolConfigSpec struct {
 	// even if maxUnavailable is greater than one.
 	MaxUnavailable *intstr.IntOrString `json:"maxUnavailable,omitempty"`
 
+	// SkipDrainOnReboot defines if the operator should make a full no drain before reboot
+	//
+	// This is useful for single node deployments instead of using the skipDrain from the operatorConfig.
+	// This will allow the operator to drain pods using sriov devices when drain is needed on single node
+	// instead of just removing the VF's from running pods that is the case if skipDrain is used.
+	SkipDrainOnReboot bool `json:"skipDrainOnReboot,omitempty"`
+
 	// +kubebuilder:validation:Enum=shared;exclusive
 	// RDMA subsystem. Allowed value "shared", "exclusive".
 	RdmaMode string `json:"rdmaMode,omitempty"`

--- a/config/crd/bases/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
+++ b/config/crd/bases/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
@@ -117,6 +117,15 @@ spec:
                 - shared
                 - exclusive
                 type: string
+              skipDrainOnReboot:
+                description: |-
+                  SkipDrainOnReboot defines if the operator should make a full no drain before reboot
+
+
+                  This is useful for single node deployments instead of using the skipDrain from the operatorConfig.
+                  This will allow the operator to drain pods using sriov devices when drain is needed on single node
+                  instead of just removing the VF's from running pods that is the case if skipDrain is used.
+                type: boolean
             type: object
           status:
             description: SriovNetworkPoolConfigStatus defines the observed state of

--- a/deployment/sriov-network-operator-chart/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
+++ b/deployment/sriov-network-operator-chart/crds/sriovnetwork.openshift.io_sriovnetworkpoolconfigs.yaml
@@ -117,6 +117,15 @@ spec:
                 - shared
                 - exclusive
                 type: string
+              skipDrainOnReboot:
+                description: |-
+                  SkipDrainOnReboot defines if the operator should make a full no drain before reboot
+
+
+                  This is useful for single node deployments instead of using the skipDrain from the operatorConfig.
+                  This will allow the operator to drain pods using sriov devices when drain is needed on single node
+                  instead of just removing the VF's from running pods that is the case if skipDrain is used.
+                type: boolean
             type: object
           status:
             description: SriovNetworkPoolConfigStatus defines the observed state of

--- a/hack/virtual-cluster-redeploy.sh
+++ b/hack/virtual-cluster-redeploy.sh
@@ -75,6 +75,7 @@ if [ $CLUSTER_TYPE == "openshift" ]; then
   echo "## deploying SRIOV Network Operator"
   hack/deploy-setup.sh $NAMESPACE
 else
+  kubectl apply -f deployment/sriov-network-operator-chart/crds
   export HELM_MODE=upgrade
   hack/deploy-operator-helm.sh
 fi


### PR DESCRIPTION
With this change if a single node needs to drain to make configure changes it will remove pods using SR-IOV devices, but in case if a reboot is needed we just go and reboot.

This is an improvements from the skipDrain option we have in the sriovOperatorConfig where in case of only draining is needed to make the configuration change running pods using sriov will lost the VFs in runtime...