### PR TITLE
fix reboot loops when applying or removing rdmaMode.

### DIFF
--- a/pkg/plugins/generic/generic_plugin.go
+++ b/pkg/plugins/generic/generic_plugin.go
@@ -447,6 +447,14 @@ func (p *GenericPlugin) addVfioDesiredKernelArg(state *sriovnetworkv1.SriovNetwo
 }
 
 func (p *GenericPlugin) configRdmaKernelArg(state *sriovnetworkv1.SriovNetworkNodeState) error {
+	current := state.Status.System.RdmaMode
+	desired := state.Spec.System.RdmaMode
+
+	// RDMA mode already matches desired state, skipping kernel arg changes
+	if desired == current {
+		return p.helpers.SetRDMASubsystem(desired)
+	}
+
 	if state.Spec.System.RdmaMode == "" {
 		p.disableDesiredKernelArgs(consts.KernelArgRdmaExclusive)
 		p.disableDesiredKernelArgs(consts.KernelArgRdmaShared)


### PR DESCRIPTION
The generic plugin was unconditionally modifying ib_core.netns_mode kernel arguments whenever spec.system.rdmaMode was present or removed, even when the current status already reflected the desired mode.

This change makes RDMA mode handling fully idempotent by:
- Comparing spec.system.rdmaMode against status.system.rdmaMode
- Skipping kernel argument changes when no actual change is needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized RDMA configuration logic to eliminate redundant operations when desired settings match current state, improving system configuration efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->