### PR TITLE
e2e: Fix RDMA test

### DIFF
--- a/test/conformance/tests/test_networkpool.go
+++ b/test/conformance/tests/test_networkpool.go
@@ -273,7 +273,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 			}, 1*time.Minute, 5*time.Second).Should(Equal(allocatable))
 
 			By("checking counters inside the pods")
-			strOut, _, err := pod.ExecCommand(clients, firstPod, "/bin/bash", "-c", "ip link show net1 | grep net1 | wc -l")
+			strOut, _, err := pod.ExecCommand(clients, firstPod, "/bin/bash", "-c", "ip link show net1")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strOut).To(ContainSubstring("net1"))
 			strOut, _, err = pod.ExecCommand(clients, firstPod, "/bin/bash", "-c", "ls /sys/bus/pci/devices/${PCIDEVICE_OPENSHIFT_IO_TESTRDMA}/infiniband/*/ports/*/hw_counters | wc -l")
@@ -357,9 +357,9 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			firstPod = waitForPodRunning(firstPod)
 
-			strOut, _, err := pod.ExecCommand(clients, firstPod, "/bin/bash", "-c", "ip link show net1 | grep net1 | wc -l")
+			strOut, _, err := pod.ExecCommand(clients, firstPod, "/bin/bash", "-c", "ip link show net1")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(strings.HasPrefix(strOut, "1")).To(BeTrue())
+			Expect(strOut).To(ContainSubstring("net1"))
 			strOut, _, err = pod.ExecCommand(clients, firstPod, "/bin/bash", "-c", "ls /sys/bus/pci/devices/${PCIDEVICE_OPENSHIFT_IO_TESTRDMA}/infiniband/*/ports/* | grep hw_counters | wc -l")
 			strOut = strings.TrimSpace(strOut)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
Fix test error:
```
> Enter [BeforeAll] Check rdma metrics inside a pod in exclusive mode - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:153 @ 04/11/25 08:53:14.39
STEP: Creating sriov network to use the rdma device - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:170 @ 04/11/25 08:53:16.609
STEP: waiting for operator to finish the configuration - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:209 @ 04/11/25 08:53:17.695
< Exit [BeforeAll] Check rdma metrics inside a pod in exclusive mode - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:153 @ 04/11/25 09:00:21.606 (7m7.216s)
> Enter [It] should run pod with RDMA cni and expose nic metrics and another one without rdma info - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:220 @ 04/11/25 09:00:21.606
STEP: creating a policy - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:221 @ 04/11/25 09:00:21.606
STEP: waiting for operator to finish the configuration - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:226 @ 04/11/25 09:00:21.666
STEP: restart device plugin - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:246 @ 04/11/25 09:08:22.401
STEP: checking the amount of allocatable devices remains after device plugin reset - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:266 @ 04/11/25 09:08:24.47
STEP: checking counters inside the pods - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:275 @ 04/11/25 09:09:24.475
[FAILED] Expected
    <string>: 1

to contain substring
    <string>: net1
In [It] at: /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:278 @ 04/11/25 09:10:00.395
< Exit [It] should run pod with RDMA cni and expose nic metrics and another one without rdma info - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:220 @ 04/11/25 09:10:00.395 (9m38.789s)
> Enter [AfterEach] [sriov] NetworkPool - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:51 @ 04/11/25 09:10:00.395
< Exit [AfterEach] [sriov] NetworkPool - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_networkpool.go:51 @ 04/11/25 09:17:53.9 (7m53.504s)
```

Openshift job example

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_sriov-network-operator/1078/pull-ci-openshift-sriov-network-operator-main-e2e-telco5g-sriov/1910584283160907776

This is a leftover of:
- https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/876