### PR TITLE
fix: switch to semantic DeepEquals check from apimachinery

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"slices"
 	"sort"
@@ -15,6 +14,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	intstrutil "k8s.io/apimachinery/pkg/util/intstr"
@@ -952,7 +952,7 @@ func GenerateBridgeName(iface *InterfaceExt) string {
 
 // NeedToUpdateBridges returns true if bridge for the host requires update
 func NeedToUpdateBridges(bridgeSpec, bridgeStatus *Bridges) bool {
-	return !reflect.DeepEqual(bridgeSpec, bridgeStatus)
+	return !equality.Semantic.DeepEqual(bridgeSpec, bridgeStatus)
 }
 
 // SetKeepUntilTime sets an annotation to hold the "keep until time" for the node’s state.

--- a/controllers/generic_network_controller.go
+++ b/controllers/generic_network_controller.go
@@ -18,10 +18,10 @@ package controllers
 
 import (
 	"context"
-	"reflect"
 
 	netattdefv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	uns "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -180,7 +180,7 @@ func (r *genericNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		}
 	} else {
 		reqLogger.Info("NetworkAttachmentDefinition CR already exist")
-		if !reflect.DeepEqual(found.Spec, netAttDef.Spec) || !reflect.DeepEqual(found.GetAnnotations(), netAttDef.GetAnnotations()) {
+		if !equality.Semantic.DeepEqual(found.Spec, netAttDef.Spec) || !equality.Semantic.DeepEqual(found.GetAnnotations(), netAttDef.GetAnnotations()) {
 			reqLogger.Info("Update NetworkAttachmentDefinition CR", "Namespace", netAttDef.Namespace, "Name", netAttDef.Name)
 			netAttDef.SetResourceVersion(found.GetResourceVersion())
 			err = r.Update(ctx, netAttDef)

--- a/controllers/sriovnetworknodepolicy_controller.go
+++ b/controllers/sriovnetworknodepolicy_controller.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -182,7 +181,7 @@ func (r *SriovNetworkNodePolicyReconciler) SetupWithManager(mgr ctrl.Manager) er
 			qHandler(w)
 		},
 		UpdateFunc: func(c context.Context, e event.TypedUpdateEvent[client.Object], w workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-			if reflect.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
+			if equality.Semantic.DeepEqual(e.ObjectOld.GetLabels(), e.ObjectNew.GetLabels()) {
 				return
 			}
 			log.Log.WithName("SriovNetworkNodePolicy").
@@ -479,7 +478,7 @@ func (r *SriovNetworkNodePolicyReconciler) syncSriovNetworkNodeState(ctx context
 		// Note(adrianc): we check same ownerReferences since SriovNetworkNodeState
 		// was owned by a default SriovNetworkNodePolicy. if we encounter a descripancy
 		// we need to update.
-		if !keepUntilAnnotationUpdated && reflect.DeepEqual(newVersion.OwnerReferences, found.OwnerReferences) &&
+		if !keepUntilAnnotationUpdated && equality.Semantic.DeepEqual(newVersion.OwnerReferences, found.OwnerReferences) &&
 			equality.Semantic.DeepEqual(newVersion.Spec, found.Spec) {
 			logger.V(1).Info("SriovNetworkNodeState did not change, not updating")
 			return nil

--- a/controllers/sriovnetworkpoolconfig_controller.go
+++ b/controllers/sriovnetworkpoolconfig_controller.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	mcfgv1 "github.com/openshift/api/machineconfiguration/v1"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -196,7 +196,7 @@ func (r *SriovNetworkPoolConfigReconciler) syncOvsHardwareOffloadMachineConfigs(
 			// ignition and compare.
 			json.Unmarshal(foundMC.Spec.Config.Raw, &foundIgn)
 			json.Unmarshal(mc.Spec.Config.Raw, &renderedIgn)
-			if !reflect.DeepEqual(foundIgn, renderedIgn) {
+			if !equality.Semantic.DeepEqual(foundIgn, renderedIgn) {
 				logger.Info("MachineConfig already exists, updating")
 				mc.SetResourceVersion(foundMC.GetResourceVersion())
 				err = r.Update(ctx, mc)

--- a/pkg/daemon/config.go
+++ b/pkg/daemon/config.go
@@ -2,8 +2,8 @@ package daemon
 
 import (
 	"context"
-	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +48,7 @@ func (oc *OperatorConfigNodeReconcile) Reconcile(ctx context.Context, req ctrl.R
 		log.Log.Info("Set Disable Drain", "value", vars.DisableDrain)
 	}
 
-	if !reflect.DeepEqual(oc.latestFeatureGates, operatorConfig.Spec.FeatureGates) {
+	if !equality.Semantic.DeepEqual(oc.latestFeatureGates, operatorConfig.Spec.FeatureGates) {
 		vars.FeatureGate.Init(operatorConfig.Spec.FeatureGates)
 		oc.latestFeatureGates = operatorConfig.Spec.FeatureGates
 		log.Log.Info("Updated featureGates", "featureGates", vars.FeatureGate.String())

--- a/pkg/daemon/status.go
+++ b/pkg/daemon/status.go
@@ -3,8 +3,8 @@ package daemon
 import (
 	"context"
 	"fmt"
-	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,12 +66,12 @@ func (dn *NodeReconciler) shouldUpdateStatus(current, desiredNodeState *sriovnet
 	}
 
 	// check for bridges
-	if !reflect.DeepEqual(current.Status.Bridges, desiredNodeState.Status.Bridges) {
+	if !equality.Semantic.DeepEqual(current.Status.Bridges, desiredNodeState.Status.Bridges) {
 		return true
 	}
 
 	// check for system
-	if !reflect.DeepEqual(current.Status.System, desiredNodeState.Status.System) {
+	if !equality.Semantic.DeepEqual(current.Status.System, desiredNodeState.Status.System) {
 		return true
 	}
 
@@ -89,7 +89,7 @@ func (dn *NodeReconciler) shouldUpdateStatus(current, desiredNodeState *sriovnet
 		d[idx].VFs = nil
 		c[idx].VFs = nil
 
-		if !reflect.DeepEqual(d[idx], c[idx]) {
+		if !equality.Semantic.DeepEqual(d[idx], c[idx]) {
 			return true
 		}
 	}

--- a/pkg/host/internal/bridge/ovs/ovs_test.go
+++ b/pkg/host/internal/bridge/ovs/ovs_test.go
@@ -338,6 +338,19 @@ var _ = Describe("OVS", func() {
 				// dbContent should be exactly same
 				Expect(dbContent).To(Equal(initialDBContent))
 			})
+			It("Bridge already exists, provided config semantically the same", func() {
+				storedConf := getManagedBridges()["br-0000_d8_00.0"]
+				providedConf := storedConf.DeepCopy()
+				storedConf.Uplinks[0].Interface.ExternalIDs = nil
+				providedConf.Uplinks[0].Interface.ExternalIDs = map[string]string{}
+				store.EXPECT().GetManagedOVSBridge("br-0000_d8_00.0").Return(storedConf, nil)
+				initialDBContent := getDefaultInitialDBContent()
+				createInitialDBContent(ctx, ovsClient, initialDBContent)
+				Expect(ovs.CreateOVSBridge(ctx, providedConf)).NotTo(HaveOccurred())
+				dbContent := getDBContent(ctx, ovsClient)
+				// dbContent should be exactly the same
+				Expect(dbContent).To(Equal(initialDBContent))
+			})
 			It("No Bridge, create bridge", func() {
 				expectedConf := getManagedBridges()["br-0000_d8_00.0"]
 				store.EXPECT().GetManagedOVSBridge("br-0000_d8_00.0").Return(nil, nil)

--- a/pkg/host/store/store_test.go
+++ b/pkg/host/store/store_test.go
@@ -3,11 +3,10 @@ package store
 import (
 	"os"
 	"path"
-	"reflect"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
+	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
@@ -258,7 +257,7 @@ var _ = Describe("Store", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(ns).ToNot(BeNil())
 			Expect(sriovnetworkv1.InitialState.Name).To(Equal("worker-0"))
-			Expect(reflect.DeepEqual(*ns, sriovnetworkv1.InitialState)).To(BeTrue())
+			Expect(equality.Semantic.DeepEqual(*ns, sriovnetworkv1.InitialState)).To(BeTrue())
 		})
 	})
 

--- a/pkg/plugins/virtual/virtual_plugin.go
+++ b/pkg/plugins/virtual/virtual_plugin.go
@@ -1,8 +1,7 @@
 package virtual
 
 import (
-	"reflect"
-
+	"k8s.io/apimachinery/pkg/api/equality"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
@@ -90,7 +89,7 @@ func (p *VirtualPlugin) Apply() error {
 
 	if p.LastState != nil {
 		log.Log.Info("virtual plugin Apply()", "last-state", p.LastState.Spec)
-		if reflect.DeepEqual(p.LastState.Spec.Interfaces, p.DesireState.Spec.Interfaces) {
+		if equality.Semantic.DeepEqual(p.LastState.Spec.Interfaces, p.DesireState.Spec.Interfaces) {
 			log.Log.Info("virtual plugin Apply(): nothing to apply")
 			return nil
 		}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -4,10 +4,6 @@ import (
 	goctx "context"
 	"encoding/json"
 	"fmt"
-	"reflect"
-
-	// "strings"
-	// "testing"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,6 +12,7 @@ import (
 	// "github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	appsv1 "k8s.io/api/apps/v1"
 	// corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -229,7 +226,7 @@ func validateSelector(rc *dptypes.NetDeviceSelectors, ns *sriovnetworkv1.SriovNe
 		}
 	}
 	if len(ns.PfNames) > 0 {
-		if !reflect.DeepEqual(ns.PfNames, rc.PfNames) {
+		if !equality.Semantic.DeepEqual(ns.PfNames, rc.PfNames) {
 			return false
 		}
 	}


### PR DESCRIPTION
The switch to controller-runtime in thhe https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/788/commits/683101d9497db308d7840e2068f5731ed5952f0c commit introduced an interesting regression where there would be `{}` empty obj vs. `nil` obj discrepancies between semantically the same objects (e.g. OVS Bridged in spec and status). 
In the switchdev ovs use case it leads to SriovNetworkNodeState constantly shifting between the InProgress and Succeeded statuses and to sriov-network-device-plugin being recreated every few minutes.
Let's switch to using the `DeepEquals` function from k8s api-machinery, which treats empty and nil objects as equal.
I've changed all usages of `reflect.DeepEquals` to `equality.Semantic.DeepEquals`. Please, let me know if some of them should keep using the former one.