### PR TITLE
test: wait for operator pods readiness after networkpool configuration

### DIFF
--- a/test/conformance/tests/test_networkpool.go
+++ b/test/conformance/tests/test_networkpool.go
@@ -212,6 +212,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 
 			By("waiting for operator to finish the configuration")
 			WaitForSRIOVStable()
+			WaitForOperatorPodsReady()
 			nodeState := &sriovv1.SriovNetworkNodeState{}
 			Eventually(func(g Gomega) {
 				err = clients.Get(context.Background(), client.ObjectKey{Name: testNode, Namespace: operatorNamespace}, nodeState)
@@ -229,6 +230,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 
 			By("waiting for operator to finish the configuration")
 			WaitForSRIOVStable()
+			WaitForOperatorPodsReady()
 			podDefinition := pod.DefineWithNetworks([]string{"test-rdmanetwork"})
 			firstPod, err := clients.Pods(namespaces.Test).Create(context.Background(), podDefinition, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -268,13 +270,13 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 			}
 
 			By("checking the amount of allocatable devices remains after device plugin reset")
-			Consistently(func() int64 {
+			Eventually(func() int64 {
 				err = clients.Get(context.Background(), client.ObjectKey{Name: testNode}, testedNode)
 				Expect(err).ToNot(HaveOccurred())
 				resNum := testedNode.Status.Allocatable[corev1.ResourceName("openshift.io/"+resourceName)]
 				newAllocatable, _ := resNum.AsInt64()
 				return newAllocatable
-			}, 1*time.Minute, 5*time.Second).Should(Equal(allocatable))
+			}, 2*time.Minute, 5*time.Second).Should(Equal(allocatable))
 
 			By("checking counters inside the pods")
 			strOut, _, err := pod.ExecCommand(clients, firstPod, "/bin/bash", "-c", "ip link show net1")
@@ -340,6 +342,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			By("waiting for operator to finish the configuration")
 			WaitForSRIOVStable()
+			WaitForOperatorPodsReady()
 			nodeState := &sriovv1.SriovNetworkNodeState{}
 			Eventually(func(g Gomega) {
 				err = clients.Get(context.Background(), client.ObjectKey{Name: testNode, Namespace: operatorNamespace}, nodeState)
@@ -355,6 +358,7 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 				func(policy *sriovv1.SriovNetworkNodePolicy) { policy.Spec.IsRdma = true })
 			Expect(err).ToNot(HaveOccurred())
 			WaitForSRIOVStable()
+			WaitForOperatorPodsReady()
 
 			podDefinition := pod.DefineWithNetworks([]string{"test-rdmanetwork"})
 			firstPod, err := clients.Pods(namespaces.Test).Create(context.Background(), podDefinition, metav1.CreateOptions{})
@@ -373,3 +377,38 @@ var _ = Describe("[sriov] NetworkPool", Ordered, func() {
 		})
 	})
 })
+
+func WaitForOperatorPodsReady() {
+	Eventually(func(g Gomega) bool {
+		podList := &corev1.PodList{}
+		err := clients.List(context.Background(), podList,
+			client.InNamespace(operatorNamespace))
+		if err != nil {
+			return false
+		}
+
+		if len(podList.Items) == 0 {
+			return false
+		}
+
+		for _, pod := range podList.Items {
+			if pod.Status.Phase != corev1.PodRunning {
+				return false
+			}
+
+			isReady := false
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					isReady = true
+					break
+				}
+			}
+
+			if !isReady {
+				return false
+			}
+		}
+
+		return true
+	}, 2*time.Minute, 5*time.Second).Should(BeTrue())
+}


### PR DESCRIPTION
creating SriovNetworkPoolConfig(https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/808502cfc21a1af48d724bcf45b6cf9139602c22/test/conformance/tests/test_networkpool.go#L210) may trigger node reboot during SR-IOV reconfiguration. 
after the reboot, SR-IOV operator pods (network-resources-injector, operator-webhook) take some time to restart.
we can below in container creating state after node reboot even after log msg- Sriov state is stable

$**oc get all -n openshift-sriov-network-operator**
Warning: kubevirt.io/v1 VirtualMachineInstancePresets is now deprecated and will be removed in v2.
NAME                                         READY   STATUS              RESTARTS   AGE
pod/network-resources-injector-nxkm5         0/1     **ContainerCreating**   15         25h
pod/operator-webhook-c9rtw                   0/1     **ContainerCreating**   16         25h
pod/sriov-network-config-daemon-5lpms        1/1     Running             1          7m59s
pod/sriov-network-operator-bfb9b97cc-qdkj2   1/1     Running             16         25h
pod/testpod-79dmm                            1/1     Running             9          21h


The test could proceed before these pods are ready, causing the admission webhook to timeout when creating SriovNetworkNodePolicy.

Add an explicit wait for operator namespace pods to reach the Running/Ready state before continuing the test to avoid this race condition.


NetworkPool conformance tests may fail intermittently after creating
SriovNetworkPoolConfig because the node can reboot as part of the
configuration process.

After the reboot, several SR-IOV operator components restart, including
the sriov-network-operator, sriov-network-config-daemon and device plugin
pods. The test may proceed while these pods are still initializing.

When the test immediately creates a SriovNetworkNodePolicy, the admission
webhook served by the sriov-network-operator may not yet be ready,
resulting in errors such as:

  failed calling webhook "operator-webhook.sriovnetwork.openshift.io":
  context deadline exceeded

To avoid this race condition, the test now waits for the SR-IOV operator
pods in the operator namespace to reach the Running/Ready state before
continuing with further configuration steps.

This ensures the admission webhook is available and stabilizes the
NetworkPool RDMA tests in environments where node reboot occurs.

we see below errors:

------------------------------
[sriov] NetworkPool Check rdma metrics inside a pod in shared mode not exist should run pod without RDMA cni and not expose nic metrics
/root/ap/sriov-network-operator/test/conformance/tests/test_networkpool.go:355
Waiting for the sriov state to stable
Sriov state is stable
  STEP: Testing on node master-0.ocp-ashok.lnxero1.boe, 2 devices found @ 03/11/26 10:59:52.782
Waiting for the sriov state to stable
Sriov state is stable
  STEP: Creating sriov network to use the rdma device @ 03/11/26 11:01:42.853
  STEP: waiting for operator to finish the configuration @ 03/11/26 11:01:43.89
Waiting for the sriov state to stable
Sriov state is stable
  STEP: creating a policy @ 03/11/26 11:06:08.645
  [FAILED] in [It] - /root/ap/sriov-network-operator/test/conformance/tests/test_networkpool.go:359 @ 03/11/26 11:06:36.928
Waiting for the sriov state to stable


Sriov state is stable
• [FAILED] [720.567 seconds]
[sriov] NetworkPool Check rdma metrics inside a pod in shared mode not exist [It] should run pod without RDMA cni and not expose nic metrics
/root/ap/sriov-network-operator/test/conformance/tests/test_networkpool.go:355

  [FAILED] Unexpected error:
      <*errors.StatusError | 0xc000453400>: 
      Internal error occurred: failed calling webhook "operator-webhook.sriovnetwork.openshift.io": failed to call webhook: Post "https://operator-webhook-service.openshift-sriov-network-operator.svc:443/mutating-custom-resource?timeout=10s": context deadline exceeded
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Internal error occurred: failed calling webhook \"operator-webhook.sriovnetwork.openshift.io\": failed to call webhook: Post \"https://operator-webhook-service.openshift-sriov-network-operator.svc:443/mutating-custom-resource?timeout=10s\": context deadline exceeded",
              Reason: "InternalError",
              Details: {
                  Name: "",
                  Group: "",
                  Kind: "",
                  UID: "",
                  Causes: [
                      {
                          Type: "",
                          Message: "failed calling webhook \"operator-webhook.sriovnetwork.openshift.io\": failed to call webhook: Post \"https://operator-webhook-service.openshift-sriov-network-operator.svc:443/mutating-custom-resource?timeout=10s\": context deadline exceeded",
                          Field: "",
                      },
                  ],
                  RetryAfterSeconds: 0,
              },
              Code: 500,
          },
      }
  occurred
  In [It] at: /root/ap/sriov-network-operator/test/conformance/tests/test_networkpool.go:359 @ 03/11/26 11:06:36.928



