### PR TITLE
Simplify drain controller test to use deterministic node ordering

### DIFF
--- a/controllers/drain_controller_test.go
+++ b/controllers/drain_controller_test.go
@@ -394,6 +394,9 @@ func ExpectDrainCompleteNodesHaveIsNotSchedule(nodesState ...*sriovnetworkv1.Sri
 	}
 }
 
+// expectFirstDrainedNode waits until exactly one of the two nodes completes draining,
+// then returns the drained node first and the waiting node second. This accounts for
+// non-deterministic goroutine scheduling in the concurrent reconcile loops.
 func expectFirstDrainedNode(
 	node1 *corev1.Node,
 	nodeState1 *sriovnetworkv1.SriovNetworkNodeState,


### PR DESCRIPTION
Remove the non-deterministic expectFirstDrainedNode helper and replace it with straightforward sequential assertions on node1/node2.