### PR TITLE
chore: update Go version to 1.24.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/k8snetworkplumbingwg/sriov-network-operator
 
-go 1.24.2
-
-toolchain go1.24.6
+go 1.24.11
 
 require (
 	github.com/Masterminds/sprig/v3 v3.3.0


### PR DESCRIPTION
Fix several CVEs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Go runtime version to 1.24.11

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->