### PR TITLE
Fix NAD creation blocked by stale LASTNETWORKNAMESPACE annotation

### DIFF
--- a/controllers/generic_network_controller.go
+++ b/controllers/generic_network_controller.go
@@ -149,7 +149,16 @@ func (r *genericNetworkReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 			},
 		})
 		if err != nil {
-			reqLogger.Error(err, "Couldn't delete NetworkAttachmentDefinition CR", "Namespace", instance.GetName(), "Name", lnns)
+			if !errors.IsNotFound(err) {
+				reqLogger.Error(err, "Couldn't delete NetworkAttachmentDefinition CR", "Namespace", lnns, "Name", instance.GetName())
+				return reconcile.Result{}, err
+			}
+			reqLogger.Info("Old NetworkAttachmentDefinition not found, skipping deletion", "Namespace", lnns, "Name", instance.GetName())
+		}
+		// Clear the stale annotation so we don't retry deletion.
+		// It will be re-set at creation time (L192).
+		if err := utils.AnnotateObject(ctx, instance, sriovnetworkv1.LASTNETWORKNAMESPACE, "", r.Client); err != nil {
+			reqLogger.Error(err, "Couldn't clear LASTNETWORKNAMESPACE annotation", "Name", instance.GetName())
 			return reconcile.Result{}, err
 		}
 	}

--- a/controllers/generic_network_controller_test.go
+++ b/controllers/generic_network_controller_test.go
@@ -64,6 +64,38 @@ var _ = Describe("All Network Controllers", Ordered, func() {
 		})
 	})
 
+	Context("NAD cleanup with stale LASTNETWORKNAMESPACE annotation", func() {
+		AfterEach(func() {
+			cleanNetworksInNamespace(testNamespace)
+			cleanNetworksInNamespace("default")
+		})
+
+		It("should create NAD even when old namespace NAD does not exist", func() {
+			By("Creating a SriovNetwork with a stale LASTNETWORKNAMESPACE annotation")
+			cr := sriovnetworkv1.SriovNetwork{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "stale-ns-net",
+					Namespace: testNamespace,
+					Annotations: map[string]string{
+						sriovnetworkv1.LASTNETWORKNAMESPACE: "non-existent-namespace",
+					},
+				},
+				Spec: sriovnetworkv1.SriovNetworkSpec{
+					ResourceName:     "resource_1",
+					NetworkNamespace: "default",
+				},
+			}
+
+			err := k8sClient.Create(ctx, &cr)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying that the NAD is created despite the stale annotation")
+			netAttDef := &netattdefv1.NetworkAttachmentDefinition{}
+			err = util.WaitForNamespacedObject(netAttDef, k8sClient, "default", cr.GetName(), util.RetryInterval, util.Timeout)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Context("owner-reference annotations", func() {
 		AfterEach(func() {
 			cleanNetworksInNamespace(testNamespace)


### PR DESCRIPTION
## Summary

- When a SriovNetwork has a `LASTNETWORKNAMESPACE` annotation pointing to a namespace where the old NetworkAttachmentDefinition no longer exists, the reconciler returned a NotFound error and blocked creation of the new NAD.
- Handle NotFound errors gracefully by logging and continuing, so cleanup of non-existent resources does not prevent forward progress.
- Also fixes swapped Namespace/Name fields in the error log message.

Jira: https://redhat.atlassian.net/browse/OCPBUGS-64886

🤖 Generated with [Claude Code](https://claude.com/claude-code)