### PR TITLE
test: replace curl with wget in exporter metrics conformance test

### DIFF
--- a/test/conformance/tests/test_exporter_metrics.go
+++ b/test/conformance/tests/test_exporter_metrics.go
@@ -190,7 +190,7 @@ func getMetricsForNode(nodeName string) map[string]*dto.MetricFamily {
 
 	metricsExporterPod := metricsExporterPods.Items[0]
 
-	command := []string{"curl", "http://127.0.0.1:9110/metrics"}
+	command := []string{"wget", "-qO-", "http://127.0.0.1:9110/metrics"}
 	stdout, stderr, err := pod.ExecCommand(clients, &metricsExporterPod, command...)
 	Expect(err).ToNot(HaveOccurred(),
 		"pod: [%s/%s] command: [%v]\nstdout: %s\nstderr: %s", metricsExporterPod.Namespace, metricsExporterPod.Name, command, stdout, stderr)


### PR DESCRIPTION
We need this change to fix below test issue on s390x,

The test at
https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/e4cb25b7ca6bcaddd305d1660175e23f3aa2a87c/test/conformance/tests/test_exporter_metrics.go#L79

is currently failing because curl is not available inside the sriov-network-metrics-exporter pod.


To resolve this, replacing curl with wget, which is available in the container image.

```[sriov] Metrics Exporter collects metrics regarding receiving traffic via VF
/root/ap/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:84
  STEP: Enabling `metricsExporter` feature flag @ 02/24/26 07:54:13.655
  STEP: Adding monitoring label to openshift-sriov-network-operator @ 02/24/26 07:54:13.656
Waiting for the sriov state to stable
Sriov state is stable
  STEP: Using device ens2048f0np0 on node master-0.ocp-ashok.lnxero1.boe @ 02/24/26 07:54:46.728
Waiting for the sriov state to stable
Sriov state is stable
  [FAILED] in [It] - /root/ap/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:200 @ 02/24/26 07:55:41.689
• [FAILED] [88.053 seconds]
[sriov] Metrics Exporter [It] collects metrics regarding receiving traffic via VF
/root/ap/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:84

  [FAILED] pod: [openshift-sriov-network-operator/sriov-network-metrics-exporter-l2fw8] command: [[curl http://127.0.0.1:9110/metrics]]
  stdout: 
  **stderr: executable file `curl` not found in $PATH: No such file or directory**

  Unexpected error:
      <exec.CodeExitError>: 
      command terminated with exit code 1
      {
          Err: <*errors.errorString | 0xc0005aa800>{
              s: "command terminated with exit code 1",
          },
          Code: 1,
      }
  occurred
  In [It] at: /root/ap/sriov-network-operator/test/conformance/tests/test_exporter_metrics.go:200 @ 02/24/26 07:55:41.689

