### PR TITLE
fix conditional mstflint install on s390x

### DIFF
--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -7,7 +7,7 @@ FROM quay.io/centos/centos:stream9
 ARG MSTFLINT=mstflint
 # We have to ensure that pciutils is installed. This package is needed for mstfwreset to succeed.
 # xref pkg/vendors/mellanox/mellanox.go#L150
-RUN ARCH_DEP_PKGS=$(if [ "$(uname -m)" != "s390x" ]; then printf "%s" "${MSTFLINT}" ; fi) && yum -y install hwdata pciutils "${ARCH_DEP_PKGS}" && yum clean all
+RUN if [ "$(uname -m)" = "s390x" ]; then yum -y install hwdata pciutils; else yum -y install hwdata pciutils "${MSTFLINT}"; fi && yum clean all
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/


### PR DESCRIPTION
Avoid passing empty arguments to yum when building on s390x. This fixes build failures and satisfies hadolint rules while preserving behavior on non-s390x architectures.

### Why this PR needed
image build fails on s390x due to changes done in pr: https://github.com/k8snetworkplumbingwg/sriov-network-operator/pull/974
on s390x
yum -y install hwdata pciutils "${ARCH_DEP_PKGS}"
 
translate to yum -y install hwdata pciutils "" 

which fails on s390x.
This fix avoids empty arguments and satisfies hadolint-action@v3.3.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dockerfile for sriov-network-config-daemon with improved architecture-specific package dependency handling, ensuring proper installation across different processor architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->