### PR TITLE
fix(daemon): require a full drain before reboot escalation

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -571,14 +571,34 @@ func (dn *NodeReconciler) writeSystemdConfigFile(desiredNodeState *sriovnetworkv
 // returns true if we need to finish the reconcile loop and wait for a new object
 func (dn *NodeReconciler) handleDrain(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState, reqReboot bool) (bool, error) {
 	funcLog := log.Log.WithName("handleDrain")
-	// done with the drain we can continue with the configuration
+
 	if utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotationCurrent, consts.DrainComplete) {
+		// If we need a reboot but the desired-state was Drain_Required, the completed drain
+		// was only partial (SR-IOV pods only). We must reset to Idle, wait for the operator to
+		// uncordon, then re-request with Reboot_Required to get a full drain before rebooting.
+		if reqReboot && !utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotation, consts.RebootRequired) {
+			if utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotation, consts.DrainIdle) {
+				funcLog.Info("reboot is required, waiting for operator to rollback to Idle")
+				return true, nil
+			}
+			funcLog.Info("drain completed but reboot is now required, resetting to Idle to re-request full drain")
+			return true, dn.annotate(ctx, desiredNodeState, consts.DrainIdle)
+		}
 		funcLog.Info("the node complete the draining")
 		return false, nil
 	}
 
-	// the operator is still draining the node so we reconcile
 	if utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotationCurrent, consts.Draining) {
+		// If we need a reboot but the desired-state is only Drain_Required, the operator is
+		// performing a partial drain. Move to Idle to abort and re-request with Reboot_Required.
+		if reqReboot && !utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotation, consts.RebootRequired) {
+			if utils.ObjectHasAnnotation(desiredNodeState, consts.NodeStateDrainAnnotation, consts.DrainIdle) {
+				funcLog.Info("reboot is required, waiting for operator to abort and rollback to Idle")
+				return true, nil
+			}
+			funcLog.Info("drain in progress but reboot now required, resetting to Idle to re-request full drain")
+			return true, dn.annotate(ctx, desiredNodeState, consts.DrainIdle)
+		}
 		funcLog.Info("the node is still draining")
 		return true, nil
 	}

--- a/pkg/daemon/daemon_test.go
+++ b/pkg/daemon/daemon_test.go
@@ -359,6 +359,84 @@ var _ = Describe("Daemon Controller", Ordered, func() {
 			Expect(nodeState.Status.LastSyncError).To(Equal(""))
 		})
 
+		It("Should reset desired drain to idle when reboot is required during a partial drain", func(ctx context.Context) {
+			configureDrainRequiredScenario(ctx, nodeState)
+
+			By("simulating a partial drain already in progress")
+			patchAnnotation(nodeState, constants.NodeStateDrainAnnotationCurrent, constants.Draining)
+
+			By("changing the desired state to require a reboot")
+			hostHelper.EXPECT().SetRDMASubsystem(constants.RdmaSubsystemModeExclusive).Return(nil).AnyTimes()
+			EventuallyWithOffset(1, func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				nodeState.Spec.System.RdmaMode = constants.RdmaSubsystemModeExclusive
+				err = k8sClient.Update(ctx, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, waitTime, retryTime).Should(Succeed())
+
+			By("waiting for the daemon to abort the partial drain and request idle")
+			expectDrainState(nodeState, constants.DrainIdle, constants.Draining, constants.DrainIdle)
+		})
+
+		It("Should reset desired drain to idle after a partial drain completes and then re-request reboot", func(ctx context.Context) {
+			configureDrainRequiredScenario(ctx, nodeState)
+
+			By("simulating a completed partial drain")
+			patchAnnotation(nodeState, constants.NodeStateDrainAnnotationCurrent, constants.DrainComplete)
+
+			By("changing the desired state to require a reboot")
+			hostHelper.EXPECT().SetRDMASubsystem(constants.RdmaSubsystemModeExclusive).Return(nil).AnyTimes()
+			EventuallyWithOffset(1, func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				nodeState.Spec.System.RdmaMode = constants.RdmaSubsystemModeExclusive
+				err = k8sClient.Update(ctx, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, waitTime, retryTime).Should(Succeed())
+
+			By("waiting for the daemon to move the desired drain back to idle")
+			expectDrainState(nodeState, constants.DrainIdle, constants.DrainComplete, constants.DrainIdle)
+
+			By("simulating the operator finishing the rollback to idle")
+			patchAnnotation(nodeState, constants.NodeStateDrainAnnotationCurrent, constants.DrainIdle)
+
+			By("waiting for the daemon to request a full reboot drain")
+			expectDrainState(nodeState, constants.RebootRequired, constants.DrainIdle, constants.RebootRequired)
+		})
+
+		It("Should keep reboot required when a full drain is already in progress", func(ctx context.Context) {
+			By("requesting a reboot-required drain")
+			hostHelper.EXPECT().SetRDMASubsystem(constants.RdmaSubsystemModeExclusive).Return(nil).AnyTimes()
+			EventuallyWithOffset(1, func(g Gomega) {
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+
+				nodeState.Spec.System.RdmaMode = constants.RdmaSubsystemModeExclusive
+				err = k8sClient.Update(ctx, nodeState)
+				g.Expect(err).ToNot(HaveOccurred())
+			}, waitTime, retryTime).Should(Succeed())
+
+			expectDrainState(nodeState, constants.RebootRequired, constants.DrainIdle, constants.RebootRequired)
+
+			By("simulating the operator already performing the full drain")
+			patchAnnotation(nodeState, constants.NodeStateDrainAnnotationCurrent, constants.Draining)
+
+			By("verifying the daemon does not downgrade the request back to idle")
+			ConsistentlyWithOffset(1, func(g Gomega) {
+				g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)).
+					ToNot(HaveOccurred())
+				g.Expect(nodeState.Annotations[constants.NodeStateDrainAnnotation]).To(Equal(constants.RebootRequired))
+				g.Expect(nodeState.Annotations[constants.NodeStateDrainAnnotationCurrent]).To(Equal(constants.Draining))
+
+				node := &corev1.Node{}
+				g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, node)).ToNot(HaveOccurred())
+				g.Expect(node.Annotations[constants.NodeDrainAnnotation]).To(Equal(constants.RebootRequired))
+			}, 2*time.Second, 200*time.Millisecond).Should(Succeed())
+		})
+
 		It("Should apply external drainer annotation when useExternalDrainer is true", func(ctx context.Context) {
 			DeferCleanup(func(x bool) { vars.UseExternalDrainer = x }, vars.UseExternalDrainer)
 			vars.UseExternalDrainer = true
@@ -779,6 +857,115 @@ func patchAnnotation(nodeState *sriovnetworkv1.SriovNetworkNodeState, key, value
 	nodeState.Annotations[key] = value
 	err := k8sClient.Patch(context.Background(), nodeState, client.MergeFrom(originalNodeState))
 	Expect(err).ToNot(HaveOccurred())
+}
+
+// configureDrainRequiredScenario configures the test node so the daemon requests a partial SR-IOV drain.
+func configureDrainRequiredScenario(ctx context.Context, nodeState *sriovnetworkv1.SriovNetworkNodeState) {
+	originalInterface := sriovnetworkv1.InterfaceExt{
+		Name:           "eno1",
+		Driver:         "ice",
+		PciAddress:     "0000:16:00.0",
+		DeviceID:       "1593",
+		Vendor:         "8086",
+		EswitchMode:    "legacy",
+		LinkAdminState: "up",
+		LinkSpeed:      "10000 Mb/s",
+		LinkType:       "ETH",
+		Mac:            "aa:bb:cc:dd:ee:ff",
+		Mtu:            1500,
+		TotalVfs:       2,
+		NumVfs:         0,
+	}
+	discoverSriovReturn.SetOriginal([]sriovnetworkv1.InterfaceExt{originalInterface})
+
+	afterInterface := *originalInterface.DeepCopy()
+	afterInterface.NumVfs = 2
+	afterInterface.VFs = []sriovnetworkv1.VirtualFunction{
+		{
+			Name:       "eno1f0",
+			PciAddress: "0000:16:00.1",
+			VfID:       0,
+			Driver:     "iavf",
+		},
+		{
+			Name:       "eno1f1",
+			PciAddress: "0000:16:00.2",
+			VfID:       1,
+			Driver:     "iavf",
+		},
+	}
+	discoverSriovReturn.SetAfter([]sriovnetworkv1.InterfaceExt{afterInterface})
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		nodeState.Spec.Interfaces = []sriovnetworkv1.Interface{
+			{Name: "eno1",
+				PciAddress: "0000:16:00.0",
+				LinkType:   "eth",
+				NumVfs:     2,
+				VfGroups: []sriovnetworkv1.VfGroup{
+					{ResourceName: "test",
+						DeviceType: "netdevice",
+						PolicyName: "test-policy",
+						VfRange:    "eno1#0-1"},
+				}},
+		}
+		err = k8sClient.Update(ctx, nodeState)
+		g.Expect(err).ToNot(HaveOccurred())
+	}, waitTime, retryTime).Should(Succeed())
+
+	waitForInterfaceNumVfs(nodeState, originalInterface.PciAddress, 2)
+	eventuallySyncStatusEqual(nodeState, constants.SyncStatusSucceeded)
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)
+		g.Expect(err).ToNot(HaveOccurred())
+
+		nodeState.Spec.Interfaces = []sriovnetworkv1.Interface{}
+		err = k8sClient.Update(ctx, nodeState)
+		g.Expect(err).ToNot(HaveOccurred())
+	}, waitTime, retryTime).Should(Succeed())
+
+	expectDrainState(nodeState, constants.DrainRequired, constants.DrainIdle, constants.DrainRequired)
+}
+
+// expectDrainState waits until the desired node, nodeState, and current-state drain annotations match the expected values.
+func expectDrainState(
+	nodeState *sriovnetworkv1.SriovNetworkNodeState,
+	expectedDesired string,
+	expectedCurrent string,
+	expectedNode string,
+) {
+	EventuallyWithOffset(1, func(g Gomega) {
+		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)).
+			ToNot(HaveOccurred())
+		g.Expect(nodeState.Annotations[constants.NodeStateDrainAnnotation]).To(Equal(expectedDesired))
+		g.Expect(nodeState.Annotations[constants.NodeStateDrainAnnotationCurrent]).To(Equal(expectedCurrent))
+
+		node := &corev1.Node{}
+		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Name: nodeName}, node)).ToNot(HaveOccurred())
+		g.Expect(node.Annotations[constants.NodeDrainAnnotation]).To(Equal(expectedNode))
+	}, waitTime, retryTime).Should(Succeed())
+}
+
+// waitForInterfaceNumVfs waits until the status for the given PCI device reports the expected VF count.
+func waitForInterfaceNumVfs(nodeState *sriovnetworkv1.SriovNetworkNodeState, pciAddress string, expectedNumVfs int) {
+	EventuallyWithOffset(1, func(g Gomega) {
+		g.Expect(k8sClient.Get(context.Background(), types.NamespacedName{Namespace: nodeState.Namespace, Name: nodeState.Name}, nodeState)).
+			ToNot(HaveOccurred())
+
+		found := false
+		for _, iface := range nodeState.Status.Interfaces {
+			if iface.PciAddress == pciAddress {
+				found = true
+				g.Expect(iface.NumVfs).To(Equal(expectedNumVfs))
+			}
+		}
+
+		g.Expect(found).To(BeTrue(), "status interface for %s was not found", pciAddress)
+	}, waitTime, retryTime).Should(Succeed())
 }
 
 func createNode(nodeName string) *corev1.Node {


### PR DESCRIPTION
A node can start with Drain_Required, which only triggers a partial drain for SR-IOV workloads. If the daemon later detects that the same change also requires a reboot, such as an RDMA subsystem mode change or firmware-related update, it could observe DrainComplete and proceed to reboot even though the node never went through a full drain.

Fix this by resetting the desired drain state back to Idle whenever a reboot becomes required during or after a partial drain. This forces the operator to finish the rollback to Idle, after which the daemon re-requests Reboot_Required and gets a full drain before rebooting.

Add daemon tests that cover the drain-to-reboot escalation flow and the main non-regression cases around partial and full drain handling.