### PR TITLE
e2e: enable `resourceInjectorMatchCondition` featureGate

### DIFF
--- a/test/conformance/tests/fixtures.go
+++ b/test/conformance/tests/fixtures.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/clean"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/cluster"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/discovery"
@@ -32,6 +33,10 @@ var _ = BeforeSuite(func() {
 			Expect(err).ToNot(HaveOccurred())
 			clean.RestoreNodeDrainState = true
 		}
+	}
+
+	if !isFeatureFlagEnabled(consts.ResourceInjectorMatchConditionFeatureGate) {
+		setFeatureFlag(consts.ResourceInjectorMatchConditionFeatureGate, true)
 	}
 
 	err = namespaces.Create(namespaces.Test, clients)


### PR DESCRIPTION
Enable the featureGate `resourceInjectorMatchCondition` at the beginning of the test suite to pursue the following goals:
a. Solve some flakes in the test suite [1], as sometimes a pod is scheduled while the resource injector is restarting b. Better validate the reliability of the feature, to see if it can be the default behavior

[1] https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-openshift-release-master-nightly-4.17-e2e-telco5g-hcp-cnftests/1912597246457679872