### PR TITLE
Add Intel E830 Network Adapters

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -24,6 +24,8 @@ data:
   Intel_ice_Columbiapark_E825C_BACKPLANE: "8086 579c 1889"
   Intel_ice_Columbiapark_E825C_QSFP: "8086 579d 1889"
   Intel_ice_Columbiapark_E825C_SFP: "8086 579e 1889"
+  Intel_ice_Connorsville_E830_QSFP: "8086 12d2 1889"
+  Intel_ice_Connorsville_E830_SFP: "8086 12d3 1889"
   Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
   Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
   Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"

--- a/deployment/sriov-network-operator-chart/templates/configmap.yaml
+++ b/deployment/sriov-network-operator-chart/templates/configmap.yaml
@@ -24,6 +24,8 @@ data:
   Intel_ice_Columbiapark_E825C_BACKPLANE: "8086 579c 1889"
   Intel_ice_Columbiapark_E825C_QSFP: "8086 579d 1889"
   Intel_ice_Columbiapark_E825C_SFP: "8086 579e 1889"
+  Intel_ice_Connorsville_E830_QSFP: "8086 12d2 1889"
+  Intel_ice_Connorsville_E830_SFP: "8086 12d3 1889"
   Nvidia_mlx5_ConnectX-4: "15b3 1013 1014"
   Nvidia_mlx5_ConnectX-4LX: "15b3 1015 1016"
   Nvidia_mlx5_ConnectX-5: "15b3 1017 1018"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -69,6 +69,8 @@ The following table depicts the supported SR-IOV hardware features of each suppo
 | Intel E825-C Backplane | V | V | X |
 | Intel E825-C QSFP Family | V | V | X |
 | Intel E825-C SFP Family | V | V | X |
+| Intel E830-CC QSFP Family | V | V | X |
+| Intel E830-CC SFP Family | V | V | X |
 | Mellanox MT27700 Family [ConnectX-4] | V | V | V |
 | Mellanox MT27710 Family [ConnectX-4 Lx] | V | V | V |
 | Mellanox MT27800 Family [ConnectX-5] | V | V | V |

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -20,6 +20,8 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Intel E825-C Backplane Family | 8086 | 579c |
 | Intel E825-C QSFP Family | 8086 | 579d |
 | Intel E825-C SFP Family | 8086 | 579e |
+| Intel E830-CC QSFP Family | 8086 | 12d2 |
+| Intel E830-CC SFP Family | 8086 | 12d3 |
 | Mellanox MT27700 Family [ConnectX-4] | 15b3 | 1013 |
 | Mellanox MT27710 Family [ConnectX-4 Lx] | 15b3 | 1015 |
 | Mellanox MT27800 Family [ConnectX-5] | 15b3 | 1017 |


### PR DESCRIPTION
This PR:

1. Adds support for Intel's E830 Controller.

Fixes https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/907