### PR TITLE
fix: set SR-IOV NUM_VFS to 0 for mellanox NICs before fw reset

### DIFF
--- a/pkg/helper/host.go
+++ b/pkg/helper/host.go
@@ -26,12 +26,12 @@ type hostHelpers struct {
 
 func NewDefaultHostHelpers() (HostHelpersInterface, error) {
 	utilsHelper := utils.New()
-	mlxHelper := mlx.New(utilsHelper)
 	hostManager, err := host.NewHostManager(utilsHelper)
 	if err != nil {
 		log.Log.Error(err, "failed to create host manager")
 		return nil, err
 	}
+	mlxHelper := mlx.New(utilsHelper, hostManager)
 	storeManager, err := store.NewManager()
 	if err != nil {
 		log.Log.Error(err, "failed to create store manager")

--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -816,17 +816,17 @@ func (mr *MockHostHelpersInterfaceMockRecorder) MlxConfigFW(attributesToChange a
 }
 
 // MlxResetFW mocks base method.
-func (m *MockHostHelpersInterface) MlxResetFW(pciAddresses []string) error {
+func (m *MockHostHelpersInterface) MlxResetFW(pciAddresses []string, mellanoxNicsStatus map[string]map[string]v1.InterfaceExt) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MlxResetFW", pciAddresses)
+	ret := m.ctrl.Call(m, "MlxResetFW", pciAddresses, mellanoxNicsStatus)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MlxResetFW indicates an expected call of MlxResetFW.
-func (mr *MockHostHelpersInterfaceMockRecorder) MlxResetFW(pciAddresses any) *gomock.Call {
+func (mr *MockHostHelpersInterfaceMockRecorder) MlxResetFW(pciAddresses, mellanoxNicsStatus any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxResetFW", reflect.TypeOf((*MockHostHelpersInterface)(nil).MlxResetFW), pciAddresses)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxResetFW", reflect.TypeOf((*MockHostHelpersInterface)(nil).MlxResetFW), pciAddresses, mellanoxNicsStatus)
 }
 
 // MstConfigReadData mocks base method.

--- a/pkg/host/internal/network/network_test.go
+++ b/pkg/host/internal/network/network_test.go
@@ -12,11 +12,11 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/consts"
-	hostMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/helper/mock"
 	dputilsMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/lib/dputils/mock"
 	ethtoolMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/lib/ethtool/mock"
 	netlinkMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/internal/lib/netlink/mock"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/host/types"
+	utilsMockPkg "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/utils/mock"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/fakefilesystem"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/test/util/helpers"
 )
@@ -36,7 +36,7 @@ var _ = Describe("Network", func() {
 		netlinkLibMock *netlinkMockPkg.MockNetlinkLib
 		ethtoolLibMock *ethtoolMockPkg.MockEthtoolLib
 		dputilsLibMock *dputilsMockPkg.MockDPUtilsLib
-		hostMock       *hostMockPkg.MockHostHelpersInterface
+		utilsMock      *utilsMockPkg.MockCmdInterface
 
 		testCtrl *gomock.Controller
 		testErr  = fmt.Errorf("test")
@@ -46,9 +46,9 @@ var _ = Describe("Network", func() {
 		netlinkLibMock = netlinkMockPkg.NewMockNetlinkLib(testCtrl)
 		ethtoolLibMock = ethtoolMockPkg.NewMockEthtoolLib(testCtrl)
 		dputilsLibMock = dputilsMockPkg.NewMockDPUtilsLib(testCtrl)
-		hostMock = hostMockPkg.NewMockHostHelpersInterface(testCtrl)
+		utilsMock = utilsMockPkg.NewMockCmdInterface(testCtrl)
 
-		n = New(hostMock, dputilsLibMock, netlinkLibMock, ethtoolLibMock)
+		n = New(utilsMock, dputilsLibMock, netlinkLibMock, ethtoolLibMock)
 	})
 
 	AfterEach(func() {

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -206,7 +206,7 @@ func (p *MellanoxPlugin) Apply() error {
 		return err
 	}
 	if vars.FeatureGate.IsEnabled(consts.MellanoxFirmwareResetFeatureGate) {
-		return p.helpers.MlxResetFW(pciAddressesToReset)
+		return p.helpers.MlxResetFW(pciAddressesToReset, mellanoxNicsStatus)
 	}
 	return nil
 }

--- a/pkg/vendors/mellanox/mock/mock_mellanox.go
+++ b/pkg/vendors/mellanox/mock/mock_mellanox.go
@@ -12,6 +12,7 @@ package mock_mlxutils
 import (
 	reflect "reflect"
 
+	v1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	mlxutils "github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vendors/mellanox"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -86,17 +87,17 @@ func (mr *MockMellanoxInterfaceMockRecorder) MlxConfigFW(attributesToChange any)
 }
 
 // MlxResetFW mocks base method.
-func (m *MockMellanoxInterface) MlxResetFW(pciAddresses []string) error {
+func (m *MockMellanoxInterface) MlxResetFW(pciAddresses []string, mellanoxNicsStatus map[string]map[string]v1.InterfaceExt) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "MlxResetFW", pciAddresses)
+	ret := m.ctrl.Call(m, "MlxResetFW", pciAddresses, mellanoxNicsStatus)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // MlxResetFW indicates an expected call of MlxResetFW.
-func (mr *MockMellanoxInterfaceMockRecorder) MlxResetFW(pciAddresses any) *gomock.Call {
+func (mr *MockMellanoxInterfaceMockRecorder) MlxResetFW(pciAddresses, mellanoxNicsStatus any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxResetFW", reflect.TypeOf((*MockMellanoxInterface)(nil).MlxResetFW), pciAddresses)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MlxResetFW", reflect.TypeOf((*MockMellanoxInterface)(nil).MlxResetFW), pciAddresses, mellanoxNicsStatus)
 }
 
 // MstConfigReadData mocks base method.


### PR DESCRIPTION
we are using --skip-driver option with mlxfwreset to speed up the process. However, if there are still VFs created for the PF, the command will fail. Let's reset the VFs to mitigate the error.