### PR TITLE
Update github workflow to use newer images

### DIFF
--- a/.github/workflows/chart-push-release.yml
+++ b/.github/workflows/chart-push-release.yml
@@ -9,7 +9,7 @@ on:
       - v*
 jobs:
   package-and-push-helm-chart:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: install helm
         uses: azure/setup-helm@v4.2.0

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-and-push-image-operator:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
           file: ./Dockerfile
 
   build-and-push-image-config-daemon:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -89,7 +89,7 @@ jobs:
           file: ./Dockerfile.sriov-network-config-daemon
 
   build-and-push-image-webhook:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -10,7 +10,7 @@ on:
       - v*
 jobs:
   build-and-push-image-operator:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -50,7 +50,7 @@ jobs:
           file: ./Dockerfile
 
   build-and-push-image-config-daemon:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -90,7 +90,7 @@ jobs:
           file: ./Dockerfile.sriov-network-config-daemon
 
   build-and-push-image-webhook:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
ubuntu 20.04 image is deprecated and is scheduled to be retired on april 1st.

Let's switch to ubuntu-latest