### PR TITLE
Fix drain escalation race that could reboot node without full drain

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -1010,6 +1010,27 @@ func OwnerRefToString(cr client.Object) string {
 	return cr.GetObjectKind().GroupVersionKind().GroupKind().String() + "/" + cr.GetNamespace() + "/" + cr.GetName()
 }
 
+// DrainActionSatisfiesDesired returns true if the performed drain action
+// is sufficient for the desired drain type.
+// An empty performedAction means the drain controller hasn't set it yet (backward compat) — treated as satisfied.
+// A desiredAction of Idle means no drain is needed — any performed action satisfies this.
+// Reboot_Required (full drain) satisfies Drain_Required (partial drain).
+func DrainActionSatisfiesDesired(performedAction, desiredAction string) bool {
+	if performedAction == "" {
+		return true
+	}
+	if desiredAction == consts.DrainIdle || desiredAction == "" {
+		return true
+	}
+	if performedAction == desiredAction {
+		return true
+	}
+	if performedAction == consts.RebootRequired && desiredAction == consts.DrainRequired {
+		return true
+	}
+	return false
+}
+
 // ResolveInterfaceName resolves an interface name that might be an alternative name
 // to the actual interface name using the nodeState. If the name is an alternative name,
 // it returns the actual interface name. Otherwise, it returns the name as-is.

--- a/controllers/drain_controller.go
+++ b/controllers/drain_controller.go
@@ -113,27 +113,40 @@ func (dr *DrainReconcile) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 		return ctrl.Result{}, nil
 	}
 
-	// create the drain state annotation if it doesn't exist in the sriovNetworkNodeState object
-	nodeStateDrainAnnotationCurrent, currentNodeStateExist, err := dr.ensureAnnotationExists(ctx, nodeNetworkState, constants.NodeStateDrainAnnotationCurrent)
-	if err != nil {
-		reqLogger.Error(err, "failed to ensure nodeStateDrainAnnotationCurrent")
-		return ctrl.Result{}, err
+	// create the drain state annotations if they don't exist in the sriovNetworkNodeState object
+	nodeStateAnnotations := nodeNetworkState.GetAnnotations()
+	annotationsToSet := make(map[string]string)
+
+	nodeStateDrainAnnotationCurrent, currentExists := nodeStateAnnotations[constants.NodeStateDrainAnnotationCurrent]
+	if !currentExists {
+		nodeStateDrainAnnotationCurrent = constants.DrainIdle
+		annotationsToSet[constants.NodeStateDrainAnnotationCurrent] = constants.DrainIdle
 	}
-	_, desireNodeStateExist, err := dr.ensureAnnotationExists(ctx, nodeNetworkState, constants.NodeStateDrainAnnotation)
-	if err != nil {
-		reqLogger.Error(err, "failed to ensure nodeStateDrainAnnotation")
-		return ctrl.Result{}, err
+
+	if _, desiredExists := nodeStateAnnotations[constants.NodeStateDrainAnnotation]; !desiredExists {
+		annotationsToSet[constants.NodeStateDrainAnnotation] = constants.DrainIdle
+	}
+
+	if _, actionExists := nodeStateAnnotations[constants.NodeStateDrainActionAnnotation]; !actionExists {
+		annotationsToSet[constants.NodeStateDrainActionAnnotation] = ""
+	}
+
+	if len(annotationsToSet) > 0 {
+		if err := utils.AnnotateObjectMultiple(ctx, nodeNetworkState, annotationsToSet, dr.Client); err != nil {
+			reqLogger.Error(err, "failed to set default annotations on nodeNetworkState")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{Requeue: true}, nil
 	}
 
 	// create the drain state annotation if it doesn't exist in the node object
-	nodeDrainAnnotation, nodeExist, err := dr.ensureAnnotationExists(ctx, node, constants.NodeDrainAnnotation)
+	nodeDrainAnnotation, nodeExist, err := dr.ensureAnnotationExistsWithDefault(ctx, node, constants.NodeDrainAnnotation, constants.DrainIdle)
 	if err != nil {
-		reqLogger.Error(err, "failed to ensure nodeStateDrainAnnotation")
+		reqLogger.Error(err, "failed to ensure node drain annotation")
 		return ctrl.Result{}, err
 	}
 
-	// requeue the request if we needed to add any of the annotations
-	if !nodeExist || !currentNodeStateExist || !desireNodeStateExist {
+	if !nodeExist {
 		return ctrl.Result{Requeue: true}, nil
 	}
 	reqLogger.V(2).Info("Drain annotations", "nodeAnnotation", nodeDrainAnnotation, "nodeStateAnnotation", nodeStateDrainAnnotationCurrent)
@@ -164,7 +177,7 @@ func (dr *DrainReconcile) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// this cover the case a node request to drain or reboot
 	if nodeDrainAnnotation == constants.DrainRequired ||
 		nodeDrainAnnotation == constants.RebootRequired {
-		return dr.handleNodeDrainOrReboot(ctx, node, nodeNetworkState, nodeDrainAnnotation, nodeStateDrainAnnotationCurrent)
+		return dr.handleNodeDrainOrReboot(ctx, node, nodeNetworkState)
 	}
 
 	reqLogger.Error(nil, "unexpected node drain annotation")
@@ -182,14 +195,14 @@ func (dr *DrainReconcile) getObject(ctx context.Context, req ctrl.Request, objec
 	return true, nil
 }
 
-func (dr *DrainReconcile) ensureAnnotationExists(ctx context.Context, object client.Object, key string) (string, bool, error) {
+func (dr *DrainReconcile) ensureAnnotationExistsWithDefault(ctx context.Context, object client.Object, key, defaultValue string) (string, bool, error) {
 	value, exist := object.GetAnnotations()[key]
 	if !exist {
-		err := utils.AnnotateObject(ctx, object, key, constants.DrainIdle, dr.Client)
+		err := utils.AnnotateObject(ctx, object, key, defaultValue, dr.Client)
 		if err != nil {
 			return "", false, err
 		}
-		return constants.DrainIdle, false, nil
+		return defaultValue, false, nil
 	}
 
 	return value, true, nil

--- a/controllers/drain_controller_helper.go
+++ b/controllers/drain_controller_helper.go
@@ -46,10 +46,13 @@ func (dr *DrainReconcile) handleNodeIdleNodeStateDrainingOrCompleted(ctx context
 		return reconcile.Result{RequeueAfter: constants.DrainControllerRequeueTime}, nil
 	}
 
-	// move the node state back to idle
-	err = utils.AnnotateObject(ctx, nodeNetworkState, constants.NodeStateDrainAnnotationCurrent, constants.DrainIdle, dr.Client)
+	// clear drain-action and move current-state back to idle in a single patch
+	err = utils.AnnotateObjectMultiple(ctx, nodeNetworkState, map[string]string{
+		constants.NodeStateDrainActionAnnotation:  "",
+		constants.NodeStateDrainAnnotationCurrent: constants.DrainIdle,
+	}, dr.Client)
 	if err != nil {
-		reqLogger.Error(err, "failed to annotate node with annotation", "annotation", constants.DrainIdle)
+		reqLogger.Error(err, "failed to clear drain-action and set current-state to idle")
 		return ctrl.Result{}, err
 	}
 
@@ -64,19 +67,30 @@ func (dr *DrainReconcile) handleNodeIdleNodeStateDrainingOrCompleted(ctx context
 
 func (dr *DrainReconcile) handleNodeDrainOrReboot(ctx context.Context,
 	node *corev1.Node,
-	nodeNetworkState *sriovnetworkv1.SriovNetworkNodeState,
-	nodeDrainAnnotation,
-	nodeStateDrainAnnotationCurrent string) (ctrl.Result, error) {
+	nodeNetworkState *sriovnetworkv1.SriovNetworkNodeState) (ctrl.Result, error) {
 	reqLogger := ctx.Value(constants.LoggerContextKey).(logr.Logger).WithName("handleNodeDrainOrReboot")
-	// nothing to do here we need to wait for the node to move back to idle
+
+	// get the relevant annotations
+	desiredDrainState := nodeNetworkState.GetAnnotations()[constants.NodeStateDrainAnnotation]
+	nodeStateDrainAnnotationCurrent := nodeNetworkState.GetAnnotations()[constants.NodeStateDrainAnnotationCurrent]
+	drainAction := nodeNetworkState.GetAnnotations()[constants.NodeStateDrainActionAnnotation]
+
+	// if the node state is on drain complete we need to check if the drain action satisfies the desired drain type
 	if nodeStateDrainAnnotationCurrent == constants.DrainComplete {
+		escalated, err := dr.handleDrainEscalation(ctx, nodeNetworkState, drainAction, desiredDrainState)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		if escalated {
+			return reconcile.Result{Requeue: true}, nil
+		}
 		reqLogger.Info("node requested a drain and nodeState is on drain completed nothing todo")
 		return ctrl.Result{}, nil
 	}
 
 	// we need to start the drain, but first we need to check that we can drain the node
 	if nodeStateDrainAnnotationCurrent == constants.DrainIdle {
-		result, err := dr.tryDrainNode(ctx, node)
+		result, err := dr.tryDrainNode(ctx, node, desiredDrainState)
 		if err != nil {
 			reqLogger.Error(err, "failed to check if we can drain the node")
 			return ctrl.Result{}, err
@@ -89,7 +103,7 @@ func (dr *DrainReconcile) handleNodeDrainOrReboot(ctx context.Context,
 	}
 
 	// Check if we are on a single node, and we require a reboot/full-drain we just return
-	fullNodeDrain := nodeDrainAnnotation == constants.RebootRequired
+	fullNodeDrain := desiredDrainState == constants.RebootRequired
 	singleNode := false
 	if fullNodeDrain {
 		nodeList := &corev1.NodeList{}
@@ -127,15 +141,34 @@ func (dr *DrainReconcile) handleNodeDrainOrReboot(ctx context.Context,
 		return reconcile.Result{RequeueAfter: constants.DrainControllerRequeueTime}, nil
 	}
 
-	// if we manage to drain we label the node state with drain completed and finish
-	err = utils.AnnotateObject(ctx, nodeNetworkState, constants.NodeStateDrainAnnotationCurrent, constants.DrainComplete, dr.Client)
+	// After drain succeeds, re-read the NodeState to get the latest version.
+	// The drain process can take minutes, so the original nodeNetworkState is likely stale.
+	updatedNodeState := &sriovnetworkv1.SriovNetworkNodeState{}
+	if err := dr.Client.Get(ctx, client.ObjectKeyFromObject(nodeNetworkState), updatedNodeState); err != nil {
+		reqLogger.Error(err, "failed to re-read nodeState after drain")
+		return ctrl.Result{}, err
+	}
+	currentDesiredState := updatedNodeState.GetAnnotations()[constants.NodeStateDrainAnnotation]
+	escalated, err := dr.handleDrainEscalation(ctx, updatedNodeState, desiredDrainState, currentDesiredState)
 	if err != nil {
-		reqLogger.Error(err, "failed to annotate node with annotation", "annotation", constants.DrainComplete)
+		return ctrl.Result{}, err
+	}
+	if escalated {
+		return reconcile.Result{Requeue: true}, nil
+	}
+
+	// if we manage to drain we set drain completed and ensure drain-action reflects what was performed
+	err = utils.AnnotateObjectMultiple(ctx, updatedNodeState, map[string]string{
+		constants.NodeStateDrainAnnotationCurrent: constants.DrainComplete,
+		constants.NodeStateDrainActionAnnotation:  desiredDrainState,
+	}, dr.Client)
+	if err != nil {
+		reqLogger.Error(err, "failed to set DrainComplete and drain-action annotations")
 		return ctrl.Result{}, err
 	}
 
 	reqLogger.Info("node drained successfully")
-	dr.recorder.Eventf(nodeNetworkState, nil,
+	dr.recorder.Eventf(updatedNodeState, nil,
 		corev1.EventTypeWarning,
 		"DrainController",
 		"DrainNode",
@@ -143,7 +176,34 @@ func (dr *DrainReconcile) handleNodeDrainOrReboot(ctx context.Context,
 	return ctrl.Result{}, nil
 }
 
-func (dr *DrainReconcile) tryDrainNode(ctx context.Context, node *corev1.Node) (*reconcile.Result, error) {
+// handleDrainEscalation checks if the current desired drain state requires a stronger drain than what was performed.
+// Returns true if escalation was detected and re-drain is needed, false if no escalation.
+func (dr *DrainReconcile) handleDrainEscalation(ctx context.Context,
+	nodeNetworkState *sriovnetworkv1.SriovNetworkNodeState,
+	performedAction, currentDesiredState string) (bool, error) {
+	reqLogger := ctx.Value(constants.LoggerContextKey).(logr.Logger).WithName("handleDrainEscalation")
+
+	if sriovnetworkv1.DrainActionSatisfiesDesired(performedAction, currentDesiredState) {
+		return false, nil
+	}
+
+	reqLogger.Info("drain escalation detected, re-draining",
+		"performedAction", performedAction, "currentDesired", currentDesiredState)
+	if err := utils.AnnotateObjectMultiple(ctx, nodeNetworkState, map[string]string{
+		constants.NodeStateDrainActionAnnotation:  currentDesiredState,
+		constants.NodeStateDrainAnnotationCurrent: constants.Draining,
+	}, dr.Client); err != nil {
+		return false, err
+	}
+	dr.recorder.Eventf(nodeNetworkState, nil,
+		corev1.EventTypeWarning,
+		"DrainController",
+		"DrainEscalated",
+		fmt.Sprintf("drain escalated from %s to %s, re-draining", performedAction, currentDesiredState))
+	return true, nil
+}
+
+func (dr *DrainReconcile) tryDrainNode(ctx context.Context, node *corev1.Node, desiredDrainState string) (*reconcile.Result, error) {
 	reqLogger := ctx.Value(constants.LoggerContextKey).(logr.Logger).WithName("tryDrainNode")
 
 	//critical section we need to check if we can start the draining
@@ -204,9 +264,13 @@ func (dr *DrainReconcile) tryDrainNode(ctx context.Context, node *corev1.Node) (
 		return nil, fmt.Errorf("failed to find sriov network node state for requested node")
 	}
 
-	err = utils.AnnotateObject(ctx, currentSnns, constants.NodeStateDrainAnnotationCurrent, constants.Draining, dr.Client)
+	// Set current-state=Draining and drain-action atomically in the same critical section
+	err = utils.AnnotateObjectMultiple(ctx, currentSnns, map[string]string{
+		constants.NodeStateDrainAnnotationCurrent: constants.Draining,
+		constants.NodeStateDrainActionAnnotation:  desiredDrainState,
+	}, dr.Client)
 	if err != nil {
-		reqLogger.Error(err, "failed to annotate node with annotation", "annotation", constants.Draining)
+		reqLogger.Error(err, "failed to set draining and drain-action annotations")
 		return nil, err
 	}
 

--- a/controllers/drain_controller_test.go
+++ b/controllers/drain_controller_test.go
@@ -354,7 +354,104 @@ var _ = Describe("Drain Controller", Ordered, func() {
 			expectNodeStateAnnotation(nodeState1, constants.Draining)
 		})
 	})
+
+	Context("drain escalation", func() {
+		It("should set drain-action annotation on normal drain", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1", nil)
+
+			simulateDaemonSetAnnotation(node, constants.DrainRequired)
+
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectDrainActionAnnotation(nodeState, constants.DrainRequired)
+		})
+
+		It("should set drain-action annotation on reboot drain", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1", nil)
+			createNode(ctx, "node2", nil)
+
+			simulateDaemonSetAnnotation(node, constants.RebootRequired)
+
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectDrainActionAnnotation(nodeState, constants.RebootRequired)
+		})
+
+		It("should re-drain when escalated from Drain_Required to Reboot_Required after DrainComplete", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1", nil)
+			createNode(ctx, "node2", nil)
+
+			simulateDaemonSetAnnotation(node, constants.DrainRequired)
+
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectDrainActionAnnotation(nodeState, constants.DrainRequired)
+
+			simulateDaemonSetAnnotation(node, constants.RebootRequired)
+
+			expectDrainActionAnnotation(nodeState, constants.RebootRequired)
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectNodeIsNotSchedulable(node)
+		})
+
+		It("should clear drain-action on return to idle", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1", nil)
+
+			simulateDaemonSetAnnotation(node, constants.DrainRequired)
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+
+			simulateDaemonSetAnnotation(node, constants.DrainIdle)
+			expectNodeStateAnnotation(nodeState, constants.DrainIdle)
+			expectDrainActionAnnotation(nodeState, "")
+		})
+
+		It("should not re-drain when Reboot_Required satisfies Drain_Required", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1", nil)
+			createNode(ctx, "node2", nil)
+
+			simulateDaemonSetAnnotation(node, constants.RebootRequired)
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectDrainActionAnnotation(nodeState, constants.RebootRequired)
+			expectNodeIsNotSchedulable(node)
+			simulateDaemonSetAnnotation(node, constants.DrainRequired)
+
+			Consistently(func(g Gomega) {
+				g.Expect(k8sClient.Get(context.Background(),
+					types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)).
+					ToNot(HaveOccurred())
+				g.Expect(utils.ObjectHasAnnotation(nodeState,
+					constants.NodeStateDrainAnnotationCurrent, constants.DrainComplete)).To(BeTrue())
+			}, "5s", "1s").Should(Succeed())
+			expectNodeIsNotSchedulable(node)
+		})
+
+		It("should uncordon when daemon moves back to Idle during drain", func(ctx context.Context) {
+			node, nodeState := createNode(ctx, "node1", nil)
+			createNode(ctx, "node2", nil)
+
+			simulateDaemonSetAnnotation(node, constants.DrainRequired)
+			expectNodeStateAnnotation(nodeState, constants.DrainComplete)
+			expectDrainActionAnnotation(nodeState, constants.DrainRequired)
+
+			// User removes the policy — daemon moves back to Idle
+			simulateDaemonSetAnnotation(node, constants.DrainIdle)
+
+			// Controller should uncordon and clear drain-action
+			expectNodeStateAnnotation(nodeState, constants.DrainIdle)
+			expectDrainActionAnnotation(nodeState, "")
+			expectNodeIsSchedulable(node)
+		})
+	})
 })
+
+func expectDrainActionAnnotation(nodeState *sriovnetworkv1.SriovNetworkNodeState, expectedValue string) {
+	EventuallyWithOffset(1, func(g Gomega) {
+		g.Expect(k8sClient.Get(context.Background(),
+			types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)).
+			ToNot(HaveOccurred())
+
+		actual := nodeState.GetAnnotations()[constants.NodeStateDrainActionAnnotation]
+		g.Expect(actual).To(Equal(expectedValue),
+			"Node[%s] drain-action == '%s'. Expected '%s'", nodeState.Name, actual, expectedValue)
+	}, "40s", "1s").Should(Succeed())
+}
 
 func expectNodeStateAnnotation(nodeState *sriovnetworkv1.SriovNetworkNodeState, expectedAnnotationValue string) {
 	EventuallyWithOffset(1, func(g Gomega) {
@@ -364,7 +461,7 @@ func expectNodeStateAnnotation(nodeState *sriovnetworkv1.SriovNetworkNodeState, 
 		g.Expect(utils.ObjectHasAnnotation(nodeState, constants.NodeStateDrainAnnotationCurrent, expectedAnnotationValue)).
 			To(BeTrue(),
 				"Node[%s] annotation[%s] == '%s'. Expected '%s'", nodeState.Name, constants.NodeDrainAnnotation, nodeState.GetLabels()[constants.NodeStateDrainAnnotationCurrent], expectedAnnotationValue)
-	}, "20s", "1s").Should(Succeed())
+	}, "40s", "1s").Should(Succeed())
 }
 
 func expectNumberOfDrainingNodes(numbOfDrain int, nodesState ...*sriovnetworkv1.SriovNetworkNodeState) {
@@ -380,7 +477,7 @@ func expectNumberOfDrainingNodes(numbOfDrain int, nodesState ...*sriovnetworkv1.
 		}
 
 		g.Expect(drainingNodes).To(Equal(numbOfDrain))
-	}, "20s", "1s").Should(Succeed())
+	}, "40s", "1s").Should(Succeed())
 }
 
 func ExpectDrainCompleteNodesHaveIsNotSchedule(nodesState ...*sriovnetworkv1.SriovNetworkNodeState) {
@@ -414,7 +511,7 @@ func expectFirstDrainedNode(
 		// Exactly one node should complete draining first.
 		g.Expect(node1DrainComplete != node2DrainComplete).To(BeTrue())
 		firstIsNode1 = node1DrainComplete
-	}, "20s", "1s").Should(Succeed())
+	}, "40s", "1s").Should(Succeed())
 
 	if firstIsNode1 {
 		return node1, nodeState1, node2, nodeState2
@@ -428,7 +525,7 @@ func expectNodeIsNotSchedulable(node *corev1.Node) {
 			ToNot(HaveOccurred())
 
 		g.Expect(node.Spec.Unschedulable).To(BeTrue())
-	}, "20s", "1s").Should(Succeed())
+	}, "40s", "1s").Should(Succeed())
 }
 
 func expectNodeIsSchedulable(node *corev1.Node) {
@@ -437,51 +534,29 @@ func expectNodeIsSchedulable(node *corev1.Node) {
 			ToNot(HaveOccurred())
 
 		g.Expect(node.Spec.Unschedulable).To(BeFalse())
-	}, "20s", "1s").Should(Succeed())
+	}, "40s", "1s").Should(Succeed())
 }
 
 func simulateDaemonSetAnnotation(node *corev1.Node, drainAnnotationValue string) {
+	nodeState := &sriovnetworkv1.SriovNetworkNodeState{}
+	ExpectWithOffset(1,
+		k8sClient.Get(context.Background(), types.NamespacedName{Name: node.Name, Namespace: vars.Namespace}, nodeState)).
+		ToNot(HaveOccurred())
+	ExpectWithOffset(1,
+		utils.AnnotateObject(context.Background(), nodeState, constants.NodeStateDrainAnnotation, drainAnnotationValue, k8sClient)).
+		ToNot(HaveOccurred())
+
 	ExpectWithOffset(1,
 		utils.AnnotateObject(context.Background(), node, constants.NodeDrainAnnotation, drainAnnotationValue, k8sClient)).
 		ToNot(HaveOccurred())
 }
 
 func createNode(ctx context.Context, nodeName string,
-	additionalAnnotations map[string]string) (*corev1.Node, *sriovnetworkv1.SriovNetworkNodeState) {
-	node := corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: nodeName,
-			Annotations: map[string]string{
-				constants.NodeDrainAnnotation:                     constants.DrainIdle,
-				"machineconfiguration.openshift.io/desiredConfig": "worker-1",
-			},
-			Labels: map[string]string{
-				"test": "",
-			},
-		},
-	}
-
-	nodeState := sriovnetworkv1.SriovNetworkNodeState{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      nodeName,
-			Namespace: vars.Namespace,
-			Annotations: map[string]string{
-				constants.NodeStateDrainAnnotationCurrent: constants.DrainIdle,
-			},
-		},
-	}
-
-	for key, value := range additionalAnnotations {
-		nodeState.Annotations[key] = value
-	}
-
-	Expect(k8sClient.Create(ctx, &node)).ToNot(HaveOccurred())
-	Expect(k8sClient.Create(ctx, &nodeState)).ToNot(HaveOccurred())
-
-	return &node, &nodeState
+	additionalNodeStateAnnotations map[string]string) (*corev1.Node, *sriovnetworkv1.SriovNetworkNodeState) {
+	return createNodeWithLabel(ctx, nodeName, "test", additionalNodeStateAnnotations)
 }
 
-func createNodeWithLabel(ctx context.Context, nodeName string, label string) (*corev1.Node, *sriovnetworkv1.SriovNetworkNodeState) {
+func createNodeWithLabel(ctx context.Context, nodeName string, label string, additionalNodeStateAnnotations ...map[string]string) (*corev1.Node, *sriovnetworkv1.SriovNetworkNodeState) {
 	node := corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: nodeName,
@@ -501,8 +576,16 @@ func createNodeWithLabel(ctx context.Context, nodeName string, label string) (*c
 			Namespace: vars.Namespace,
 			Annotations: map[string]string{
 				constants.NodeStateDrainAnnotationCurrent: constants.DrainIdle,
+				constants.NodeStateDrainAnnotation:        constants.DrainIdle,
+				constants.NodeStateDrainActionAnnotation:  "",
 			},
 		},
+	}
+
+	for _, annotations := range additionalNodeStateAnnotations {
+		for key, value := range annotations {
+			nodeState.Annotations[key] = value
+		}
 	}
 
 	Expect(k8sClient.Create(ctx, &node)).ToNot(HaveOccurred())

--- a/controllers/helper.go
+++ b/controllers/helper.go
@@ -71,10 +71,13 @@ const (
 	trueString                            = "true"
 )
 
+// DrainAnnotationPredicate filters Node events, triggering reconciliation only when
+// the drain annotation (sriovnetwork.openshift.io/state) on the Node object changes.
 type DrainAnnotationPredicate struct {
 	predicate.Funcs
 }
 
+// Create returns true if the Node has the drain annotation present.
 func (DrainAnnotationPredicate) Create(e event.CreateEvent) bool {
 	if e.Object == nil {
 		return false
@@ -86,6 +89,7 @@ func (DrainAnnotationPredicate) Create(e event.CreateEvent) bool {
 	return false
 }
 
+// Update returns true if the drain annotation value changed between old and new objects.
 func (DrainAnnotationPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil {
 		return false
@@ -104,14 +108,18 @@ func (DrainAnnotationPredicate) Update(e event.UpdateEvent) bool {
 	return oldAnno != newAnno
 }
 
+// DrainStateAnnotationPredicate filters SriovNetworkNodeState events, triggering reconciliation
+// when the current-state or desired-state drain annotations change.
 type DrainStateAnnotationPredicate struct {
 	predicate.Funcs
 }
 
+// Create returns true for any non-nil object creation.
 func (DrainStateAnnotationPredicate) Create(e event.CreateEvent) bool {
 	return e.Object != nil
 }
 
+// Update returns true if either the current-state or desired-state annotation changed.
 func (DrainStateAnnotationPredicate) Update(e event.UpdateEvent) bool {
 	if e.ObjectOld == nil {
 		return false
@@ -120,16 +128,23 @@ func (DrainStateAnnotationPredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
-	oldAnno, hasOldAnno := e.ObjectOld.GetAnnotations()[constants.NodeStateDrainAnnotationCurrent]
-	newAnno, hasNewAnno := e.ObjectNew.GetAnnotations()[constants.NodeStateDrainAnnotationCurrent]
+	oldCurrent, hasOldCurrent := e.ObjectOld.GetAnnotations()[constants.NodeStateDrainAnnotationCurrent]
+	newCurrent, hasNewCurrent := e.ObjectNew.GetAnnotations()[constants.NodeStateDrainAnnotationCurrent]
 
-	if !hasOldAnno || !hasNewAnno {
+	if !hasOldCurrent || !hasNewCurrent {
+		return true
+	}
+	if oldCurrent != newCurrent {
 		return true
 	}
 
-	return oldAnno != newAnno
+	oldDesired := e.ObjectOld.GetAnnotations()[constants.NodeStateDrainAnnotation]
+	newDesired := e.ObjectNew.GetAnnotations()[constants.NodeStateDrainAnnotation]
+
+	return oldDesired != newDesired
 }
 
+// GetImagePullSecrets returns the list of image pull secret names from the IMAGE_PULL_SECRETS environment variable.
 func GetImagePullSecrets() []string {
 	imagePullSecrets := os.Getenv("IMAGE_PULL_SECRETS")
 	if imagePullSecrets != "" {

--- a/pkg/consts/constants.go
+++ b/pkg/consts/constants.go
@@ -77,16 +77,37 @@ const (
 	SriovDevicePluginLabelEnabled  = "Enabled"
 	SriovDevicePluginLabelDisabled = "Disabled"
 
-	NodeDrainAnnotation                = "sriovnetwork.openshift.io/state"
-	NodeStateDrainAnnotation           = "sriovnetwork.openshift.io/desired-state"
-	NodeStateDrainAnnotationCurrent    = "sriovnetwork.openshift.io/current-state"
+	// NodeDrainAnnotation is set on the Node object by the config-daemon to request a drain operation.
+	// Values: Idle, Drain_Required, Reboot_Required. Owned by config-daemon, read by drain controller.
+	// TODO: deprecate this annotation in favor of NodeStateDrainAnnotation and NodeStateDrainAnnotationCurrent.
+	NodeDrainAnnotation = "sriovnetwork.openshift.io/state"
+
+	// NodeStateDrainAnnotation is set on SriovNetworkNodeState by the config-daemon to mirror the desired drain state.
+	// Values: Idle, Drain_Required, Reboot_Required. Owned by config-daemon, read by drain controller.
+	NodeStateDrainAnnotation = "sriovnetwork.openshift.io/desired-state"
+
+	// NodeStateDrainAnnotationCurrent is set on SriovNetworkNodeState by the drain controller to report drain progress.
+	// Values: Idle, Draining, DrainComplete. Owned by drain controller, read by config-daemon.
+	NodeStateDrainAnnotationCurrent = "sriovnetwork.openshift.io/current-state"
+
+	// NodeStateDrainActionAnnotation is set on SriovNetworkNodeState by the drain controller to record the drain type
+	// that was actually performed. Used to prevent the daemon from proceeding after a partial drain when a full drain
+	// (reboot) is now required. Values: "", Drain_Required, Reboot_Required. Owned by drain controller, read by config-daemon.
+	NodeStateDrainActionAnnotation = "sriovnetwork.openshift.io/drain-action"
+
+	// NodeStateExternalDrainerAnnotation is set on SriovNetworkNodeState by the config-daemon when USE_EXTERNAL_DRAINER
+	// is enabled. When set to "true", the drain controller skips internal drain and expects an external system to manage it.
 	NodeStateExternalDrainerAnnotation = "sriovnetwork.openshift.io/use-external-drainer"
-	DesiredMachineConfigAnnotation     = "machineconfiguration.openshift.io/desiredConfig"
-	DrainIdle                          = "Idle"
-	DrainRequired                      = "Drain_Required"
-	RebootRequired                     = "Reboot_Required"
-	Draining                           = "Draining"
-	DrainComplete                      = "DrainComplete"
+
+	// DesiredMachineConfigAnnotation is read from the Node by the OpenShift orchestrator to determine
+	// which MachineConfig the node should be running. Used to detect if MCP is mid-update.
+	DesiredMachineConfigAnnotation = "machineconfiguration.openshift.io/desiredConfig"
+
+	DrainIdle      = "Idle"
+	DrainRequired  = "Drain_Required"
+	RebootRequired = "Reboot_Required"
+	Draining       = "Draining"
+	DrainComplete  = "DrainComplete"
 
 	SyncStatusSucceeded  = "Succeeded"
 	SyncStatusFailed     = "Failed"

--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -164,7 +164,8 @@ func (dn *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	// Check the object as the drain controller annotations
 	// if not just wait for the drain controller to add them before we start taking care of the nodeState
 	if !utils.ObjectHasAnnotationKey(desiredNodeState, consts.NodeStateDrainAnnotationCurrent) ||
-		!utils.ObjectHasAnnotationKey(desiredNodeState, consts.NodeStateDrainAnnotation) {
+		!utils.ObjectHasAnnotationKey(desiredNodeState, consts.NodeStateDrainAnnotation) ||
+		!utils.ObjectHasAnnotationKey(desiredNodeState, consts.NodeStateDrainActionAnnotation) {
 		reqLogger.V(2).Info("NodeState doesn't have the current drain annotation")
 		return ctrl.Result{}, nil
 	}
@@ -281,7 +282,7 @@ func (dn *NodeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl
 	}
 
 	// if we finish the drain we should run apply here
-	if dn.isDrainCompleted(reqDrain, desiredNodeState) {
+	if dn.isDrainCompleted(reqDrain, reqReboot, desiredNodeState) {
 		return dn.apply(ctx, desiredNodeState, reqReboot, sriovResult)
 	}
 
@@ -571,14 +572,25 @@ func (dn *NodeReconciler) writeSystemdConfigFile(desiredNodeState *sriovnetworkv
 // returns true if we need to finish the reconcile loop and wait for a new object
 func (dn *NodeReconciler) handleDrain(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState, reqReboot bool) (bool, error) {
 	funcLog := log.Log.WithName("handleDrain")
-	// done with the drain we can continue with the configuration
+
 	if utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotationCurrent, consts.DrainComplete) {
+		drainAction, desiredAnnotation := drainActionAndDesired(desiredNodeState, reqReboot)
+
+		if !sriovnetworkv1.DrainActionSatisfiesDesired(drainAction, desiredAnnotation) {
+			funcLog.Info("drain completed but action does not satisfy current requirement, escalating",
+				"drainAction", drainAction, "required", desiredAnnotation)
+			return true, dn.annotate(ctx, desiredNodeState, desiredAnnotation)
+		}
+
 		funcLog.Info("the node complete the draining")
 		return false, nil
 	}
 
-	// the operator is still draining the node so we reconcile
 	if utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotationCurrent, consts.Draining) {
+		if reqReboot && !utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotation, consts.RebootRequired) {
+			funcLog.Info("drain in progress but requirements escalated to reboot, updating desired-state")
+			return true, dn.annotate(ctx, desiredNodeState, consts.RebootRequired)
+		}
 		funcLog.Info("the node is still draining")
 		return true, nil
 	}
@@ -752,14 +764,19 @@ func (dn *NodeReconciler) rebootNode() error {
 }
 
 // isDrainCompleted returns true if the current-state annotation is drain completed
-func (dn *NodeReconciler) isDrainCompleted(reqDrain bool, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState) bool {
+// and the drain-action matches or satisfies the current desired-state.
+func (dn *NodeReconciler) isDrainCompleted(reqDrain bool, reqReboot bool, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState) bool {
 	if vars.DisableDrain {
 		return true
 	}
 
 	// if we need to drain check the drain status
 	if reqDrain {
-		return utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotationCurrent, consts.DrainComplete)
+		if !utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotationCurrent, consts.DrainComplete) {
+			return false
+		}
+		drainAction, desiredAnnotation := drainActionAndDesired(desiredNodeState, reqReboot)
+		return sriovnetworkv1.DrainActionSatisfiesDesired(drainAction, desiredAnnotation)
 	}
 
 	// check in case a reboot was requested and the second run doesn't require a drain
@@ -769,6 +786,17 @@ func (dn *NodeReconciler) isDrainCompleted(reqDrain bool, desiredNodeState *srio
 
 	// if we don't need to drain at all just return true so we can apply the configuration
 	return true
+}
+
+// drainActionAndDesired returns the performed drain action from the node state annotations
+// and the desired drain action based on whether a reboot is required.
+func drainActionAndDesired(nodeState *sriovnetworkv1.SriovNetworkNodeState, reqReboot bool) (performedAction, desiredAction string) {
+	performedAction = nodeState.GetAnnotations()[consts.NodeStateDrainActionAnnotation]
+	desiredAction = consts.DrainRequired
+	if reqReboot {
+		desiredAction = consts.RebootRequired
+	}
+	return
 }
 
 // annotate annotates the nodeState object with specified annotation.

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -688,6 +688,7 @@ var _ = Describe("Daemon Controller", Ordered, func() {
 			}, waitTime, retryTime).Should(Succeed())
 		})
 	})
+
 })
 
 var _ = Describe("Daemon CheckSystemdStatus", func() {
@@ -818,6 +819,7 @@ func ensureEmptyNodeState(nodeName string) *sriovnetworkv1.SriovNetworkNodeState
 			Annotations: map[string]string{
 				constants.NodeStateDrainAnnotation:        constants.DrainIdle,
 				constants.NodeStateDrainAnnotationCurrent: constants.DrainIdle,
+				constants.NodeStateDrainActionAnnotation:  "",
 			},
 		},
 	}

--- a/pkg/utils/cluster.go
+++ b/pkg/utils/cluster.go
@@ -59,6 +59,43 @@ func AnnotateObject(ctx context.Context, obj client.Object, key, value string, c
 	return nil
 }
 
+// AnnotateObjectMultiple sets multiple annotations on a kubernetes object in a single API call.
+func AnnotateObjectMultiple(ctx context.Context, obj client.Object, annotations map[string]string, c client.Client) error {
+	original := obj.DeepCopyObject().(client.Object)
+	annos := obj.GetAnnotations()
+	if annos == nil {
+		annos = make(map[string]string)
+		obj.SetAnnotations(annos)
+	}
+
+	changed := false
+	for key, value := range annotations {
+		existing, exists := annos[key]
+		if !exists || existing != value {
+			annos[key] = value
+			changed = true
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+
+	logger, ok := ctx.Value(constants.LoggerContextKey).(logr.Logger)
+	if !ok {
+		log.Log.Info("Annotate object multiple", "name", obj.GetName(), "annotations", annotations)
+	} else {
+		logger.Info("Annotate object multiple", "name", obj.GetName(), "annotations", annotations)
+	}
+
+	patch := client.MergeFrom(original)
+	if err := c.Patch(ctx, obj, patch); err != nil {
+		log.Log.Error(err, "AnnotateObjectMultiple(): Failed to patch object")
+		return err
+	}
+	return nil
+}
+
 // AnnotateNode add annotation to a node
 func AnnotateNode(ctx context.Context, nodeName string, key, value string, c client.Client) error {
 	node := &corev1.Node{}


### PR DESCRIPTION
A race condition existed where a node could be rebooted with production workloads still running. The scenario:

1. Daemon requests Drain_Required (partial drain - only SR-IOV pods evicted)
2. Drain controller performs partial drain and sets DrainComplete
3. Meanwhile, a new policy requiring reboot (e.g. RDMA mode change) arrives
4. Daemon sees DrainComplete and proceeds to reboot without a full drain

The root cause is that the daemon could not distinguish whether the completed drain was sufficient for its current (escalated) requirements.

Fix: introduce a new annotation `sriovnetwork.openshift.io/drain-action` on SriovNetworkNodeState, owned by the drain controller, that records the drain type actually performed. The daemon verifies this matches its current need before proceeding to apply configuration or reboot.

The drain controller:
- Sets drain-action when starting a drain (atomically with current-state)
- Re-reads desired-state after drain completes to detect mid-drain escalation
- Resets to Draining and re-drains if desired-state escalated beyond drain-action
- Clears drain-action when returning to Idle

The daemon:
- Checks drain-action satisfies its requirement at DrainComplete
- Escalates desired-state during Draining if reboot becomes needed
- Never proceeds to apply/reboot if drain-action is insufficient

Also adds DrainStateAnnotationPredicate watch on desired-state changes and AnnotateObjectMultiple utility to batch annotation writes in a single API call.