### PR TITLE
use kubeclient to get and delete machineconfig

### DIFF
--- a/cmd/sriov-network-operator-config-cleanup/cleanup_test.go
+++ b/cmd/sriov-network-operator-config-cleanup/cleanup_test.go
@@ -141,11 +141,11 @@ func newConfigController() *configController {
 	platformHelper.EXPECT().IsHypershift().Return(false).AnyTimes()
 
 	err = (&controllers.SriovOperatorConfigReconciler{
-		Client:         k8sManager.GetClient(),
-		Scheme:         k8sManager.GetScheme(),
-		PlatformHelper: platformHelper,
-		FeatureGate:    featuregate.New(),
-		KubeClient:     k8sClient,
+		Client:            k8sManager.GetClient(),
+		Scheme:            k8sManager.GetScheme(),
+		PlatformHelper:    platformHelper,
+		FeatureGate:       featuregate.New(),
+		UncachedAPIReader: k8sManager.GetAPIReader(),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/cmd/sriov-network-operator-config-cleanup/cleanup_test.go
+++ b/cmd/sriov-network-operator-config-cleanup/cleanup_test.go
@@ -145,6 +145,7 @@ func newConfigController() *configController {
 		Scheme:         k8sManager.GetScheme(),
 		PlatformHelper: platformHelper,
 		FeatureGate:    featuregate.New(),
+		KubeClient:     k8sClient,
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -415,7 +415,7 @@ func (r *SriovOperatorConfigReconciler) syncOpenShiftSystemdService(ctx context.
 	if cr.Spec.ConfigurationMode != sriovnetworkv1.SystemdConfigurationMode {
 		obj := &machinev1.MachineConfig{}
 		// use uncached api reader to get machineconfig to reduce memory footprint
-		err := r.UncachedAPIReader.Get(context.TODO(), types.NamespacedName{Name: consts.SystemdServiceOcpMachineConfigName}, obj)
+		err := r.UncachedAPIReader.Get(ctx, types.NamespacedName{Name: consts.SystemdServiceOcpMachineConfigName}, obj)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil
@@ -426,7 +426,7 @@ func (r *SriovOperatorConfigReconciler) syncOpenShiftSystemdService(ctx context.
 		}
 
 		logger.Info("Systemd service was deployed but the operator is now operating on daemonset mode, removing the machine config")
-		err = r.Delete(context.TODO(), obj)
+		err = r.Delete(ctx, obj)
 		if err != nil {
 			logger.Error(err, "failed to remove the systemd service machine config")
 			return err

--- a/controllers/sriovoperatorconfig_controller.go
+++ b/controllers/sriovoperatorconfig_controller.go
@@ -59,6 +59,7 @@ type SriovOperatorConfigReconciler struct {
 	Scheme         *runtime.Scheme
 	PlatformHelper platforms.Interface
 	FeatureGate    featuregate.FeatureGate
+	KubeClient     client.Client
 }
 
 //+kubebuilder:rbac:groups=sriovnetwork.openshift.io,resources=sriovoperatorconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -413,7 +414,7 @@ func (r *SriovOperatorConfigReconciler) syncOpenShiftSystemdService(ctx context.
 
 	if cr.Spec.ConfigurationMode != sriovnetworkv1.SystemdConfigurationMode {
 		obj := &machinev1.MachineConfig{}
-		err := r.Get(context.TODO(), types.NamespacedName{Name: consts.SystemdServiceOcpMachineConfigName}, obj)
+		err := r.KubeClient.Get(context.TODO(), types.NamespacedName{Name: consts.SystemdServiceOcpMachineConfigName}, obj)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return nil
@@ -424,7 +425,7 @@ func (r *SriovOperatorConfigReconciler) syncOpenShiftSystemdService(ctx context.
 		}
 
 		logger.Info("Systemd service was deployed but the operator is now operating on daemonset mode, removing the machine config")
-		err = r.Delete(context.TODO(), obj)
+		err = r.KubeClient.Delete(context.TODO(), obj)
 		if err != nil {
 			logger.Error(err, "failed to remove the systemd service machine config")
 			return err

--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -69,6 +69,7 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 			Scheme:         k8sManager.GetScheme(),
 			PlatformHelper: platformHelper,
 			FeatureGate:    featuregate.New(),
+			KubeClient:     k8sClient,
 		}).SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -65,11 +65,11 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 		platformHelper.EXPECT().IsHypershift().Return(false).AnyTimes()
 
 		err = (&SriovOperatorConfigReconciler{
-			Client:         k8sManager.GetClient(),
-			Scheme:         k8sManager.GetScheme(),
-			PlatformHelper: platformHelper,
-			FeatureGate:    featuregate.New(),
-			KubeClient:     k8sClient,
+			Client:            k8sManager.GetClient(),
+			Scheme:            k8sManager.GetScheme(),
+			PlatformHelper:    platformHelper,
+			FeatureGate:       featuregate.New(),
+			UncachedAPIReader: k8sManager.GetAPIReader(),
 		}).SetupWithManager(k8sManager)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -219,11 +219,11 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.SriovOperatorConfigReconciler{
-		Client:         mgr.GetClient(),
-		Scheme:         mgr.GetScheme(),
-		PlatformHelper: platformsHelper,
-		FeatureGate:    featureGate,
-		KubeClient:     kubeClient,
+		Client:            mgr.GetClient(),
+		Scheme:            mgr.GetScheme(),
+		PlatformHelper:    platformsHelper,
+		FeatureGate:       featureGate,
+		UncachedAPIReader: mgr.GetAPIReader(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SriovOperatorConfig")
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -223,6 +223,7 @@ func main() {
 		Scheme:         mgr.GetScheme(),
 		PlatformHelper: platformsHelper,
 		FeatureGate:    featureGate,
+		KubeClient:     kubeClient,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "SriovOperatorConfig")
 		os.Exit(1)


### PR DESCRIPTION
Use kubeclient to get and delete machineconfig, to fix https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/846