### PR TITLE
security: Add `NetworkPolicies` to operands

### DIFF
--- a/bindata/manifests/operator-webhook/004-networkpolicy.yaml
+++ b/bindata/manifests/operator-webhook/004-networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: operator-webhook-allow-traffic-api-server
+  namespace: {{.Namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      app: operator-webhook
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 6443
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443
+  policyTypes:
+  - Ingress
+  - Egress

--- a/bindata/manifests/webhook/005-networkpolicy.yaml
+++ b/bindata/manifests/webhook/005-networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: network-resources-injector-allow-traffic-api-server
+  namespace: {{.Namespace}}
+spec:
+  podSelector:
+    matchLabels:
+      app: network-resources-injector
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 6443
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 6443
+  policyTypes:
+  - Ingress
+  - Egress

--- a/controllers/sriovoperatorconfig_controller_test.go
+++ b/controllers/sriovoperatorconfig_controller_test.go
@@ -10,6 +10,7 @@ import (
 	admv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -177,6 +178,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 			err = util.WaitForNamespacedObjectDeleted(daemonSet, k8sClient, testNamespace, "network-resources-injector", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
 
+			networkPolicy := &networkv1.NetworkPolicy{}
+			err = util.WaitForNamespacedObjectDeleted(networkPolicy, k8sClient, testNamespace, "network-resources-injector-allow-traffic-api-server", util.RetryInterval, util.APITimeout)
+			Expect(err).NotTo(HaveOccurred())
+
 			mutateCfg := &admv1.MutatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObjectDeleted(mutateCfg, k8sClient, testNamespace, "network-resources-injector-config", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
@@ -191,6 +196,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 
 			daemonSet = &appsv1.DaemonSet{}
 			err = util.WaitForNamespacedObject(daemonSet, k8sClient, testNamespace, "network-resources-injector", util.RetryInterval, util.APITimeout)
+			Expect(err).NotTo(HaveOccurred())
+
+			networkPolicy = &networkv1.NetworkPolicy{}
+			err = util.WaitForNamespacedObject(networkPolicy, k8sClient, testNamespace, "network-resources-injector-allow-traffic-api-server", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			mutateCfg = &admv1.MutatingWebhookConfiguration{}
@@ -212,6 +221,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 			err = util.WaitForNamespacedObjectDeleted(daemonSet, k8sClient, testNamespace, "operator-webhook", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
 
+			networkPolicy := &networkv1.NetworkPolicy{}
+			err = util.WaitForNamespacedObjectDeleted(networkPolicy, k8sClient, testNamespace, "operator-webhook-allow-traffic-api-server", util.RetryInterval, util.APITimeout)
+			Expect(err).NotTo(HaveOccurred())
+
 			mutateCfg := &admv1.MutatingWebhookConfiguration{}
 			err = util.WaitForNamespacedObjectDeleted(mutateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
@@ -220,7 +233,7 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 			err = util.WaitForNamespacedObjectDeleted(validateCfg, k8sClient, testNamespace, "sriov-operator-webhook-config", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("set disable to enableOperatorWebhook")
+			By("set enable to enableOperatorWebhook")
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: "default"}, config)).NotTo(HaveOccurred())
 
 			config.Spec.EnableOperatorWebhook = true
@@ -229,6 +242,10 @@ var _ = Describe("SriovOperatorConfig controller", Ordered, func() {
 
 			daemonSet = &appsv1.DaemonSet{}
 			err = util.WaitForNamespacedObject(daemonSet, k8sClient, testNamespace, "operator-webhook", util.RetryInterval, util.APITimeout)
+			Expect(err).NotTo(HaveOccurred())
+
+			networkPolicy = &networkv1.NetworkPolicy{}
+			err = util.WaitForNamespacedObject(networkPolicy, k8sClient, testNamespace, "operator-webhook-allow-traffic-api-server", util.RetryInterval, util.APITimeout)
 			Expect(err).NotTo(HaveOccurred())
 
 			mutateCfg = &admv1.MutatingWebhookConfiguration{}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -35,6 +35,15 @@ rules:
   - update
   - delete
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - networkpolicies
+  verbs:
+  - get
+  - create
+  - update
+  - delete
+- apiGroups:
   - apps
   resourceNames:
   - sriov-network-operator

--- a/deployment/sriov-network-operator-chart/templates/role.yaml
+++ b/deployment/sriov-network-operator-chart/templates/role.yaml
@@ -29,6 +29,15 @@ rules:
     verbs:
       - '*'
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - create
+      - update
+      - delete
+  - apiGroups:
       - monitoring.coreos.com
     resources:
       - servicemonitors

--- a/test/conformance/tests/test_sriov_operator.go
+++ b/test/conformance/tests/test_sriov_operator.go
@@ -17,6 +17,7 @@ import (
 	admission "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1169,6 +1170,7 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 				assertObjectIsNotFound("network-resources-injector-role-binding", &rbacv1.ClusterRoleBinding{})
 				assertObjectIsNotFound("network-resources-injector-config", &admission.MutatingWebhookConfiguration{})
 				assertObjectIsNotFound("nri-control-switches", &corev1.ConfigMap{})
+				assertObjectIsNotFound("network-resources-injector-allow-traffic-api-server", &networkv1.NetworkPolicy{})
 			})
 
 			It("SR-IOV Operator Config, disable Operator Webhook", func() {
@@ -1189,6 +1191,7 @@ var _ = Describe("[sriov] operator", Ordered, func() {
 				assertObjectIsNotFound("operator-webhook", &rbacv1.ClusterRole{})
 				assertObjectIsNotFound("operator-webhook-role-binding", &rbacv1.ClusterRoleBinding{})
 				assertObjectIsNotFound("sriov-operator-webhook-config", &admission.MutatingWebhookConfiguration{})
+				assertObjectIsNotFound("operator-webhook-allow-traffic-api-server", &networkv1.NetworkPolicy{})
 			})
 
 			It("SR-IOV Operator Config, disable Resource Injector and Operator Webhook", func() {


### PR DESCRIPTION
`NetworkPolicy.networking.k8s.io` objects [1] allow defining which network traffic can reach a pod or can go leave a pod, in a kubernated cluster.

In order to reduce the surface attack all the operands that are not hostNetworked, should be covered by NetworkPolicies, explicitly setting the connections they require to work.

[1] https://kubernetes.io/docs/concepts/services-networking/network-policies/