### PR TITLE
daemon: mount writable /tmp for mstconfig lockfiles

### DIFF
--- a/bindata/manifests/daemon/daemonset.yaml
+++ b/bindata/manifests/daemon/daemonset.yaml
@@ -185,6 +185,8 @@ spec:
         volumeMounts:
           - name: host
             mountPath: /host
+          - name: tmp
+            mountPath: /tmp
         lifecycle:
           preStop:
             exec:
@@ -200,3 +202,5 @@ spec:
         hostPath:
           path: /etc/os-release
           type: File
+      - name: tmp
+        emptyDir: {}


### PR DESCRIPTION
When running with readOnlyRootFilesystem enabled, mstconfig fails to create its lockfiles because the path /tmp/mstflint_lockfiles is hardcoded in the mstflint source code.

This patch adds an emptyDir volume mounted at /tmp to provide a writable location for these lockfiles while maintaining the security benefits of a read-only root filesystem for the rest of the container.

```
2026-01-15T13:32:21.190908067Z  ERROR   mellanox/mellanox_plugin.go:111 mellanox-plugin getMlnxNicFwData(): failed      {"stderr": "Warrning: Failed to create lockfile: /tmp/mstflint_lockfiles/0000:0d:00.0_config (parallel access not supported)\nWarrning: Failed to create lockfile: /tmp/mstflint_lockfiles/0000:0d:00.0_config (parallel access not supported)\n", "error": "exit status 3"}
```