### PR TITLE
logging: avoid `TryGetInterfaceName` logs

### DIFF
--- a/cmd/sriov-network-config-daemon/service.go
+++ b/cmd/sriov-network-config-daemon/service.go
@@ -368,6 +368,7 @@ func (s *ServiceConfig) waitForDevicesInitialization() {
 	for time.Now().Before(deadline) {
 		for pciAddr, name := range devicesToWait {
 			if s.hostHelper.TryGetInterfaceName(pciAddr) == name {
+				s.log.Info("Device ready", "pci", pciAddr, "name", name)
 				delete(devicesToWait, pciAddr)
 			}
 		}

--- a/pkg/host/internal/network/network.go
+++ b/pkg/host/internal/network/network.go
@@ -75,7 +75,6 @@ func (n *network) TryToGetVirtualInterfaceName(pciAddr string) string {
 func (n *network) TryGetInterfaceName(pciAddr string) string {
 	names, err := n.dputilsLib.GetNetNames(pciAddr)
 	if err != nil || len(names) < 1 {
-		log.Log.V(2).Info("TryGetInterfaceName(): failed to get interface name", "err", err, "pciAddress", pciAddr)
 		return ""
 	}
 	netDevName := names[0]
@@ -96,7 +95,6 @@ func (n *network) TryGetInterfaceName(pciAddr string) string {
 		return name
 	}
 
-	log.Log.V(2).Info("TryGetInterfaceName()", "name", netDevName)
 	return netDevName
 }
 

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -176,7 +176,7 @@ func (s *sriov) VFIsReady(pciAddr string) (netlink.Link, error) {
 	err = wait.PollImmediate(time.Second, 10*time.Second, func() (bool, error) {
 		vfIndex, err := s.networkHelper.GetInterfaceIndex(pciAddr)
 		if err != nil {
-			log.Log.Error(err, "VFIsReady(): invalid index number")
+			log.Log.Error(err, "VFIsReady(): invalid index number", "device", pciAddr)
 			return false, nil
 		}
 		vfLink, err = s.netlinkLib.LinkByIndex(vfIndex)


### PR DESCRIPTION
Function `TryGetInterfaceName` is called during the discovery routine, which runs every ~30s. It is called for each PFs and VFs, producing a large amount of log lines like:
```
2025-03-10T05:26:17.131237799Z	LEVEL(-2)	sriov/sriov.go:150	TryGetInterfaceName()	{"name": "eno12399v11"}
```
which usually don't help debugging operator's problems.

Also, when a netdevice VF is assigned to a pod, the function produce logs like:
```
2025-03-10T05:26:17.140153074Z	LEVEL(-2)	sriov/sriov.go:150	TryGetInterfaceName(): failed to get interface name	{"err": "GetNetName(): no net directory under pci device 0000:31:03.5: \"lstat /sys/bus/pci/devices/0000:31:03.5/net: no such file or directory\"", "pciAddress": "0000:31:03.5"}
```

Make `TryGetInterfaceName()` produce no logs.

Attached is an example of an operator's configuration with
1 Intel NIC configured with 32 VFs, mixed netdevice and vfio-pci. 8 pods running those VFs
1 Mellanopx NIC configured with 32 VFs, mixed netdevice and vfio-pci. 8 pods running those VFs
The configuration run for around 1h
[openshift-sriov-network-operator-pods_logs.log](https://github.com/user-attachments/files/19162300/openshift-sriov-network-operator-pods_logs.log)

```
$ grep "sriov/sriov.go:150     TryGetInterfaceName()" openshift-sriov-network-operator-pods_logs.log | wc -l
8000

$ wc -l openshift-sriov-network-operator-pods_logs.log
24783 openshift-sriov-network-operator-pods_logs.log
```
