### PR TITLE
Remove vf configuration file from host

### DIFF
--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -658,7 +658,7 @@ func (s *sriov) getConfigureAndReset(storeManager store.ManagerInterface, interf
 			}
 		}
 
-		if !configured && ifaceStatus.NumVfs > 0 {
+		if !configured {
 			toBeResetted = append(toBeResetted, ifaceStatus)
 		}
 	}
@@ -824,8 +824,10 @@ func (s *sriov) checkForConfigAndReset(ifaceStatus sriovnetworkv1.InterfaceExt, 
 		return err
 	}
 
-	if err = s.ResetSriovDevice(ifaceStatus); err != nil {
-		return err
+	if ifaceStatus.NumVfs > 0 {
+		if err = s.ResetSriovDevice(ifaceStatus); err != nil {
+			return err
+		}
 	}
 
 	// remove pf status from host

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -241,8 +241,13 @@ var _ = Describe("SRIOV", func() {
 			hostMock.EXPECT().HasDriver("0000:d8:00.3").Return(true, "vfio-pci").Times(2)
 			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.3", false).Return(nil)
 			hostMock.EXPECT().BindDpdkDriver("0000:d8:00.3", "vfio-pci").Return(nil)
+			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.1").Return(nil)
+			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.1").Return(nil)
+			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.1").Return(nil)
 
 			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
+			storeManagerMode.EXPECT().RemovePfAppliedStatus(gomock.Any()).Return(nil)
+			storeManagerMode.EXPECT().LoadPfsStatus("0000:d8:00.1").Return(&sriovnetworkv1.Interface{ExternallyManaged: false}, true, nil)
 
 			Expect(s.ConfigSriovInterfaces(storeManagerMode,
 				[]sriovnetworkv1.Interface{{


### PR DESCRIPTION
In case a policy gets removed when a node is rebooting after the reboot the number of virtual functions will be 0 and we will not remove the related configuration files from the host.

This commit fixes that issue