### PR TITLE
add re-queue when we wait for drain to complete

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -260,9 +260,11 @@ func (dn *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 			reqLogger.Error(err, "failed to handle drain")
 			return ctrl.Result{}, err
 		}
-		// drain is still in progress we don't need to re-queue the request as the operator will update the annotation
+		// drain is still in progress we will still requeue the request in case there is an un-expect state in the draining
+		// this will allow the daemon to try again.
 		if drainInProcess {
-			return ctrl.Result{}, nil
+			reqLogger.Info("node drain still in process")
+			return ctrl.Result{RequeueAfter: consts.DaemonRequeueTime}, nil
 		}
 	}
 


### PR DESCRIPTION
in case we have waiting for a drain and the user change the label in the node annotation manually it can make the configuration stuck as the daemon will not re-apply the right label to correct the user changes.

This will also help cover issue if exist in the draining logic in a way that the daemon will be able to retry again and not stuck waiting for a reconcile