### PR TITLE
fix: logging serialization bug:

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -281,7 +281,7 @@ func (dn *NodeReconciler) checkOnNodeStateChange(desiredNodeState *sriovnetworkv
 	// Check the main plugin for changes
 	reqDrain, reqReboot, err := dn.mainPlugin.OnNodeStateChange(desiredNodeState)
 	if err != nil {
-		funcLog.Error(err, "OnNodeStateChange plugin error", "mainPluginName", dn.mainPlugin.Name)
+		funcLog.Error(err, "OnNodeStateChange plugin error", "mainPluginName", dn.mainPlugin.Name())
 		return false, false, err
 	}
 	funcLog.V(0).Info("OnNodeStateChange result",


### PR DESCRIPTION
Updated NodeReconciler to correctly call the Name() method of the main plugin when logging errors. Previously, passing the function pointer directly caused "json: unsupported type: func() string" errors, masking the actual reconciliation failures.