### PR TITLE
e2e: Improve `WaitForSRIOVStable()`

### DIFF
--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -32,6 +32,7 @@ import (
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/discovery"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/execute"
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/k8sreporter"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/namespaces"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/network"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/nodes"
@@ -2109,12 +2110,15 @@ func WaitForSRIOVStable() {
 	time.Sleep((10 + snoTimeoutMultiplier*20) * time.Second)
 
 	fmt.Println("Waiting for the sriov state to stable")
-	Eventually(func() bool {
-		// ignoring the error. This can eventually be executed against a single node cluster,
-		// and if a reconfiguration triggers a reboot then the api calls will return an error
-		res, _ := cluster.SriovStable(operatorNamespace, clients)
-		return res
-	}, waitingTime, 1*time.Second).Should(BeTrue())
+	Eventually(func(g Gomega) {
+		res, err := cluster.SriovStable(operatorNamespace, clients)
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(res).To(BeTrue())
+	}, waitingTime, 1*time.Second).Should(Succeed(), func() string {
+		return "SR-IOV Operator is not stable" +
+			k8sreporter.SriovNetworkNodeStatesSummary(clients, operatorNamespace) +
+			k8sreporter.Events(clients, operatorNamespace)
+	})
 	fmt.Println("Sriov state is stable")
 
 	Eventually(func() bool {

--- a/test/util/k8sreporter/descriptions.go
+++ b/test/util/k8sreporter/descriptions.go
@@ -1,0 +1,38 @@
+package k8sreporter
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	testclient "github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/client"
+)
+
+func SriovNetworkNodeStatesSummary(client *testclient.ClientSet, operatorNamespace string) string {
+	ret := "SriovNetworkNodeStates:\n"
+	nodeStates, err := client.SriovNetworkNodeStates(operatorNamespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return ret + "Summary error: " + err.Error()
+	}
+
+	for _, state := range nodeStates.Items {
+		ret += fmt.Sprintf("%s\t%s\t%+v\n", state.Name, state.Status.SyncStatus, state.Annotations)
+	}
+
+	return ret
+}
+
+func Events(client *testclient.ClientSet, namespace string) string {
+	ret := fmt.Sprintf("Events in [%s]:\n", namespace)
+	events, err := client.Events(namespace).List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		return ret + fmt.Sprintf("can't retrieve events for namespace %s: %s", namespace, err.Error())
+	}
+
+	for _, item := range events.Items {
+		ret += fmt.Sprintf("%s: %s\t%s\t%s\n", item.LastTimestamp, item.Reason, item.InvolvedObject.Name, item.Message)
+	}
+
+	return ret
+}


### PR DESCRIPTION
When the `WaitForSRIOVStable()` function fails, it outputs something like:
```
{Timed out after 1200.000s.
Expected
    <bool>: false
to be true failed [FAILED] Timed out after 1200.000s.
Expected
    <bool>: false
to be true
In [It] at: /tmp/cnf-gaH5c/cnf-features-deploy/cnf-tests/submodules/sriov-network-operator/test/conformance/tests/test_sriov_operator.go:2087 @ 04/04/25 23:07:39.673
}
```

Which is not helpful to understand the root cause.

Add information about the SriovNetworkNodeStates and the latest events in the operator's namespace