### PR TITLE
feat: Make SR-IOV Network Operator working in STIG-Enabled Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN make _build-manager BIN_PATH=build/_output/cmd && \
     make _build-sriov-network-operator-config-cleanup BIN_PATH=build/_output/cmd
 
 FROM quay.io/centos/centos:stream9
+USER 65532:65532
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/manager /usr/bin/sriov-network-operator
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-operator-config-cleanup /usr/bin/sriov-network-operator-config-cleanup
 COPY bindata /bindata

--- a/bindata/manifests/operator-webhook/server.yaml
+++ b/bindata/manifests/operator-webhook/server.yaml
@@ -82,6 +82,12 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           requests:
             cpu: 10m

--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -85,6 +85,12 @@ spec:
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          runAsNonRoot: true
+          seccompProfile:
+            type: RuntimeDefault
         resources:
           requests:
             cpu: 10m

--- a/deployment/sriov-network-operator-chart/templates/operator.yaml
+++ b/deployment/sriov-network-operator-chart/templates/operator.yaml
@@ -46,6 +46,12 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
           resources:
             requests:
               cpu: 100m

--- a/deployment/sriov-network-operator-chart/templates/pre-delete-webooks.yaml
+++ b/deployment/sriov-network-operator-chart/templates/pre-delete-webooks.yaml
@@ -47,6 +47,14 @@ spec:
       containers:
         - name: cleanup
           image: {{ .Values.images.operator }}
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            seccompProfile:
+              type: RuntimeDefault
           command:
             - sriov-network-operator-config-cleanup
           args:


### PR DESCRIPTION
… Cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Hardened container runtime for operator, cleanup hook, and webhook: dropped capabilities, enforced non-root execution, enabled seccomp runtime profile, and prevented privilege escalation.
  * Docker image now runs processes as a non-privileged (non-root) user at runtime.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->