### PR TITLE
e2e: Improve `SriovNetworkMetricsExporter` stability

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -296,10 +296,10 @@ var _ = Describe("[sriov] operator", func() {
 				By("Checking that a daemon is scheduled on selected node")
 				Eventually(func() bool {
 					return isDaemonsetScheduledOnNodes("node-role.kubernetes.io/worker", "app=sriov-network-metrics-exporter")
-				}, 1*time.Minute, 1*time.Second).Should(Equal(true))
+				}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Equal(true))
 			})
 
-			It("should deploy ServiceMonitor if the Promethueus operator is installed", func() {
+			It("should deploy ServiceMonitor if the Prometheus operator is installed", func() {
 				_, err := clients.ServiceMonitors(operatorNamespace).List(context.Background(), metav1.ListOptions{})
 				if k8serrors.IsNotFound(err) {
 					Skip("Prometheus operator not available in the cluster")
@@ -309,7 +309,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func(g Gomega) {
 					_, err := clients.ServiceMonitors(operatorNamespace).Get(context.Background(), "sriov-network-metrics-exporter", metav1.GetOptions{})
 					g.Expect(err).ToNot(HaveOccurred())
-				}).Should(Succeed())
+				}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Succeed())
 			})
 
 			It("should remove ServiceMonitor when the feature is turned off", func() {
@@ -317,7 +317,7 @@ var _ = Describe("[sriov] operator", func() {
 				Eventually(func(g Gomega) {
 					_, err := clients.ServiceMonitors(operatorNamespace).Get(context.Background(), "sriov-network-metrics-exporter", metav1.GetOptions{})
 					g.Expect(k8serrors.IsNotFound(err)).To(BeTrue())
-				}).Should(Succeed())
+				}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Succeed())
 			})
 		})
 	})


### PR DESCRIPTION
Gomega default timings for `Eventually` blocks are Timeout: 1s, Polling 100ms. This can be too strict for the operator and lead to flakes in case of loaded systems.

Relax Eventually timings for SriovNetworkMetricsExporter tests