### PR TITLE
e2e: Fix `expfmt.TextParser` in metrics test

### DIFF
--- a/test/conformance/tests/test_exporter_metrics.go
+++ b/test/conformance/tests/test_exporter_metrics.go
@@ -198,7 +198,7 @@ func getMetricsForNode(nodeName string) map[string]*dto.MetricFamily {
 	// Clean the scraped output from carriage returns
 	stdout = strings.ReplaceAll(stdout, "\r", "")
 
-	var parser expfmt.TextParser
+	parser := expfmt.NewTextParser(model.UTF8Validation)
 	mf, err := parser.TextToMetricFamilies(strings.NewReader(stdout))
 	Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
`TextParser` objects must be initialized since `github.com/prometheus/common` `v0.67.0`

Links:
- https://github.com/prometheus/common/blob/main/CHANGELOG.md#whats-changed-3

This PR fixes the failure:
```
> Enter [BeforeAll] [sriov] Metrics Exporter - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:34 @ 02/23/26 16:24:05.991
STEP: Enabling `metricsExporter` feature flag - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:51 @ 02/23/26 16:24:06.237
STEP: Adding monitoring label to openshift-sriov-network-operator - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:54 @ 02/23/26 16:24:06.304
STEP: Using device ens1f0 on node cnfdr13.telco5g.eng.rdu2.redhat.com - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:65 @ 02/23/26 16:24:21.179
< Exit [BeforeAll] [sriov] Metrics Exporter - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:34 @ 02/23/26 16:24:31.747 (25.756s)
> Enter [It] collects metrics regarding receiving traffic via VF - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:79 @ 02/23/26 16:24:31.747
[PANICKED] Test Panicked
In [It] at: /go/src/github.com/openshift/sriov-network-operator/vendor/github.com/prometheus/common/model/metric.go:179 @ 02/23/26 16:24:34.123

Invalid name validation scheme requested: unset

Full Stack Trace
  github.com/prometheus/common/model.ValidationScheme.IsValidMetricName(0x51d3c5?, {0xc000e32060?, 0x16?})
  	/go/src/github.com/openshift/sriov-network-operator/vendor/github.com/prometheus/common/model/metric.go:179 +0xb9
  github.com/prometheus/common/expfmt.(*TextParser).setOrCreateCurrentMF(0xc0000fe000)
  	/go/src/github.com/openshift/sriov-network-operator/vendor/github.com/prometheus/common/expfmt/text_parse.go:899 +0x85
  github.com/prometheus/common/expfmt.(*TextParser).startComment(0xc0000fe000)
  	/go/src/github.com/openshift/sriov-network-operator/vendor/github.com/prometheus/common/expfmt/text_parse.go:264 +0x15c
  github.com/prometheus/common/expfmt.(*TextParser).TextToMetricFamilies(0xc0000fe000, {0x1c111c0?, 0xc0004da9c0?})
  	/go/src/github.com/openshift/sriov-network-operator/vendor/github.com/prometheus/common/expfmt/text_parse.go:118 +0x5f
  github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests.getMetricsForNode({0xc000a52450, 0x23})
  	/go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:202 +0x545
  github.com/k8snetworkplumbingwg/sriov-network-operator/test/conformance/tests.init.func4.2()
  	/go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:92 +0x2bc
< Exit [It] collects metrics regarding receiving traffic via VF - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:79 @ 02/23/26 16:24:34.123 (2.376s)
> Enter [DeferCleanup (Each)] [sriov] Metrics Exporter - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:85 @ 02/23/26 16:24:34.123
< Exit [DeferCleanup (Each)] [sriov] Metrics Exporter - /go/src/github.com/openshift/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:85 @ 02/23/26 16:24:34.187 (64ms)
```