### PR TITLE
Allow to drain on single node

### DIFF
--- a/controllers/drain_controller_helper.go
+++ b/controllers/drain_controller_helper.go
@@ -88,8 +88,24 @@ func (dr *DrainReconcile) handleNodeDrainOrReboot(ctx context.Context,
 		}
 	}
 
+	// Check if we are on a single node, and we require a reboot/full-drain we just return
+	fullNodeDrain := nodeDrainAnnotation == constants.RebootRequired
+	singleNode := false
+	if fullNodeDrain {
+		nodeList := &corev1.NodeList{}
+		err := dr.Client.List(ctx, nodeList)
+		if err != nil {
+			reqLogger.Error(err, "failed to list nodes")
+			return ctrl.Result{}, err
+		}
+		if len(nodeList.Items) == 1 {
+			reqLogger.Info("drainNode(): FullNodeDrain requested and we are on Single node")
+			singleNode = true
+		}
+	}
+
 	// call the drain function that will also call drain to other platform providers like openshift
-	drained, err := dr.drainer.DrainNode(ctx, node, nodeDrainAnnotation == constants.RebootRequired)
+	drained, err := dr.drainer.DrainNode(ctx, node, fullNodeDrain, singleNode)
 	if err != nil {
 		reqLogger.Error(err, "error trying to drain the node")
 		dr.recorder.Event(nodeNetworkState,

--- a/controllers/drain_controller_test.go
+++ b/controllers/drain_controller_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Drain Controller", Ordered, func() {
 
 	Context("when there is only one node", func() {
 
-		It("should drain", func(ctx context.Context) {
+		It("should drain single node on drain require", func(ctx context.Context) {
 			node, nodeState := createNode(ctx, "node1")
 
 			simulateDaemonSetAnnotation(node, constants.DrainRequired)
@@ -123,6 +123,33 @@ var _ = Describe("Drain Controller", Ordered, func() {
 
 			simulateDaemonSetAnnotation(node, constants.DrainIdle)
 
+			expectNodeStateAnnotation(nodeState, constants.DrainIdle)
+			expectNodeIsSchedulable(node)
+		})
+
+		It("should not drain on reboot for single node", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1")
+
+			simulateDaemonSetAnnotation(node, constants.RebootRequired)
+
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectNodeIsSchedulable(node)
+
+			simulateDaemonSetAnnotation(node, constants.DrainIdle)
+			expectNodeStateAnnotation(nodeState, constants.DrainIdle)
+			expectNodeIsSchedulable(node)
+		})
+
+		It("should drain on reboot for multiple node", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1")
+			createNode(ctx, "node2")
+
+			simulateDaemonSetAnnotation(node, constants.RebootRequired)
+
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectNodeIsNotSchedulable(node)
+
+			simulateDaemonSetAnnotation(node, constants.DrainIdle)
 			expectNodeStateAnnotation(nodeState, constants.DrainIdle)
 			expectNodeIsSchedulable(node)
 		})


### PR DESCRIPTION
With this change we can stop using the skipDrain for single node clusters.

when a daemon request for drain we remove all the pods using sriov devices from the node, but in case the daemon requests a reboot and we are on a single node cluster we just mark the node as ready for reboot.

NOTE: we check the number of nodes in general not with the daemonSelector or the pool nodeSelector as in that case pods not using sriov devices can in theory move to other nodes.