### PR TITLE
Dockerfile: add systemd for mstfwreset warm-reboot support

### DIFF
--- a/Dockerfile.sriov-network-config-daemon
+++ b/Dockerfile.sriov-network-config-daemon
@@ -7,7 +7,9 @@ FROM quay.io/centos/centos:stream9
 ARG MSTFLINT=mstflint
 # We have to ensure that pciutils is installed. This package is needed for mstfwreset to succeed.
 # xref pkg/vendors/mellanox/mellanox.go#L150
-RUN if [ "$(uname -m)" = "s390x" ]; then yum -y install hwdata pciutils; else yum -y install hwdata pciutils kmod "${MSTFLINT}"; fi && yum clean all
+# systemd is required for the reboot binary used by mstfwreset.py:rebootMachine() on the
+# WARM_REBOOT path (mstfwreset -l 3), triggered when mellanoxFirmwareReset feature gate is enabled.
+RUN if [ "$(uname -m)" = "s390x" ]; then yum -y install hwdata pciutils; else yum -y install hwdata pciutils kmod systemd "${MSTFLINT}"; fi && yum clean all
 LABEL io.k8s.display-name="sriov-network-config-daemon" \
       io.k8s.description="This is a daemon that manage and config sriov network devices in Kubernetes cluster"
 COPY --from=builder /go/src/github.com/k8snetworkplumbingwg/sriov-network-operator/build/_output/cmd/sriov-network-config-daemon /usr/bin/


### PR DESCRIPTION
## Summary

`mstfwreset.py:rebootMachine()` calls `reboot` as a direct subprocess ([mstfwreset.py:1663](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/vendor/github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vendors/mellanox/mellanox.go)) on the `WARM_REBOOT` path (`mstfwreset -l 3`). The `reboot` binary is provided by the `systemd` package, which was not installed in the container image.

## Failure

Without `systemd`, the `WARM_REBOOT` path fails with:

```
Return code: 127
stderr: '/bin/sh: line 1: reboot: command not found'
Exception: Failed to reboot machine please reboot machine manually
```

This was reproduced by directly invoking `mstfwreset.py:rebootMachine()` inside the `sriov-network-config-daemon` container on OCP 4.21 with the `mellanoxFirmwareReset` feature gate enabled.

## Context

This path is triggered when:
1. `mellanoxFirmwareReset` feature gate is enabled
2. `mstfwreset` is called with `-l 3` (WARM_REBOOT level)
3. Firmware activation requires a machine reboot

The `kmod` package was previously added to support `lsmod` (also called by `mstfwreset.py`). `systemd` is the remaining missing dependency for the complete mstfwreset warm-reboot code path.

## Change

```diff
-RUN if [ "$(uname -m)" = "s390x" ]; then yum -y install hwdata pciutils; else yum -y install hwdata pciutils kmod "${MSTFLINT}"; fi && yum clean all
+# systemd is required for the reboot binary used by mstfwreset.py:rebootMachine() on the
+# WARM_REBOOT path (mstfwreset -l 3), triggered when mellanoxFirmwareReset feature gate is enabled.
+RUN if [ "$(uname -m)" = "s390x" ]; then yum -y install hwdata pciutils; else yum -y install hwdata pciutils kmod systemd "${MSTFLINT}"; fi && yum clean all
```

## Test plan

- [ ] Build `sriov-network-config-daemon` image and verify `which reboot` returns `/usr/sbin/reboot`
- [ ] Enable `mellanoxFirmwareReset` feature gate and verify `mstfwreset -l 3` can reach the reboot step without `command not found`

🤖 Generated with [Claude Code](https://claude.com/claude-code)