### PR TITLE
Fix CPU vendor detection on s390x to prevent fallback to Intel.

### DIFF
--- a/pkg/host/internal/cpu/cpu.go
+++ b/pkg/host/internal/cpu/cpu.go
@@ -34,6 +34,8 @@ func (c *cpuInfoProvider) GetCPUVendor() (types.CPUVendor, error) {
 		return types.CPUVendorAMD, nil
 	case "ARM":
 		return types.CPUVendorARM, nil
+	case "IBM/S390":
+		return types.CPUVendorS390X, nil
 	}
 
 	return -1, fmt.Errorf("unknown CPU vendor: %s", cpuInfo.Processors[0].Vendor)

--- a/pkg/host/types/interfaces.go
+++ b/pkg/host/types/interfaces.go
@@ -201,6 +201,7 @@ const (
 	CPUVendorIntel CPUVendor = iota
 	CPUVendorAMD
 	CPUVendorARM
+	CPUVendorS390X
 )
 
 type CPUInfoProviderInterface interface {


### PR DESCRIPTION
The operator was failing to detect the CPU vendor on IBM Z (s390x) systems, causing GHW to return an empty CPU topology. This resulted in the generic plugin falling back to Intel and incorrectly enabling Intel-specific kernel parameters intel_iommu=on,iommu=pt. With this change, the operator no longer falls back to Intel on s390x and avoids injecting unwanted x86 IOMMU kernel args.

This changes fixes below error seen on s390x architecture.
```
2025-11-19T04:14:37.650633527Z	ERROR	generic/generic_plugin.go:471	can't get CPU vendor, falling back to Intel	{"error": "wrong CPU information retrieved: cpu (0 physical packages, 0 cores, 0 hardware threads)"}
2025-11-19T04:14:37.650642749Z	INFO	generic/generic_plugin.go:427	generic plugin enableDesiredKernelArgs(): enable kernel arg	{"karg": "intel_iommu=on"}
2025-11-19T04:14:37.65065033Z	INFO	generic/generic_plugin.go:428	generic plugin enableDesiredKernelArgs(): enable kernel arg	{"karg": "iommu=pt"}
```