### PR TITLE
Test Fix for AWS platform

### DIFF
--- a/test/conformance/tests/test_aws_platform.go
+++ b/test/conformance/tests/test_aws_platform.go
@@ -15,6 +15,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/utils/ptr"
 	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -191,10 +193,19 @@ var _ = Describe("[sriov] aws platform", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			By("waiting for the new config daemon pod to be running")
-			Eventually(func() bool {
-				newPod, err := getConfigDaemonPod(node)
-				// Make sure the replacement pod exists and is different from the deleted one
-				if err != nil || newPod.Name == oldPodName {
+			Eventually(func(g Gomega) bool {
+				pods := &corev1.PodList{}
+				label, err := labels.Parse("app=sriov-network-config-daemon")
+				g.Expect(err).ToNot(HaveOccurred())
+				field, err := fields.ParseSelector(fmt.Sprintf("spec.nodeName=%s", node))
+				g.Expect(err).ToNot(HaveOccurred())
+				err = clients.List(context.Background(), pods, &runtimeclient.ListOptions{Namespace: operatorNamespace, LabelSelector: label, FieldSelector: field})
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(len(pods.Items)).To(Equal(1))
+
+				newPod := pods.Items[0]
+				// Make sure we got a different pod (new one)
+				if newPod.Name == oldPodName {
 					return false
 				}
 				return newPod.Status.Phase == corev1.PodRunning


### PR DESCRIPTION
Fixes the test for AWS platform to not fail if the config daemon pod is not found.

we can't use `getConfigDaemonPod` as it uses `gomega Expect` and failed if the pod doesn't exist