### PR TITLE
add support for NVIDIA ConnectX-9 NICs

### DIFF
--- a/deploy/configmap.yaml
+++ b/deploy/configmap.yaml
@@ -37,6 +37,7 @@ data:
   Nvidia_mlx5_ConnectX-6_Lx: "15b3 101f 101e"
   Nvidia_mlx5_ConnectX-7: "15b3 1021 101e"
   Nvidia_mlx5_ConnectX-8: "15b3 1023 101e"
+  Nvidia_mlx5_ConnectX-9: "15b3 1025 101e"
   Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
   Nvidia_mlx5_MT43244_BlueField-3_integrated_ConnectX-7_Dx: "15b3 a2dc 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"

--- a/deployment/sriov-network-operator-chart/templates/configmap.yaml
+++ b/deployment/sriov-network-operator-chart/templates/configmap.yaml
@@ -37,6 +37,7 @@ data:
   Nvidia_mlx5_ConnectX-6_Lx: "15b3 101f 101e"
   Nvidia_mlx5_ConnectX-7: "15b3 1021 101e"
   Nvidia_mlx5_ConnectX-8: "15b3 1023 101e"
+  Nvidia_mlx5_ConnectX-9: "15b3 1025 101e"
   Nvidia_mlx5_MT42822_BlueField-2_integrated_ConnectX-6_Dx: "15b3 a2d6 101e"
   Nvidia_mlx5_MT43244_BlueField-3_integrated_ConnectX-7_Dx: "15b3 a2dc 101e"
   Broadcom_bnxt_BCM57414_2x25G: "14e4 16d7 16dc"

--- a/doc/supported-hardware.md
+++ b/doc/supported-hardware.md
@@ -33,6 +33,7 @@ The following SR-IOV capable hardware is supported with sriov-network-operator:
 | Mellanox MT28908 Family [ConnectX-6 Lx] | 15b3 | 101f |
 | Mellanox MT2910 Family [ConnectX-7] | 15b3 | 1021 |
 | Mellanox CX8 Family [ConnectX-8] | 15b3 | 1023 |
+| Mellanox CX9 Family [ConnectX-9] | 15b3 | 1025 |
 | Mellanox MT42822 BlueField-2 integrated ConnectX-6 Dx | 15b3 | a2d6 |
 | Mellanox MT43244 BlueField-3 integrated ConnectX-7 Dx | 15b3 | a2dc |
 | Qlogic QL45000 Series 50GbE Controller | 1077 | 1654 |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Nvidia Mellanox ConnectX-9 network adapter.

* **Documentation**
  * Updated supported hardware list to include Mellanox CX8 Family [ConnectX-9].

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->