### PR TITLE
Enable s390x architecture in GitHub Actions image builds.

### DIFF
--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -2,7 +2,7 @@ name: "Push images on merge to master"
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
-  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 on:
   push:

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -2,7 +2,7 @@ name: "Push images on release"
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}
-  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le
+  BUILD_PLATFORMS: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
 
 on:
   push:


### PR DESCRIPTION
This allows building and publishing SR-IOV Network Operator images for s390x (IBM Z / LinuxONE) architecture.

Fixes: https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/956