### PR TITLE
mlx5: switch to switchdev before setting sriov_numvfs

### DIFF
--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -1179,9 +1179,6 @@ func (s *sriov) setEswitchModeAndNumVFsMlx(pciAddr string, desiredEswitchMode st
 			return err
 		}
 	}
-	if err := s.SetSriovNumVfs(pciAddr, numVFs); err != nil {
-		return err
-	}
 
 	if desiredEswitchMode == sriovnetworkv1.ESwithModeSwitchDev {
 		if err := s.unbindAllVFsOnPF(pciAddr); err != nil {
@@ -1191,6 +1188,9 @@ func (s *sriov) setEswitchModeAndNumVFsMlx(pciAddr string, desiredEswitchMode st
 		if err := s.SetNicSriovMode(pciAddr, desiredEswitchMode); err != nil {
 			return err
 		}
+	}
+	if err := s.SetSriovNumVfs(pciAddr, numVFs); err != nil {
+		return err
 	}
 	return nil
 }


### PR DESCRIPTION
mlx5-based Network Express Card firmware(MT2894 Family [ConnectX-6 Lx]) requires eSwitch mode to be switched to switchdev before SR-IOV VFs are created. This change reorders the mlx5-specific SR-IOV configuration sequence to switch to switchdev prior to setting sriov_numvfs, enabling successful VF provisioning on affected hardware.

This PR fixes: https://github.com/k8snetworkplumbingwg/sriov-network-operator/issues/1015

**Problem**:
The current mlx5-specific SR-IOV configuration sequence performs:
legacy → unbind VFs → set sriov_numvfs → switchdev
On some mlx5 devices and firmware combinations, SR-IOV VFs can only be
successfully created after the eSwitch is already in switchdev mode

**Solution**
Reorder the mlx5 configuration flow to
legacy → unbind VFs → switchdev → set sriov_numvfs
This ensures the eSwitch mode is correctly set before VF creation,
allowing successful provisioning on affected hardware

Fix verified with MT2894 Family [ConnectX-6 Lx] :
```
lspci -nn
0101:00:00.0 Ethernet controller [0200]: Mellanox Technologies MT2894 Family [ConnectX-6 Lx] [15b3:101f]
0102:00:00.1 Ethernet controller [0200]: Mellanox Technologies MT2894 Family [ConnectX-6 Lx] [15b3:101f]
```

