### PR TITLE
daemon: move empty device-plugin pod logging to callers

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -606,7 +606,6 @@ func (dn *NodeReconciler) getDevicePluginPodsForNode(ctx context.Context) ([]cor
 		return []corev1.Pod{}, err
 	}
 	if len(pods.Items) == 0 {
-		funcLog.Info("no device plugin pods found")
 		return []corev1.Pod{}, nil
 	}
 	return pods.Items, nil
@@ -621,6 +620,10 @@ func (dn *NodeReconciler) restartDevicePluginPod(ctx context.Context) error {
 	devicePluginPods, err := dn.getDevicePluginPodsForNode(ctx)
 	if err != nil {
 		return err
+	}
+	if len(devicePluginPods) == 0 {
+		funcLog.V(2).Info("no device plugin pods found during restart attempt")
+		return nil
 	}
 	for _, pod := range devicePluginPods {
 		podUID := pod.UID


### PR DESCRIPTION
The daemon polls for device plugin pods and logs
"no device plugin pods found" at INFO level when none exist. Since this is expected during startup and
reconciliation, it caused excessive log spam.
Lower the log level to V(2) to reduce noise

currently we see below logs repeats every second for 2 mnt at INFO level

2026-02-12T10:31:54.855029794Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:31:55.855797529Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:31:55.855833706Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:31:56.855143695Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:31:56.855179519Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:31:57.855190336Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:31:57.855227366Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:31:58.85412231Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:31:58.854154317Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:31:59.854394929Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:31:59.854430497Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:32:00.854522822Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:32:00.854554272Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:32:01.855304899Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:32:01.855343385Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:32:02.854291312Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:32:02.854325902Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:32:03.854449384Z	INFO	getDevicePluginPodsForNode	daemon/daemon.go:675	no device plugin pods found
2026-02-12T10:32:03.854488544Z	LEVEL(-2)	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	no device plugin pods found while waiting for a new pod to start
2026-02-12T10:32:04.853256813Z	ERROR	getDevicePluginPodsForNode	daemon/daemon.go:675	failed to list device plugin pods	{"error": "client rate limiter Wait returned an error: context deadline exceeded"}
2026-02-12T10:32:04.853317085Z	ERROR	waitForDevicePluginPodAndTryUnblock	wait/loop.go:87	failed to get device plugin pod while waiting for a new pod to start	{"error": "client rate limiter Wait returned an error: context deadline exceeded"}