### PR TITLE
fix: exit with non-zero code on error in config daemon

### DIFF
--- a/cmd/sriov-network-config-daemon/main.go
+++ b/cmd/sriov-network-config-daemon/main.go
@@ -17,6 +17,7 @@ package main
 
 import (
 	"flag"
+	"os"
 
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -44,5 +45,6 @@ func init() {
 func main() {
 	if err := rootCmd.Execute(); err != nil {
 		log.Log.Error(err, "error executing sriov-network-config-daemon")
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Currently, if rootCmd.Execute() returns an error, the daemon logs the error but exits with code 0, incorrectly indicating success.

This fix adds os.Exit(1) to ensure the process exits with a non-zero exit code when an error occurs, allowing proper error detection by the calling process or container runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed error handling to ensure the program exits with a non-zero exit code when encountering errors, improving integration with automated systems and scripts that depend on proper exit codes for error detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->