### PR TITLE
Remove obsolete glog/klog flags from webhook manifests

### DIFF
--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -71,8 +71,7 @@ spec:
         - "--port=6443"
         - "--tls-private-key-file=/etc/tls/tls.key"
         - "--tls-cert-file=/etc/tls/tls.crt"
-        - "--alsologtostderr=true"
-        - "--v=3"
+        - "--zap-log-level=3"
         env:
         - name: NAMESPACE
           valueFrom:


### PR DESCRIPTION
The webhook code was migrated from glog/klog to Zap logging (via controller-runtime), but the deployment manifests were not updated to reflect this change.

This was causing the webhook to fail with "unknown flag: --alsologtostderr" error when the container started, as these flags are no longer supported by the Zap-based logging implementation.

Changes:
- Removed --alsologtostderr and --v=3 flags from operator-webhook/server.yaml
- Removed --logtostderr and --alsologtostderr flags from webhook/server.yaml
- Added --zap-log-level=3 to operator-webhook for equivalent verbosity

The network-resources-injector webhook (webhook/server.yaml) now uses default Zap logging settings which are appropriate for production use.