### PR TITLE
Add readOnlyRootFilesystem=true to containers missing it

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -142,6 +142,7 @@ spec:
           - sriov-network-config-daemon
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         args:
           - "start"
         {{- if .UsedSystemdMode}}

--- a/bindata/manifests/metrics-exporter/metrics-daemonset.yaml
+++ b/bindata/manifests/metrics-exporter/metrics-daemonset.yaml
@@ -78,6 +78,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.hostIP
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
         resources:
           requests:
             cpu: 10m

--- a/bindata/manifests/plugins/sriov-device-plugin.yaml
+++ b/bindata/manifests/plugins/sriov-device-plugin.yaml
@@ -56,6 +56,7 @@ spec:
               fieldPath: spec.nodeName
         securityContext:
           privileged: true
+          readOnlyRootFilesystem: true
         resources:
           requests:
             cpu: 10m

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -49,6 +49,9 @@ spec:
           image: $SRIOV_NETWORK_OPERATOR_IMAGE
           command:
           - sriov-network-operator
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           resources:
             requests:
               cpu: 100m

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -43,6 +43,9 @@ spec:
           image: {{ .Values.images.operator }}
           command:
             - sriov-network-operator
+          securityContext:
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
`readOnlyRootFilesystem=true` prevents containers from writing to the root filesystem, reducing attack surface and improving security posture by limiting potential malicious file modifications and ensuring immutable container runtime.

`allowPrivilegeEscalation=false` prevents containers from gaining additional privileges beyond those initially granted, further hardening the security posture by blocking privilege escalation attacks.