### PR TITLE
remove 5 second timeout

### DIFF
--- a/cmd/sriov-network-config-daemon/start.go
+++ b/cmd/sriov-network-config-daemon/start.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"os"
 	"strings"
-	"time"
 
 	ocpconfigapi "github.com/openshift/api/config/v1"
 	"github.com/spf13/cobra"
@@ -229,7 +228,6 @@ func runStartCmd(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	vars.Config = config
-	config.Timeout = 5 * time.Second
 
 	// create helpers
 	hostHelpers, err := helper.NewDefaultHostHelpers()


### PR DESCRIPTION
We don't want to have this low timeout better to use the default for the client.

This put the k8s api server under a huge load a big clusters