### PR TITLE
Skip device plugin configuration for non existing nodes

### DIFF
--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -317,6 +317,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncAllSriovNetworkNodeStates(ctx con
 			return err
 		}
 	}
+
 	logger.V(1).Info("Remove SriovNetworkNodeState custom resource for unselected node")
 	nsList := &sriovnetworkv1.SriovNetworkNodeStateList{}
 	err := r.List(ctx, nsList, &client.ListOptions{})
@@ -335,10 +336,10 @@ func (r *SriovNetworkNodePolicyReconciler) syncAllSriovNetworkNodeStates(ctx con
 				}
 			}
 			if !found {
-				// remove device plugin labels
+				// remove device plugin labels if the node doesn't exist we continue to handle the stale nodeState
 				logger.Info("removing device plugin label from node as SriovNetworkNodeState doesn't exist", "nodeStateName", ns.Name)
 				err = utils.RemoveLabelFromNode(ctx, ns.Name, constants.SriovDevicePluginLabel, r.Client)
-				if err != nil {
+				if err != nil && !errors.IsNotFound(err) {
 					logger.Error(err, "Fail to remove device plugin label from node", "node", ns.Name)
 					return err
 				}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -46,6 +46,7 @@ import (
 
 	//+kubebuilder:scaffold:imports
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	snolog "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/log"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util"
 )
@@ -96,6 +97,7 @@ var _ = BeforeSuite(func() {
 		func(o *zap.Options) {
 			o.TimeEncoder = zapcore.RFC3339NanoTimeEncoder
 		}))
+	snolog.InitLog()
 
 	// Go to project root directory
 	err = os.Chdir("..")


### PR DESCRIPTION
In case where a node was removed but a nodeState still exist we return error instead of allowing the other nodes to be configured as expected

this commit fix this issue