### PR TITLE
feat: add extra env variables support for operator pod to helm chart

### DIFF
--- a/deployment/sriov-network-operator-chart/README.md
+++ b/deployment/sriov-network-operator-chart/README.md
@@ -77,7 +77,8 @@ We have introduced the following Chart parameters.
 | Name | Type | Default | description |
 | ---- | ---- | ------- | ----------- |
 | `operator.tolerations` | list | `[{"key":"node-role.kubernetes.io/master","operator":"Exists","effect":"NoSchedule"},{"key":"node-role.kubernetes.io/control-plane","operator":"Exists","effect":"NoSchedule"}]` | Operator's tolerations |
-| `operator.nodeSelector` | object | {} | Operator's node selector |
+| `operator.nodeSelector` | object | `{}` | Operator's node selector |
+| `operator.extraEnv` | map[string]string | `{}` | Custom extra environment variables for the operator container |
 | `operator.affinity` | object | `{"nodeAffinity":{"preferredDuringSchedulingIgnoredDuringExecution":[{"weight":1,"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/master","operator":"In","values":[""]}]}},{"weight":1,"preference":{"matchExpressions":[{"key":"node-role.kubernetes.io/control-plane","operator":"In","values":[""]}]}}]}}` | Operator's afffinity configuration |
 | `operator.nameOverride` | string | `` | Operator's resource name override |
 | `operator.fullnameOverride` | string | `` | Operator's resource full name override |

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -115,6 +115,10 @@ spec:
               value: {{ .Values.operator.clusterType }}
             - name: STALE_NODE_STATE_CLEANUP_DELAY_MINUTES
               value: "{{ .Values.operator.staleNodeStateCleanupDelayMinutes }}"
+            {{- range $k, $v := .Values.operator.extraEnv }}
+            - name: {{ $k }}
+              value: {{ $v | toString | quote }}
+            {{- end }}
         {{- if .Values.operator.admissionControllers.enabled }}
             - name: OPERATOR_WEBHOOK_NETWORK_POLICY_PORT
               value: "{{ .Values.operator.admissionControllers.networkPolicy.operator.port }}"

--- a/deployment/sriov-network-operator-chart/values.yaml
+++ b/deployment/sriov-network-operator-chart/values.yaml
@@ -7,6 +7,8 @@ operator:
       operator: "Exists"
       effect: "NoSchedule"
   nodeSelector: {}
+  # custom extra environment variables for the operator container
+  extraEnv: {}
   affinity:
     nodeAffinity:
       preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Add operator.extraEnv helm value to allow injecting custom environment variables into the operator controller container.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the ability to configure custom environment variables for the operator container. Users can now specify additional environment variables through Helm chart parameters to customize operator behavior according to their specific deployment requirements.

* **Documentation**
  * Updated chart documentation with parameter details for the new custom environment variables configuration option.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->