### PR TITLE
docs: restore alternative interface names in API docs

### DIFF
--- a/doc/api-overview.md
+++ b/doc/api-overview.md
@@ -45,6 +45,7 @@ graph TD
 - Use `SriovNetworkPoolConfig` for parallel node operations
 - Configure `SriovOperatorConfig` for global operator configuration and update feature gates
 - Monitor `SriovNetworkNodeState` for hardware status on a specific node
+- Use interface alternative names from `SriovNetworkNodeState.status.interfaces[].altNames` in `SriovNetworkNodePolicy.spec.nicSelector.pfNames`
 
 ## Detailed API Documentation
 

--- a/doc/api/node-policies-api.md
+++ b/doc/api/node-policies-api.md
@@ -48,7 +48,7 @@ This example configures Intel XL710 NICs (vendor 8086, device 1583) on nodes lab
 |-------|------|-------------|
 | `nicSelector.vendor` | string | PCI vendor ID (e.g., "8086" for Intel) |
 | `nicSelector.deviceID` | string | PCI device ID |
-| `nicSelector.pfName` | []string | Physical function names (e.g., ["eno1", "eno2"]) |
+| `nicSelector.pfNames` | []string | Physical function names or alternative interface names (e.g., ["eno1", "sriov1", "eno1#0-3"]) |
 | `nicSelector.rootDevices` | []string | PCI addresses (e.g., ["0000:86:00.0"]) |
 | `nicSelector.netFilter` | string | Network interface name filter |
 
@@ -80,6 +80,69 @@ This example configures Intel XL710 NICs (vendor 8086, device 1583) on nodes lab
 | `linkState` | string | VF link state ("auto", "enable", "disable") |
 | `maxTxRate` | integer | Maximum transmit rate (Mbps) |
 | `minTxRate` | integer | Minimum transmit rate (Mbps) |
+
+## Alternative Interface Names
+
+The operator discovers alternative interface names automatically and stores them in `SriovNetworkNodeState.status.interfaces[].altNames`.
+
+Example `SriovNetworkNodeState` snippet:
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodeState
+status:
+  interfaces:
+    - name: "ens803f1"
+      altNames:
+        - "eth0"
+        - "net1"
+        - "sriov1"
+```
+
+You can select a PF by using either:
+
+- the primary interface name (for example, `ens803f1`)
+- an alternative interface name (for example, `sriov1`, `eth0`, `net1`)
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: policy-using-altname
+  namespace: sriov-network-operator
+spec:
+  deviceType: netdevice
+  nicSelector:
+    pfNames: ["sriov1"]
+    vendor: "8086"
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  numVfs: 4
+  priority: 99
+  resourceName: intelnics
+```
+
+Alternative names also work with VF range notation:
+
+```yaml
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: policy-with-altname-vf-range
+  namespace: sriov-network-operator
+spec:
+  deviceType: netdevice
+  nicSelector:
+    pfNames: ["eth0#0-3"]
+    vendor: "8086"
+  nodeSelector:
+    feature.node.kubernetes.io/network-sriov.capable: "true"
+  numVfs: 8
+  priority: 99
+  resourceName: intelnics
+```
+
+To discover available alternative names on a node, see the [SriovNetworkNodeState API Reference](node-state-api.md#discovering-alternative-interface-names).
 
 ## Virtual Deployment Considerations
 
@@ -128,13 +191,13 @@ Use `#` notation to specify VF ranges:
 ```yaml
 spec:
   nicSelector:
-    pfName: ["eno1#0-3"]  # VFs 0, 1, 2, 3
+    pfNames: ["eno1#0-3"]  # VFs 0, 1, 2, 3
   numVfs: 8
   resourceName: group1
 ---
 spec:
   nicSelector:
-    pfName: ["eno1#4-7"]  # VFs 4, 5, 6, 7  
+    pfNames: ["eno1#4-7"]  # VFs 4, 5, 6, 7  
   numVfs: 8
   resourceName: group2
 ```
@@ -152,7 +215,7 @@ spec:
   externallyManaged: true
   deviceType: vfio-pci
   nicSelector:
-    pfName: ["eno1"]
+    pfNames: ["eno1"]
   nodeSelector:
     feature.node.kubernetes.io/network-sriov.capable: "true"
   numVfs: 4
@@ -201,7 +264,7 @@ spec:
   deviceType: netdevice
   isRdma: true
   nicSelector:
-    pfName: ["eno1"]
+    pfNames: ["eno1"]
   nodeSelector:
     feature.node.kubernetes.io/network-sriov.capable: "true"
   numVfs: 4
@@ -224,7 +287,7 @@ spec:
   deviceType: netdevice
   eSwitchMode: switchdev
   nicSelector:
-    pfName: ["eno1"]
+    pfNames: ["eno1"]
   nodeSelector:
     feature.node.kubernetes.io/network-sriov.capable: "true"
   numVfs: 4

--- a/doc/api/node-state-api.md
+++ b/doc/api/node-state-api.md
@@ -59,6 +59,9 @@ The status section shows the actual current state of SR-IOV hardware:
 status:
   interfaces:
     - name: "eno1"
+      altNames:
+        - "eth0"
+        - "sriov1"
       mac: "a4:bf:01:12:34:56"
       driver: "i40e"
       pciAddress: "0000:03:00.0"
@@ -94,6 +97,7 @@ status:
 | `numVfs` | int | Number of virtual functions to create |
 | `mtu` | int | Maximum transmission unit size |
 | `name` | string | Interface name (e.g., "eno1") |
+| `altNames` | []string | Alternative interface names discovered by the host OS (e.g., ["eth0", "sriov1"]) |
 | `linkType` | string | Link type: "eth", "ib" |
 | `eSwitchMode` | string | E-Switch mode: "legacy", "switchdev" |
 | `externallyManaged` | bool | Whether interface is managed externally |
@@ -155,6 +159,16 @@ kubectl describe sriovnetworknodestate <node-name> -n sriov-network-operator
 
 # View node state in YAML format
 kubectl get sriovnetworknodestate <node-name> -n sriov-network-operator -o yaml
+```
+
+### Discovering Alternative Interface Names
+
+Alternative interface names are available in `status.interfaces[].altNames`. You can use those names in `SriovNetworkNodePolicy.spec.nicSelector.pfNames`.
+
+```bash
+# Show interface names and alternative names for one node
+kubectl get sriovnetworknodestate <node-name> -n sriov-network-operator \
+  -o jsonpath='{range .status.interfaces[*]}{.name}{" => "}{.altNames}{"\n"}{end}'
 ```
 
 ### Monitoring Sync Status


### PR DESCRIPTION
The documentation reorganization dropped guidance introduced in #967 for discovering and using interface alternative names. Restore that guidance in the NodeState and NodePolicy references and surface it in the API overview so it follows the new docs structure.