### PR TITLE
bug(daemon): Reset the configuration when `disableDrain: true`

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -644,6 +644,10 @@ func (dn *NodeReconciler) prepareNMUdevRule() error {
 
 // isDrainCompleted returns true if the current-state annotation is drain completed
 func (dn *NodeReconciler) isDrainCompleted(reqDrain bool, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState) bool {
+	if vars.DisableDrain {
+		return true
+	}
+
 	// if we need to drain check the drain status
 	if reqDrain {
 		return utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotationCurrent, consts.DrainComplete)


### PR DESCRIPTION
After commit [1], when the config-daemon is asked to drain and `SriovOperatorConfig.Spec.DisableDrain: true`, the configuration is not applied and the SriovNetworkNodeState SyncStatus field gets stuck in `InProgress`.

Handle the DisableDrain properly.

[1] https://github.com/openshift/sriov-network-operator/commit/683101d9497db308d7840e2068f5731ed5952f0c#diff-a53b7b593d3d778e62eaeeafa40088656f9212bfa2c2b7991df15fa78e60b0f0R271