### PR TITLE
replacing hadolint-action@v3.3.0 with commit sha for immutability

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,16 +129,17 @@ jobs:
     - name: checkout PR 
       uses: actions/checkout@v5
     - name: run hadolint on operator dockerfile
-      uses: hadolint/hadolint-action@v3.3.0
+      # using commit sha of the hadolint-action to preserve immutability
+      uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
       with:
         dockerfile: Dockerfile
     - name: run hadolint on config daemon dockerfile
-      uses: hadolint/hadolint-action@v3.3.0
+      uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
       with:
         dockerfile: Dockerfile.sriov-network-config-daemon
         ignore: DL3033
     - name: run hadolint on webhook dockerfile
-      uses: hadolint/hadolint-action@v3.3.0
+      uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5
       with:
         dockerfile: Dockerfile.webhook
   test-coverage:


### PR DESCRIPTION
I have replaced v3.3.0 with its release commit sha 2332a7b74a6de0dda2e2221d575162eba76ba5e5
[v3.3.0](https://github.com/hadolint/hadolint-action/commit/2332a7b74a6de0dda2e2221d575162eba76ba5e5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow dependencies to pinned commits for improved build consistency and reproducibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->