### PR TITLE
Fix "message too long" error for InfiniBand devices with many VFs

### DIFF
--- a/pkg/host/internal/lib/netlink/mock/mock_netlink.go
+++ b/pkg/host/internal/lib/netlink/mock/mock_netlink.go
@@ -196,6 +196,21 @@ func (mr *MockNetlinkLibMockRecorder) LinkByName(name any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkByName", reflect.TypeOf((*MockNetlinkLib)(nil).LinkByName), name)
 }
 
+// LinkByNameForSetVf mocks base method.
+func (m *MockNetlinkLib) LinkByNameForSetVf(name string) (netlink.Link, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "LinkByNameForSetVf", name)
+	ret0, _ := ret[0].(netlink.Link)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// LinkByNameForSetVf indicates an expected call of LinkByNameForSetVf.
+func (mr *MockNetlinkLibMockRecorder) LinkByNameForSetVf(name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkByNameForSetVf", reflect.TypeOf((*MockNetlinkLib)(nil).LinkByNameForSetVf), name)
+}
+
 // LinkList mocks base method.
 func (m *MockNetlinkLib) LinkList() ([]netlink.Link, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
When configuring InfiniBand devices with many VFs, LinkByName() can fail with "message too long" because the kernel's netlink response exceeds the ~16KB message limit. This happens because LinkByName requests all VF info (including GUIDs) via RTEXT_FILTER_VF, which generates very large messages for IB devices.

This commit adds a fallback mechanism:
- Add LinkByNameForSetVf() method that reads minimal link info (name and index) directly from sysfs instead of using netlink
- Update configSriovVFDevices() to catch "message too long" errors and fall back to LinkByNameForSetVf()
- Add unit test covering the fallback scenario

The fallback only triggers when the specific "message too long" error occurs, preserving normal behavior for Ethernet devices and IB devices with fewer VFs.