### PR TITLE
fix: add toleration and node affinitiy to helm hook

### DIFF
--- a/deployment/sriov-network-operator-chart/templates/pre-delete-webooks.yaml
+++ b/deployment/sriov-network-operator-chart/templates/pre-delete-webooks.yaml
@@ -19,7 +19,31 @@ spec:
       {{- range .Values.imagePullSecrets }}
       - name: {{ . }}
       {{- end }}
-      {{- end }}      
+      {{- end }}
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/master
+                  operator: In
+                  values:
+                    - ""
+          - weight: 1
+            preference:
+              matchExpressions:
+                - key: node-role.kubernetes.io/control-plane
+                  operator: In
+                  values:
+                    - ""
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
       containers:
         - name: cleanup
           image: {{ .Values.images.operator }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Kubernetes scheduling constraints in the sriov-network-operator Helm chart to improve pod placement reliability on control-plane nodes during uninstallation and lifecycle management operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->