### PR TITLE
Clean stale VF representor ports from OVS bridges during switchdev reconciliation

### DIFF
--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -285,18 +285,18 @@ func (mr *MockHostHelpersInterfaceMockRecorder) DeleteVDPADevice(pciAddr any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVDPADevice", reflect.TypeOf((*MockHostHelpersInterface)(nil).DeleteVDPADevice), pciAddr)
 }
 
-// DetachInterfaceFromManagedBridge mocks base method.
-func (m *MockHostHelpersInterface) DetachInterfaceFromManagedBridge(pciAddr string) error {
+// DetachUplinkAndVFRepresentorsFromManagedBridge mocks base method.
+func (m *MockHostHelpersInterface) DetachUplinkAndVFRepresentorsFromManagedBridge(pciAddr string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DetachInterfaceFromManagedBridge", pciAddr)
+	ret := m.ctrl.Call(m, "DetachUplinkAndVFRepresentorsFromManagedBridge", pciAddr)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DetachInterfaceFromManagedBridge indicates an expected call of DetachInterfaceFromManagedBridge.
-func (mr *MockHostHelpersInterfaceMockRecorder) DetachInterfaceFromManagedBridge(pciAddr any) *gomock.Call {
+// DetachUplinkAndVFRepresentorsFromManagedBridge indicates an expected call of DetachUplinkAndVFRepresentorsFromManagedBridge.
+func (mr *MockHostHelpersInterfaceMockRecorder) DetachUplinkAndVFRepresentorsFromManagedBridge(pciAddr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInterfaceFromManagedBridge", reflect.TypeOf((*MockHostHelpersInterface)(nil).DetachInterfaceFromManagedBridge), pciAddr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachUplinkAndVFRepresentorsFromManagedBridge", reflect.TypeOf((*MockHostHelpersInterface)(nil).DetachUplinkAndVFRepresentorsFromManagedBridge), pciAddr)
 }
 
 // DiscoverBridges mocks base method.

--- a/pkg/host/internal/bridge/bridge.go
+++ b/pkg/host/internal/bridge/bridge.go
@@ -2,6 +2,7 @@ package bridge
 
 import (
 	"context"
+	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -68,14 +69,13 @@ func (b *bridge) ConfigureBridges(bridgesSpec sriovnetworkv1.Bridges, bridgesSta
 	return nil
 }
 
-// DetachInterfaceFromManagedBridge detach interface from a managed bridge,
-// this step is required before applying some configurations to PF, e.g. changing of eSwitch mode.
-// The function detach interface from managed bridges only.
-func (b *bridge) DetachInterfaceFromManagedBridge(pciAddr string) error {
-	log.Log.V(1).Info("DetachInterfaceFromManagedBridge(): detach interface", "pciAddr", pciAddr)
-	if err := b.ovs.RemoveInterfaceFromOVSBridge(context.Background(), pciAddr); err != nil {
-		log.Log.Error(err, "DetachInterfaceFromManagedBridge(): failed to detach interface from OVS bridge", "pciAddr", pciAddr)
-		return err
+// DetachUplinkAndVFRepresentorsFromManagedBridge detaches a PF uplink and all of
+// its VF representors from a managed bridge.
+func (b *bridge) DetachUplinkAndVFRepresentorsFromManagedBridge(pciAddr string) error {
+	log.Log.V(1).Info("DetachUplinkAndVFRepresentorsFromManagedBridge(): detach uplink and VF representors", "pciAddr", pciAddr)
+	if err := b.ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(context.Background(), pciAddr); err != nil {
+		log.Log.Error(err, "DetachUplinkAndVFRepresentorsFromManagedBridge(): failed to detach uplink and VF representors from OVS bridge", "pciAddr", pciAddr)
+		return fmt.Errorf("failed to detach uplink and VF representors for device %s: %w", pciAddr, err)
 	}
 	return nil
 }

--- a/pkg/host/internal/bridge/bridge_test.go
+++ b/pkg/host/internal/bridge/bridge_test.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"errors"
 	"fmt"
 
 	"go.uber.org/mock/gomock"
@@ -82,16 +83,16 @@ var _ = Describe("Bridge", func() {
 		})
 	})
 
-	Context("DetachInterfaceFromManagedBridge", func() {
+	Context("DetachUplinkAndVFRepresentorsFromManagedBridge", func() {
 		It("succeed", func() {
-			ovsMock.EXPECT().RemoveInterfaceFromOVSBridge(gomock.Any(), "0000:d8:00.0").Return(nil)
-			err := br.DetachInterfaceFromManagedBridge("0000:d8:00.0")
+			ovsMock.EXPECT().DetachUplinkAndVFRepresentorsFromOVSBridge(gomock.Any(), "0000:d8:00.0").Return(nil)
+			err := br.DetachUplinkAndVFRepresentorsFromManagedBridge("0000:d8:00.0")
 			Expect(err).NotTo(HaveOccurred())
 		})
 		It("error", func() {
-			ovsMock.EXPECT().RemoveInterfaceFromOVSBridge(gomock.Any(), "0000:d8:00.0").Return(testErr)
-			err := br.DetachInterfaceFromManagedBridge("0000:d8:00.0")
-			Expect(err).To(MatchError(testErr))
+			ovsMock.EXPECT().DetachUplinkAndVFRepresentorsFromOVSBridge(gomock.Any(), "0000:d8:00.0").Return(testErr)
+			err := br.DetachUplinkAndVFRepresentorsFromManagedBridge("0000:d8:00.0")
+			Expect(errors.Is(err, testErr)).To(BeTrue())
 		})
 	})
 })

--- a/pkg/host/internal/bridge/ovs/mock/mock_ovs.go
+++ b/pkg/host/internal/bridge/ovs/mock/mock_ovs.go
@@ -55,6 +55,20 @@ func (mr *MockInterfaceMockRecorder) CreateOVSBridge(ctx, conf any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOVSBridge", reflect.TypeOf((*MockInterface)(nil).CreateOVSBridge), ctx, conf)
 }
 
+// DetachUplinkAndVFRepresentorsFromOVSBridge mocks base method.
+func (m *MockInterface) DetachUplinkAndVFRepresentorsFromOVSBridge(ctx context.Context, pciAddress string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DetachUplinkAndVFRepresentorsFromOVSBridge", ctx, pciAddress)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DetachUplinkAndVFRepresentorsFromOVSBridge indicates an expected call of DetachUplinkAndVFRepresentorsFromOVSBridge.
+func (mr *MockInterfaceMockRecorder) DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, pciAddress any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachUplinkAndVFRepresentorsFromOVSBridge", reflect.TypeOf((*MockInterface)(nil).DetachUplinkAndVFRepresentorsFromOVSBridge), ctx, pciAddress)
+}
+
 // GetOVSBridges mocks base method.
 func (m *MockInterface) GetOVSBridges(ctx context.Context) ([]v1.OVSConfigExt, error) {
 	m.ctrl.T.Helper()
@@ -68,20 +82,6 @@ func (m *MockInterface) GetOVSBridges(ctx context.Context) ([]v1.OVSConfigExt, e
 func (mr *MockInterfaceMockRecorder) GetOVSBridges(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOVSBridges", reflect.TypeOf((*MockInterface)(nil).GetOVSBridges), ctx)
-}
-
-// RemoveInterfaceFromOVSBridge mocks base method.
-func (m *MockInterface) RemoveInterfaceFromOVSBridge(ctx context.Context, ifaceAddr string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveInterfaceFromOVSBridge", ctx, ifaceAddr)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveInterfaceFromOVSBridge indicates an expected call of RemoveInterfaceFromOVSBridge.
-func (mr *MockInterfaceMockRecorder) RemoveInterfaceFromOVSBridge(ctx, ifaceAddr any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveInterfaceFromOVSBridge", reflect.TypeOf((*MockInterface)(nil).RemoveInterfaceFromOVSBridge), ctx, ifaceAddr)
 }
 
 // RemoveOVSBridge mocks base method.

--- a/pkg/host/internal/bridge/ovs/ovs.go
+++ b/pkg/host/internal/bridge/ovs/ovs.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -47,8 +48,9 @@ type Interface interface {
 	GetOVSBridges(ctx context.Context) ([]sriovnetworkv1.OVSConfigExt, error)
 	// RemoveOVSBridge removes managed OVS bridge by name
 	RemoveOVSBridge(ctx context.Context, bridgeName string) error
-	// RemoveInterfaceFromOVSBridge interface from the managed OVS bridge
-	RemoveInterfaceFromOVSBridge(ctx context.Context, ifaceAddr string) error
+	// DetachUplinkAndVFRepresentorsFromOVSBridge detaches a PF uplink and all of its
+	// VF representors from the managed OVS bridge identified by the PF PCI address.
+	DetachUplinkAndVFRepresentorsFromOVSBridge(ctx context.Context, pciAddress string) error
 }
 
 // New creates new instance of the OVS interface
@@ -298,61 +300,129 @@ func (o *ovs) RemoveOVSBridge(ctx context.Context, bridgeName string) error {
 	return nil
 }
 
-// RemoveInterfaceFromOVSBridge removes interface from the managed OVS bridge
-func (o *ovs) RemoveInterfaceFromOVSBridge(ctx context.Context, pciAddress string) error {
+// DetachUplinkAndVFRepresentorsFromOVSBridge detaches a PF uplink and all of its
+// VF representors from the managed OVS bridge identified by the PF PCI address.
+func (o *ovs) DetachUplinkAndVFRepresentorsFromOVSBridge(ctx context.Context, pciAddress string) error {
 	ctx, cancel := setDefaultTimeout(ctx)
 	defer cancel()
 	funcLog := log.Log.WithValues("pciAddress", pciAddress)
-	funcLog.V(1).Info("RemoveInterfaceFromOVSBridge(): remove interface from managed bridge")
+	funcLog.V(1).Info("DetachUplinkAndVFRepresentorsFromOVSBridge(): detach uplink and VF representors from managed bridge")
 	knownConfigs, err := o.store.GetManagedOVSBridges()
 	if err != nil {
-		funcLog.Error(err, "RemoveInterfaceFromOVSBridge(): failed to read data from store")
-		return fmt.Errorf("failed to read data from store: %v", err)
+		funcLog.Error(err, "DetachUplinkAndVFRepresentorsFromOVSBridge(): failed to read data from store")
+		return fmt.Errorf("failed to read data from store: %w", err)
 	}
-	var relatedBridges []*sriovnetworkv1.OVSConfigExt
+	// iterate all uplinks in each bridge config to find the bridge that contains
+	// the PF with the given PCI address; a bridge may have multiple uplinks and
+	// the target PF is not necessarily at index 0
+	var brConf *sriovnetworkv1.OVSConfigExt
+	var pfName string
 	for _, kc := range knownConfigs {
-		if len(kc.Uplinks) > 0 && kc.Uplinks[0].PciAddress == pciAddress && kc.Uplinks[0].Name != "" {
-			relatedBridges = append(relatedBridges, kc)
+		for _, uplink := range kc.Uplinks {
+			if uplink.PciAddress == pciAddress && uplink.Name != "" {
+				brConf = kc
+				pfName = uplink.Name
+				break
+			}
+		}
+		if brConf != nil {
+			break
 		}
 	}
-	if len(relatedBridges) == 0 {
-		funcLog.V(2).Info("RemoveInterfaceFromOVSBridge(): can't find related managed OVS bridge in the store")
+	if brConf == nil {
+		funcLog.V(2).Info("DetachUplinkAndVFRepresentorsFromOVSBridge(): can't find related managed OVS bridge in the store")
 		return nil
 	}
-	if len(relatedBridges) > 1 {
-		funcLog.Info("RemoveInterfaceFromOVSBridge(): WARNING: uplink match more then one managed OVS bridge in the store, use first match")
-	}
-	brConf := relatedBridges[0]
+	funcLog = funcLog.WithValues("pfName", pfName, "bridge", brConf.Name)
 
 	dbClient, err := getClient(ctx)
 	if err != nil {
-		funcLog.Error(err, "RemoveInterfaceFromOVSBridge(): failed to connect to OVSDB")
-		return fmt.Errorf("failed to connect to OVSDB: %v", err)
+		funcLog.Error(err, "DetachUplinkAndVFRepresentorsFromOVSBridge(): failed to connect to OVSDB")
+		return fmt.Errorf("failed to connect to OVSDB: %w", err)
 	}
 	defer dbClient.Close()
 
-	funcLog.V(2).Info("RemoveInterfaceFromOVSBridge(): related managed bridge found for interface in the store", "bridge", brConf.Name)
-	currentState, err := o.getCurrentBridgeState(ctx, dbClient, brConf)
+	funcLog.V(2).Info("DetachUplinkAndVFRepresentorsFromOVSBridge(): related managed bridge found for interface in the store")
+	bridge, err := o.getBridgeByName(ctx, dbClient, brConf.Name)
 	if err != nil {
-		funcLog.Error(err, "RemoveInterfaceFromOVSBridge(): failed to get state of the managed bridge", "bridge", brConf.Name)
-		return err
+		funcLog.Error(err, "DetachUplinkAndVFRepresentorsFromOVSBridge(): failed to get the managed bridge")
+		return fmt.Errorf("failed to get managed bridge %s: %w", brConf.Name, err)
 	}
-	if currentState == nil {
-		funcLog.V(2).Info("RemoveInterfaceFromOVSBridge(): bridge not found, remove information about the bridge from the store", "bridge", brConf.Name)
+	if bridge == nil {
+		funcLog.V(2).Info("DetachUplinkAndVFRepresentorsFromOVSBridge(): bridge not found, remove information about the bridge from the store")
 		if err := o.store.RemoveManagedOVSBridge(brConf.Name); err != nil {
-			funcLog.Error(err, "RemoveInterfaceFromOVSBridge(): failed to remove information from the store", "bridge", brConf.Name)
-			return err
+			funcLog.Error(err, "DetachUplinkAndVFRepresentorsFromOVSBridge(): failed to remove information from the store")
+			return fmt.Errorf("failed to remove managed bridge %s from store: %w", brConf.Name, err)
 		}
 		return nil
 	}
 
-	funcLog.V(2).Info("RemoveInterfaceFromOVSBridge(): remove interface from the bridge")
-	if err := o.deleteInterfaceByName(ctx, dbClient, brConf.Uplinks[0].Name); err != nil {
-		funcLog.Error(err, "RemoveInterfaceFromOVSBridge(): failed to remove interface from the bridge", "bridge", brConf.Name)
-		return err
+	interfaceNames, err := o.getInterfaceNamesOnBridge(ctx, dbClient, bridge)
+	if err != nil {
+		funcLog.Error(err, "DetachUplinkAndVFRepresentorsFromOVSBridge(): failed to list interfaces on the managed bridge")
+		return fmt.Errorf("failed to list interfaces on managed bridge %s: %w", brConf.Name, err)
+	}
+	for _, repName := range interfaceNames {
+		if !isVFRepresentorName(repName, pfName) {
+			continue
+		}
+		if err := o.deleteInterfaceByName(ctx, dbClient, repName); err != nil {
+			funcLog.Error(err, "DetachUplinkAndVFRepresentorsFromOVSBridge(): failed to detach VF representor", "interface", repName)
+			return fmt.Errorf("failed to detach VF representor %s: %w", repName, err)
+		}
+	}
+
+	funcLog.V(2).Info("DetachUplinkAndVFRepresentorsFromOVSBridge(): detach PF uplink", "interface", pfName)
+	if err := o.deleteInterfaceByName(ctx, dbClient, pfName); err != nil {
+		funcLog.Error(err, "DetachUplinkAndVFRepresentorsFromOVSBridge(): failed to detach PF uplink")
+		return fmt.Errorf("failed to detach PF uplink %s: %w", pfName, err)
 	}
 
 	return nil
+}
+
+func (o *ovs) getInterfaceNamesOnBridge(ctx context.Context, dbClient client.Client, bridge *BridgeEntry) ([]string, error) {
+	ports := []*PortEntry{}
+	if err := dbClient.List(ctx, &ports); err != nil {
+		return nil, fmt.Errorf("failed to list ports: %w", err)
+	}
+
+	interfaceIDs := map[string]struct{}{}
+	for _, port := range ports {
+		if bridge.HasPort(port.UUID) {
+			// A Port can reference multiple Interface rows, for example when it
+			// represents a bond, so collect every interface attached to the port.
+			for _, interfaceID := range port.Interfaces {
+				interfaceIDs[interfaceID] = struct{}{}
+			}
+		}
+	}
+
+	interfaces := []*InterfaceEntry{}
+	if err := dbClient.List(ctx, &interfaces); err != nil {
+		return nil, fmt.Errorf("failed to list interfaces: %w", err)
+	}
+
+	interfaceNames := make([]string, 0, len(interfaceIDs))
+	for _, iface := range interfaces {
+		if _, found := interfaceIDs[iface.UUID]; found {
+			interfaceNames = append(interfaceNames, iface.Name)
+		}
+	}
+	sort.Strings(interfaceNames)
+	return interfaceNames, nil
+}
+
+// isVFRepresentorName reports whether interfaceName follows the naming convention
+// of the operator-created udev rule for a VF representor of pfName. For example,
+// enp216s0f0np0_7 is VF representor 7 of PF enp216s0f0np0.
+func isVFRepresentorName(interfaceName, pfName string) bool {
+	vfIndex, found := strings.CutPrefix(interfaceName, pfName+"_")
+	if !found || vfIndex == "" {
+		return false
+	}
+	vfIndexNumber, err := strconv.Atoi(vfIndex)
+	return err == nil && vfIndexNumber >= 0 && !strings.HasPrefix(vfIndex, "+")
 }
 
 func (o *ovs) getBridgeByName(ctx context.Context, dbClient client.Client, name string) (*BridgeEntry, error) {

--- a/pkg/host/internal/bridge/ovs/ovs_test.go
+++ b/pkg/host/internal/bridge/ovs/ovs_test.go
@@ -3,6 +3,7 @@ package ovs
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -243,6 +244,21 @@ var _ = Describe("OVS", func() {
 					map[string]string{"key2": "val2new"},
 				))
 		})
+	})
+
+	Context("isVFRepresentorName", func() {
+		DescribeTable("matching the operator udev naming convention",
+			func(interfaceName, pfName string, expected bool) {
+				Expect(isVFRepresentorName(interfaceName, pfName)).To(Equal(expected))
+			},
+			Entry("zero VF index", "enp216s0f0np0_0", "enp216s0f0np0", true),
+			Entry("sparse VF index", "enp216s0f0np0_7", "enp216s0f0np0", true),
+			Entry("non-numeric suffix", "enp216s0f0np0_backup", "enp216s0f0np0", false),
+			Entry("empty suffix", "enp216s0f0np0_", "enp216s0f0np0", false),
+			Entry("negative VF index", "enp216s0f0np0_-1", "enp216s0f0np0", false),
+			Entry("explicitly positive VF index", "enp216s0f0np0_+1", "enp216s0f0np0", false),
+			Entry("different PF", "enp216s0f1np0_0", "enp216s0f0np0", false),
+		)
 	})
 
 	Context("client", func() {
@@ -606,19 +622,27 @@ var _ = Describe("OVS", func() {
 				Expect(getDBContent(ctx, ovsClient)).To(Equal(initialDBContent))
 			})
 		})
-		Context("RemoveInterfaceFromOVSBridge", func() {
+		Context("DetachUplinkAndVFRepresentorsFromOVSBridge", func() {
+			It("should preserve a managed bridge store lookup error", func() {
+				testErr := errors.New("store lookup failed")
+				store.EXPECT().GetManagedOVSBridges().Return(nil, testErr)
+
+				err := ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.0")
+
+				Expect(errors.Is(err, testErr)).To(BeTrue())
+			})
 			It("should not remove if interface is part of unmanaged bridge", func() {
 				store.EXPECT().GetManagedOVSBridges().Return(nil, nil)
 				initialDBContent := getDefaultInitialDBContent()
 				createInitialDBContent(ctx, ovsClient, initialDBContent)
-				Expect(ovs.RemoveInterfaceFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
+				Expect(ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
 				Expect(getDBContent(ctx, ovsClient)).To(Equal(initialDBContent))
 			})
 			It("should remove interface from managed bridge", func() {
 				store.EXPECT().GetManagedOVSBridges().Return(getManagedBridges(), nil)
 				initialDBContent := getDefaultInitialDBContent()
 				createInitialDBContent(ctx, ovsClient, initialDBContent)
-				Expect(ovs.RemoveInterfaceFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
+				Expect(ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
 				dbContent := getDBContent(ctx, ovsClient)
 				Expect(dbContent.Bridge[0].UUID).To(Equal(initialDBContent.Bridge[0].UUID))
 				Expect(dbContent.Interface).To(BeEmpty())
@@ -627,7 +651,121 @@ var _ = Describe("OVS", func() {
 			It("bridge not found", func() {
 				store.EXPECT().GetManagedOVSBridges().Return(getManagedBridges(), nil)
 				store.EXPECT().RemoveManagedOVSBridge("br-0000_d8_00.0").Return(nil)
-				Expect(ovs.RemoveInterfaceFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
+				Expect(ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
+			})
+			It("should preserve an error removing a stale bridge from the store", func() {
+				testErr := errors.New("store cleanup failed")
+				store.EXPECT().GetManagedOVSBridges().Return(getManagedBridges(), nil)
+				store.EXPECT().RemoveManagedOVSBridge("br-0000_d8_00.0").Return(testErr)
+
+				err := ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.0")
+
+				Expect(errors.Is(err, testErr)).To(BeTrue())
+			})
+			It("should remove every VF representor on the managed bridge", func() {
+				store.EXPECT().GetManagedOVSBridges().Return(getManagedBridges(), nil)
+				initialDBContent := getDefaultInitialDBContent()
+
+				// The gap verifies cleanup is based on actual bridge contents instead of
+				// stopping at the first missing VF index or using the current VF count.
+				rep0Iface := &InterfaceEntry{
+					Name: "enp216s0f0np0_0",
+					UUID: uuid.NewString(),
+					Type: "dpdk",
+				}
+				rep0Port := &PortEntry{
+					Name:       "enp216s0f0np0_0",
+					UUID:       uuid.NewString(),
+					Interfaces: []string{rep0Iface.UUID},
+				}
+				rep7Iface := &InterfaceEntry{
+					Name: "enp216s0f0np0_7",
+					UUID: uuid.NewString(),
+					Type: "dpdk",
+				}
+				rep7Port := &PortEntry{
+					Name:       "enp216s0f0np0_7",
+					UUID:       uuid.NewString(),
+					Interfaces: []string{rep7Iface.UUID},
+				}
+				unrelatedIface := &InterfaceEntry{
+					Name: "enp216s0f0np0_backup",
+					UUID: uuid.NewString(),
+					Type: "dpdk",
+				}
+				unrelatedPort := &PortEntry{
+					Name:       "enp216s0f0np0_backup",
+					UUID:       uuid.NewString(),
+					Interfaces: []string{unrelatedIface.UUID},
+				}
+				initialDBContent.Interface = append(initialDBContent.Interface, rep0Iface, rep7Iface, unrelatedIface)
+				initialDBContent.Port = append(initialDBContent.Port, rep0Port, rep7Port, unrelatedPort)
+				initialDBContent.Bridge[0].Ports = append(initialDBContent.Bridge[0].Ports, rep0Port.UUID, rep7Port.UUID, unrelatedPort.UUID)
+
+				createInitialDBContent(ctx, ovsClient, initialDBContent)
+				Expect(ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
+				dbContent := getDBContent(ctx, ovsClient)
+				Expect(dbContent.Interface).To(ConsistOf(unrelatedIface))
+				Expect(dbContent.Port).To(ConsistOf(unrelatedPort))
+				Expect(dbContent.Bridge).To(HaveLen(1))
+				Expect(dbContent.Bridge[0].UUID).To(Equal(initialDBContent.Bridge[0].UUID))
+				Expect(dbContent.Bridge[0].Ports).To(ConsistOf(unrelatedPort.UUID))
+			})
+			It("should find interface on second uplink of multi-uplink bridge", func() {
+				mtu := 5000
+				multiUplinkBridges := map[string]*sriovnetworkv1.OVSConfigExt{
+					"br-0000_d8_00.0": {
+						Name:   "br-0000_d8_00.0",
+						Bridge: sriovnetworkv1.OVSBridgeConfig{DatapathType: "netdev"},
+						Uplinks: []sriovnetworkv1.OVSUplinkConfigExt{
+							{PciAddress: "0000:d8:00.0", Name: "enp216s0f0np0", Interface: sriovnetworkv1.OVSInterfaceConfig{Type: "dpdk", MTURequest: &mtu}},
+							{PciAddress: "0000:d8:00.1", Name: "enp216s0f1np0", Interface: sriovnetworkv1.OVSInterfaceConfig{Type: "dpdk", MTURequest: &mtu}},
+						},
+					},
+				}
+				store.EXPECT().GetManagedOVSBridges().Return(multiUplinkBridges, nil)
+
+				// Build DB content with only the second uplink
+				iface := &InterfaceEntry{
+					Name: "enp216s0f1np0",
+					UUID: uuid.NewString(),
+					Type: "dpdk",
+				}
+				port := &PortEntry{
+					Name:       "enp216s0f1np0",
+					UUID:       uuid.NewString(),
+					Interfaces: []string{iface.UUID},
+				}
+				br := &BridgeEntry{
+					Name:         "br-0000_d8_00.0",
+					UUID:         uuid.NewString(),
+					Ports:        []string{port.UUID},
+					DatapathType: "netdev",
+				}
+				ovsEntry := &OpenvSwitchEntry{
+					UUID:    uuid.NewString(),
+					Bridges: []string{br.UUID},
+				}
+				initialDBContent := &testDBEntries{
+					OpenVSwitch: []*OpenvSwitchEntry{ovsEntry},
+					Bridge:      []*BridgeEntry{br},
+					Port:        []*PortEntry{port},
+					Interface:   []*InterfaceEntry{iface},
+				}
+				createInitialDBContent(ctx, ovsClient, initialDBContent)
+				Expect(ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.1")).NotTo(HaveOccurred())
+				dbContent := getDBContent(ctx, ovsClient)
+				Expect(dbContent.Interface).To(BeEmpty())
+				Expect(dbContent.Port).To(BeEmpty())
+			})
+			It("should succeed when representor interfaces don't exist in OVSDB", func() {
+				store.EXPECT().GetManagedOVSBridges().Return(getManagedBridges(), nil)
+				initialDBContent := getDefaultInitialDBContent()
+				createInitialDBContent(ctx, ovsClient, initialDBContent)
+				Expect(ovs.DetachUplinkAndVFRepresentorsFromOVSBridge(ctx, "0000:d8:00.0")).NotTo(HaveOccurred())
+				dbContent := getDBContent(ctx, ovsClient)
+				Expect(dbContent.Interface).To(BeEmpty())
+				Expect(dbContent.Port).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -766,7 +766,7 @@ func (s *sriov) ConfigSriovInterfaces(storeManager store.ManagerInterface,
 	}
 	if err != nil {
 		log.Log.Error(err, "cannot configure sriov interfaces")
-		return fmt.Errorf("cannot configure sriov interfaces")
+		return fmt.Errorf("cannot configure sriov interfaces: %w", err)
 	}
 	if sriovnetworkv1.ContainsSwitchdevInterface(interfaces) && len(toBeConfigured) > 0 {
 		// for switchdev devices we create udev rule that renames VF representors
@@ -1206,6 +1206,16 @@ func (s *sriov) createVFs(iface *sriovnetworkv1.Interface) error {
 			return nil
 		}
 	}
+	// Clean stale VF representor interfaces and detach PF uplink from the managed
+	// bridge before VF re-creation. After host reboot, representors from the previous
+	// lifecycle remain in the bridge; the PF uplink also needs to be detached because
+	// setEswitchModeAndNumVFsMlx() skips bridge cleanup when NIC is already
+	// in legacy mode (which is always the case after reboot).
+	if expectedEswitchMode == sriovnetworkv1.ESwithModeSwitchDev {
+		if err := s.detachUplinkAndVFRepresentorsFromBridge(iface.PciAddress); err != nil {
+			return fmt.Errorf("failed to clean managed bridge before creating VFs for device %s: %w", iface.PciAddress, err)
+		}
+	}
 	return s.setEswitchModeAndNumVFs(iface.PciAddress, expectedEswitchMode, iface.NumVfs)
 }
 
@@ -1316,8 +1326,8 @@ func (s *sriov) setEswitchModeAndNumVFsMlx(pciAddr string, desiredEswitchMode st
 	if s.GetNicSriovMode(pciAddr) != sriovnetworkv1.ESwithModeLegacy {
 		// detach PF from the managed bridge before switching the mode,
 		// changing of eSwitch mode may fail if NIC is part of the bridge (has offloaded TC rules)
-		if err := s.detachPFFromBridge(pciAddr); err != nil {
-			return err
+		if err := s.detachUplinkAndVFRepresentorsFromBridge(pciAddr); err != nil {
+			return fmt.Errorf("failed to clean managed bridge before changing eSwitch mode for device %s: %w", pciAddr, err)
 		}
 		if err := s.unbindAllVFsOnPF(pciAddr); err != nil {
 			log.Log.Error(err, "setEswitchModeAndNumVFsMlx(): failed to unbind VFs", "device", pciAddr, "mode", desiredEswitchMode)
@@ -1371,15 +1381,16 @@ func (s *sriov) setEswitchModeAndNumVFsIce(pciAddr string, desiredEswitchMode st
 	return nil
 }
 
-// detach PF from the managed bridge
-func (s *sriov) detachPFFromBridge(pciAddr string) error {
-	log.Log.V(2).Info("detachPFFromBridge(): detach PF", "device", pciAddr)
+// detachUplinkAndVFRepresentorsFromBridge detaches a PF uplink and all of its VF
+// representors from the managed bridge.
+func (s *sriov) detachUplinkAndVFRepresentorsFromBridge(pciAddr string) error {
+	log.Log.V(2).Info("detachUplinkAndVFRepresentorsFromBridge(): detach uplink and VF representors", "device", pciAddr)
 	if !vars.ManageSoftwareBridges {
 		return nil
 	}
-	if err := s.bridgeHelper.DetachInterfaceFromManagedBridge(pciAddr); err != nil {
-		log.Log.Error(err, "detachPFFromBridge(): failed to detach interface from the managed bridge", "device", pciAddr)
-		return err
+	if err := s.bridgeHelper.DetachUplinkAndVFRepresentorsFromManagedBridge(pciAddr); err != nil {
+		log.Log.Error(err, "detachUplinkAndVFRepresentorsFromBridge(): failed to detach uplink and VF representors from the managed bridge", "device", pciAddr)
+		return fmt.Errorf("failed to detach uplink and VF representors from managed bridge for device %s: %w", pciAddr, err)
 	}
 	return nil
 }

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -2,6 +2,7 @@ package sriov
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -611,6 +612,114 @@ var _ = Describe("SRIOV", func() {
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
 		})
 
+		It("should configure switchdev with bridge detach when ManageSoftwareBridges is true", func() {
+			vars.ManageSoftwareBridges = true
+			defer func() { vars.ManageSoftwareBridges = false }()
+
+			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+				Dirs:     []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
+				Files:    map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
+				Symlinks: map[string]string{"/sys/bus/pci/devices/0000:d8:00.2/physfn": "../../0000:d8:00.0"},
+			})
+
+			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
+			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.0").Return("mlx5_core", nil)
+			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
+			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
+			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("", syscall.EINVAL)
+			hostMock.EXPECT().DetachUplinkAndVFRepresentorsFromManagedBridge("0000:d8:00.0").Return(nil)
+			dputilsLibMock.EXPECT().GetVFList("0000:d8:00.0").Return([]string{"0000:d8:00.2"}, nil).AnyTimes()
+			pfLinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			netlinkLibMock.EXPECT().LinkByName("enp216s0f0np0").Return(pfLinkMock, nil).Times(2)
+			netlinkLibMock.EXPECT().IsLinkAdminStateUp(pfLinkMock).Return(false)
+			netlinkLibMock.EXPECT().LinkSetUp(pfLinkMock).Return(nil)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", "0000:d8:00.0").Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: "legacy"}}}, nil).Times(2)
+			netlinkLibMock.EXPECT().DevLinkSetEswitchMode(gomock.Any(), "switchdev").Return(nil)
+
+			dputilsLibMock.EXPECT().GetVFID("0000:d8:00.2").Return(0, nil).Times(2)
+			hostMock.EXPECT().Unbind("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(false, "")
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().HasDriver("0000:d8:00.2").Return(true, "test")
+			hostMock.EXPECT().UnbindDriverIfNeeded("0000:d8:00.2", true).Return(nil)
+			hostMock.EXPECT().BindDefaultDriver("0000:d8:00.2").Return(nil)
+			hostMock.EXPECT().SetNetdevMTU("0000:d8:00.2", 2000).Return(nil)
+			hostMock.EXPECT().GetInterfaceIndex("0000:d8:00.2").Return(42, nil).AnyTimes()
+			vf0LinkMock := netlinkMockPkg.NewMockLink(testCtrl)
+			vf0Mac, _ := net.ParseMAC("02:42:19:51:2f:af")
+			vf0LinkMock.EXPECT().Attrs().Return(&netlink.LinkAttrs{Name: "enp216s0f0_0", HardwareAddr: vf0Mac})
+			netlinkLibMock.EXPECT().LinkByIndex(42).Return(vf0LinkMock, nil).AnyTimes()
+			netlinkLibMock.EXPECT().LinkSetVfHardwareAddr(vf0LinkMock, 0, vf0Mac).Return(nil)
+			hostMock.EXPECT().GetPhysPortName("enp216s0f0np0").Return("p0", nil)
+			hostMock.EXPECT().GetPhysSwitchID("enp216s0f0np0").Return("7cfe90ff2cc0", nil)
+			hostMock.EXPECT().AddVfRepresentorUdevRule("0000:d8:00.0", "enp216s0f0np0", "7cfe90ff2cc0", "p0").Return(nil)
+			hostMock.EXPECT().CreateVDPADevice("0000:d8:00.2", "vhost_vdpa")
+			hostMock.EXPECT().LoadUdevRules().Return(nil)
+
+			storeManagerMode.EXPECT().SaveLastPfAppliedStatus(gomock.Any()).Return(nil)
+
+			Expect(s.ConfigSriovInterfaces(storeManagerMode,
+				[]sriovnetworkv1.Interface{{
+					Name:        "enp216s0f0np0",
+					PciAddress:  "0000:d8:00.0",
+					NumVfs:      1,
+					LinkType:    "ETH",
+					EswitchMode: "switchdev",
+					VfGroups: []sriovnetworkv1.VfGroup{
+						{
+							VfRange:      "0-0",
+							ResourceName: "test-resource0",
+							PolicyName:   "test-policy0",
+							Mtu:          2000,
+							IsRdma:       true,
+							VdpaType:     "vhost_vdpa",
+						}},
+				}},
+				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
+				false)).NotTo(HaveOccurred())
+			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "1")
+		})
+
+		It("should stop switchdev VF creation when bridge detach fails", func() {
+			vars.ManageSoftwareBridges = true
+			defer func() { vars.ManageSoftwareBridges = false }()
+
+			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
+				Dirs:  []string{"/sys/bus/pci/devices/0000:d8:00.0"},
+				Files: map[string][]byte{"/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs": {}},
+			})
+
+			dputilsLibMock.EXPECT().GetSriovVFcapacity("0000:d8:00.0").Return(1)
+			dputilsLibMock.EXPECT().GetVFconfigured("0000:d8:00.0").Return(0)
+			hostMock.EXPECT().RemoveDisableNMUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().RemovePersistPFNameUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().RemoveVfRepresentorUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().AddDisableNMUdevRule("0000:d8:00.0").Return(nil)
+			hostMock.EXPECT().AddPersistPFNameUdevRule("0000:d8:00.0", "enp216s0f0np0").Return(nil)
+			hostMock.EXPECT().EnableHwTcOffload("enp216s0f0np0").Return(nil)
+			hostMock.EXPECT().GetDevlinkDeviceParam("0000:d8:00.0", "flow_steering_mode").Return("", syscall.EINVAL)
+			hostMock.EXPECT().DetachUplinkAndVFRepresentorsFromManagedBridge("0000:d8:00.0").Return(testError)
+
+			err := s.ConfigSriovInterfaces(storeManagerMode,
+				[]sriovnetworkv1.Interface{{
+					Name:        "enp216s0f0np0",
+					PciAddress:  "0000:d8:00.0",
+					NumVfs:      1,
+					LinkType:    "ETH",
+					EswitchMode: "switchdev",
+				}},
+				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
+				false)
+
+			Expect(errors.Is(err, testError)).To(BeTrue())
+		})
+
 		It("should configure switchdev even if steering mode is not detected", func() {
 			helpers.GinkgoConfigureFakeFS(&fakefilesystem.FS{
 				Dirs:     []string{"/sys/bus/pci/devices/0000:d8:00.0", "/sys/bus/pci/devices/0000:d8:00.2"},
@@ -1103,6 +1212,54 @@ var _ = Describe("SRIOV", func() {
 				[]sriovnetworkv1.InterfaceExt{{PciAddress: "0000:d8:00.0"}},
 				true)).NotTo(HaveOccurred())
 			helpers.GinkgoAssertFileContentsEquals("/sys/bus/pci/devices/0000:d8:00.0/sriov_numvfs", "2")
+		})
+	})
+
+	Context("createVFs", func() {
+		BeforeEach(func() {
+			originalManageSoftwareBridges := vars.ManageSoftwareBridges
+			vars.ManageSoftwareBridges = true
+			DeferCleanup(func() {
+				vars.ManageSoftwareBridges = originalManageSoftwareBridges
+			})
+		})
+
+		It("should not detach when the switchdev configuration already matches", func() {
+			iface := &sriovnetworkv1.Interface{
+				PciAddress:        "0000:d8:00.0",
+				NumVfs:            1,
+				Mtu:               0,
+				Name:              "enp216s0f0np0",
+				LinkType:          "ETH",
+				EswitchMode:       sriovnetworkv1.ESwithModeSwitchDev,
+				VfGroups:          []sriovnetworkv1.VfGroup{},
+				ExternallyManaged: false,
+			}
+			dputilsLibMock.EXPECT().GetVFconfigured(iface.PciAddress).Return(iface.NumVfs)
+			netlinkLibMock.EXPECT().DevLinkGetDeviceByName("pci", iface.PciAddress).Return(&netlink.DevlinkDevice{
+				Attrs: netlink.DevlinkDevAttrs{Eswitch: netlink.DevlinkDevEswitchAttr{Mode: sriovnetworkv1.ESwithModeSwitchDev}},
+			}, nil)
+
+			Expect(s.(*sriov).createVFs(iface)).NotTo(HaveOccurred())
+		})
+
+		It("should not detach when recreating VFs in legacy mode", func() {
+			iface := &sriovnetworkv1.Interface{
+				PciAddress:        "0000:d8:00.0",
+				NumVfs:            1,
+				Mtu:               0,
+				Name:              "enp216s0f0np0",
+				LinkType:          "ETH",
+				EswitchMode:       sriovnetworkv1.ESwithModeLegacy,
+				VfGroups:          []sriovnetworkv1.VfGroup{},
+				ExternallyManaged: false,
+			}
+			dputilsLibMock.EXPECT().GetVFconfigured(iface.PciAddress).Return(0)
+			dputilsLibMock.EXPECT().GetDriverName(iface.PciAddress).Return("", testError)
+
+			err := s.(*sriov).createVFs(iface)
+
+			Expect(errors.Is(err, testError)).To(BeTrue())
 		})
 	})
 

--- a/pkg/host/mock/mock_host.go
+++ b/pkg/host/mock/mock_host.go
@@ -255,18 +255,18 @@ func (mr *MockHostManagerInterfaceMockRecorder) DeleteVDPADevice(pciAddr any) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteVDPADevice", reflect.TypeOf((*MockHostManagerInterface)(nil).DeleteVDPADevice), pciAddr)
 }
 
-// DetachInterfaceFromManagedBridge mocks base method.
-func (m *MockHostManagerInterface) DetachInterfaceFromManagedBridge(pciAddr string) error {
+// DetachUplinkAndVFRepresentorsFromManagedBridge mocks base method.
+func (m *MockHostManagerInterface) DetachUplinkAndVFRepresentorsFromManagedBridge(pciAddr string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DetachInterfaceFromManagedBridge", pciAddr)
+	ret := m.ctrl.Call(m, "DetachUplinkAndVFRepresentorsFromManagedBridge", pciAddr)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// DetachInterfaceFromManagedBridge indicates an expected call of DetachInterfaceFromManagedBridge.
-func (mr *MockHostManagerInterfaceMockRecorder) DetachInterfaceFromManagedBridge(pciAddr any) *gomock.Call {
+// DetachUplinkAndVFRepresentorsFromManagedBridge indicates an expected call of DetachUplinkAndVFRepresentorsFromManagedBridge.
+func (mr *MockHostManagerInterfaceMockRecorder) DetachUplinkAndVFRepresentorsFromManagedBridge(pciAddr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachInterfaceFromManagedBridge", reflect.TypeOf((*MockHostManagerInterface)(nil).DetachInterfaceFromManagedBridge), pciAddr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DetachUplinkAndVFRepresentorsFromManagedBridge", reflect.TypeOf((*MockHostManagerInterface)(nil).DetachUplinkAndVFRepresentorsFromManagedBridge), pciAddr)
 }
 
 // DiscoverBridges mocks base method.

--- a/pkg/host/types/interfaces.go
+++ b/pkg/host/types/interfaces.go
@@ -188,10 +188,9 @@ type BridgeInterface interface {
 	DiscoverBridges() (sriovnetworkv1.Bridges, error)
 	// ConfigureBridge configure managed bridges for the host
 	ConfigureBridges(bridgesSpec sriovnetworkv1.Bridges, bridgesStatus sriovnetworkv1.Bridges) error
-	// DetachInterfaceFromManagedBridge detach interface from a managed bridge,
-	// this step is required before applying some configurations to PF, e.g. changing of eSwitch mode.
-	// The function detach interface from managed bridges only.
-	DetachInterfaceFromManagedBridge(pciAddr string) error
+	// DetachUplinkAndVFRepresentorsFromManagedBridge detaches a PF uplink and all of
+	// its VF representors from a managed bridge.
+	DetachUplinkAndVFRepresentorsFromManagedBridge(pciAddr string) error
 }
 
 type InfinibandInterface interface {


### PR DESCRIPTION
After a host reboot, VF representor ports can remain attached to OVS bridges when pods were not deleted before the reboot. When the config daemon recreates the VFs, the new representors reuse those names and can fail during pod creation.

This change cleans the managed bridge before switchdev VF recreation:

- Finds the bridge and PF uplink name from the managed bridge store using the PF PCI address.
- Enumerates the interfaces currently attached to that bridge and removes every VF representor matching the operator udev convention `{pfName}_{vfIndex}`, including sparse stale indices from an older VF count.
- Detaches the PF uplink as part of the same operation.
- Runs cleanup before VF recreation even when the NIC is already in legacy mode after reboot.
- Checks every configured uplink when locating a PF in a multi-uplink bridge.

The bridge cleanup APIs were renamed to describe the combined uplink and VF representor operation and now require only the PF PCI address.

Validation:

- `go test ./pkg/host/... ./pkg/helper/... -count=1` in Linux with Go 1.26.5
- `golangci-lint v2.7.2 run ./pkg/host/... ./pkg/helper/...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Managed bridge cleanup now detaches PF uplinks and associated VF representor interfaces.
  * SR-IOV switchdev configuration cleans up interfaces before recreating VFs, including after reboot.
  * Improved handling for multiple uplinks, missing representors, and non-contiguous VF indices.

* **Bug Fixes**
  * Prevents stale interfaces from remaining attached during SR-IOV reconfiguration.
  * Preserves underlying configuration errors for clearer troubleshooting.

* **Tests**
  * Added coverage for detachment success, error propagation, multi-uplink bridges, and switchdev configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->