### PR TITLE
improve draining log

### DIFF
--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -91,7 +91,9 @@ const (
 	SyncStatusInProgress = "InProgress"
 
 	DrainDeleted = "Deleted"
+	DrainDelete  = "delete"
 	DrainEvicted = "Evicted"
+	DrainEvict   = "evict"
 
 	MCPPauseAnnotationState = "sriovnetwork.openshift.io/state"
 	MCPPauseAnnotationTime  = "sriovnetwork.openshift.io/time"

--- a/pkg/drain/drainer_test.go
+++ b/pkg/drain/drainer_test.go
@@ -16,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
@@ -59,6 +60,8 @@ var _ = Describe("Drainer", Ordered, func() {
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
+		ctx = context.WithValue(ctx, "logger", log.FromContext(ctx))
+
 		t = GinkgoT()
 		mockCtrl = gomock.NewController(t)
 		platformHelper = mock_platforms.NewMockInterface(mockCtrl)

--- a/pkg/platforms/openshift/openshift_test.go
+++ b/pkg/platforms/openshift/openshift_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	constants "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
@@ -55,6 +56,7 @@ var _ = Describe("Openshift Package", Ordered, func() {
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
+		ctx = context.WithValue(ctx, "logger", log.FromContext(ctx))
 
 		op, err = openshift.New()
 		Expect(err).ToNot(HaveOccurred())
@@ -422,14 +424,14 @@ var _ = Describe("Openshift Package", Ordered, func() {
 
 				_, err = op.GetNodeMachinePoolName(ctx, n)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("failed to find the the desiredConfig Annotation"))
+				Expect(err.Error()).To(Equal("failed to find the the annotation [machineconfiguration.openshift.io/desiredConfig] on node [worker-0]"))
 			})
 
 			It("should return error if the name of the MC in the annotation doesn't exist", func() {
 				n := createNodeWithMCName("worker-0", "worker")
 				_, err = op.GetNodeMachinePoolName(ctx, n)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("failed to get the desired Machine Config: machineconfigs.machineconfiguration.openshift.io \"worker\" not found"))
+				Expect(err.Error()).To(Equal("failed to get the desired MachineConfig [worker] for node [worker-0]: machineconfigs.machineconfiguration.openshift.io \"worker\" not found"))
 			})
 
 			It("should return error if machine config pool doesn't exist in owner reference of machine config", func() {


### PR DESCRIPTION
with this commit we can now run something like

`kubectl -n sriov-network-oprator <config-daemon-pod> | grep '"Function": "Drain"' | grep '"name": "<node>"'`

this will give us the full flow a draining a specific node.

running `kubectl -n sriov-network-oprator <config-daemon-pod> | grep '"Function": "Drain"'` will give us the logs related to draining only from the operator.