### PR TITLE
Validate CRD string fields before NAD CNI JSON rendering

### DIFF
--- a/api/v1/helper.go
+++ b/api/v1/helper.go
@@ -55,6 +55,47 @@ var NicIDMap = []string{}
 
 var InitialState SriovNetworkNodeState
 
+func sanitizeJSON(raw string) (string, error) {
+	var v any
+	if err := json.Unmarshal([]byte(raw), &v); err != nil {
+		return "", err
+	}
+	safe, err := json.Marshal(v)
+	if err != nil {
+		return "", err
+	}
+	return string(safe), nil
+}
+
+func sanitizeMetaPlugins(raw string) (string, error) {
+	var plugins []map[string]any
+	if err := json.Unmarshal([]byte("["+raw+"]"), &plugins); err != nil {
+		return "", err
+	}
+	if len(plugins) == 0 {
+		return "", fmt.Errorf("metaPlugins must contain at least one plugin object")
+	}
+	for i, plugin := range plugins {
+		typeName, ok := plugin["type"].(string)
+		if !ok || strings.TrimSpace(typeName) == "" {
+			return "", fmt.Errorf("metaPlugins[%d] must contain a non-empty string type", i)
+		}
+	}
+
+	// The templates add the surrounding plugins array, so serialize the parsed
+	// fragment without its outer array brackets.
+	safe, err := json.Marshal(plugins)
+	if err != nil {
+		return "", err
+	}
+	return string(safe[1 : len(safe)-1]), nil
+}
+
+func escapeJSONStringValue(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b[1 : len(b)-1])
+}
+
 const (
 	SupportedNicIDConfigmap = "supported-nic-ids"
 )
@@ -670,21 +711,32 @@ func (cr *SriovIBNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 	if cr.Spec.Capabilities == "" {
 		data.Data["CapabilitiesConfigured"] = false
 	} else {
+		safe, err := sanitizeJSON(cr.Spec.Capabilities)
+		if err != nil {
+			return nil, fmt.Errorf("invalid capabilities JSON: %w", err)
+		}
 		data.Data["CapabilitiesConfigured"] = true
-		data.Data["SriovCniCapabilities"] = cr.Spec.Capabilities
+		data.Data["SriovCniCapabilities"] = safe
 	}
 
 	if cr.Spec.IPAM != "" {
-		data.Data["SriovCniIpam"] = SriovCniIpam + ":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")
+		safe, err := sanitizeJSON(cr.Spec.IPAM)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ipam JSON: %w", err)
+		}
+		data.Data["SriovCniIpam"] = SriovCniIpam + ":" + safe
 	} else {
 		data.Data["SriovCniIpam"] = SriovCniIpamEmpty
 	}
 
-	// metaplugins for the infiniband cni
 	data.Data["MetaPluginsConfigured"] = false
 	if cr.Spec.MetaPluginsConfig != "" {
+		safe, err := sanitizeMetaPlugins(cr.Spec.MetaPluginsConfig)
+		if err != nil {
+			return nil, fmt.Errorf("invalid metaPlugins configuration: %w", err)
+		}
 		data.Data["MetaPluginsConfigured"] = true
-		data.Data["MetaPlugins"] = cr.Spec.MetaPluginsConfig
+		data.Data["MetaPlugins"] = safe
 	}
 
 	// logLevel and logFile are currently not supports by the ip-sriov-cni -> hardcode them to false.
@@ -746,8 +798,12 @@ func (cr *SriovNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 	if cr.Spec.Capabilities == "" {
 		data.Data["CapabilitiesConfigured"] = false
 	} else {
+		safe, err := sanitizeJSON(cr.Spec.Capabilities)
+		if err != nil {
+			return nil, fmt.Errorf("invalid capabilities JSON: %w", err)
+		}
 		data.Data["CapabilitiesConfigured"] = true
-		data.Data["SriovCniCapabilities"] = cr.Spec.Capabilities
+		data.Data["SriovCniCapabilities"] = safe
 	}
 
 	data.Data["SpoofChkConfigured"] = true
@@ -799,21 +855,29 @@ func (cr *SriovNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 	}
 
 	if cr.Spec.IPAM != "" {
-		data.Data["SriovCniIpam"] = SriovCniIpam + ":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")
+		safe, err := sanitizeJSON(cr.Spec.IPAM)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ipam JSON: %w", err)
+		}
+		data.Data["SriovCniIpam"] = SriovCniIpam + ":" + safe
 	} else {
 		data.Data["SriovCniIpam"] = SriovCniIpamEmpty
 	}
 
 	data.Data["MetaPluginsConfigured"] = false
 	if cr.Spec.MetaPluginsConfig != "" {
+		safe, err := sanitizeMetaPlugins(cr.Spec.MetaPluginsConfig)
+		if err != nil {
+			return nil, fmt.Errorf("invalid metaPlugins configuration: %w", err)
+		}
 		data.Data["MetaPluginsConfigured"] = true
-		data.Data["MetaPlugins"] = cr.Spec.MetaPluginsConfig
+		data.Data["MetaPlugins"] = safe
 	}
 
 	data.Data["LogLevelConfigured"] = (cr.Spec.LogLevel != "")
 	data.Data["LogLevel"] = cr.Spec.LogLevel
 	data.Data["LogFileConfigured"] = (cr.Spec.LogFile != "")
-	data.Data["LogFile"] = cr.Spec.LogFile
+	data.Data["LogFile"] = escapeJSONStringValue(cr.Spec.LogFile)
 
 	objs, err := render.RenderDir(filepath.Join(ManifestsPath, "sriov"), &data)
 	if err != nil {
@@ -856,11 +920,15 @@ func (cr *OVSNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 	if cr.Spec.Capabilities == "" {
 		data.Data["CapabilitiesConfigured"] = false
 	} else {
+		safe, err := sanitizeJSON(cr.Spec.Capabilities)
+		if err != nil {
+			return nil, fmt.Errorf("invalid capabilities JSON: %w", err)
+		}
 		data.Data["CapabilitiesConfigured"] = true
-		data.Data["CniCapabilities"] = cr.Spec.Capabilities
+		data.Data["CniCapabilities"] = safe
 	}
 
-	data.Data["Bridge"] = cr.Spec.Bridge
+	data.Data["Bridge"] = escapeJSONStringValue(cr.Spec.Bridge)
 	data.Data["VlanTag"] = cr.Spec.Vlan
 	data.Data["MTU"] = cr.Spec.MTU
 	if len(cr.Spec.Trunk) > 0 {
@@ -869,18 +937,26 @@ func (cr *OVSNetwork) RenderNetAttDef() (*uns.Unstructured, error) {
 	} else {
 		data.Data["Trunk"] = ""
 	}
-	data.Data["InterfaceType"] = cr.Spec.InterfaceType
+	data.Data["InterfaceType"] = escapeJSONStringValue(cr.Spec.InterfaceType)
 
 	if cr.Spec.IPAM != "" {
-		data.Data["CniIpam"] = SriovCniIpam + ":" + strings.Join(strings.Fields(cr.Spec.IPAM), "")
+		safe, err := sanitizeJSON(cr.Spec.IPAM)
+		if err != nil {
+			return nil, fmt.Errorf("invalid ipam JSON: %w", err)
+		}
+		data.Data["CniIpam"] = SriovCniIpam + ":" + safe
 	} else {
 		data.Data["CniIpam"] = SriovCniIpamEmpty
 	}
 
 	data.Data["MetaPluginsConfigured"] = false
 	if cr.Spec.MetaPluginsConfig != "" {
+		safe, err := sanitizeMetaPlugins(cr.Spec.MetaPluginsConfig)
+		if err != nil {
+			return nil, fmt.Errorf("invalid metaPlugins configuration: %w", err)
+		}
 		data.Data["MetaPluginsConfigured"] = true
-		data.Data["MetaPlugins"] = cr.Spec.MetaPluginsConfig
+		data.Data["MetaPlugins"] = safe
 	}
 
 	objs, err := render.RenderDir(filepath.Join(ManifestsPath, "ovs"), &data)

--- a/api/v1/helper_test.go
+++ b/api/v1/helper_test.go
@@ -218,7 +218,7 @@ func TestIBRendering(t *testing.T) {
 				Spec: v1.SriovIBNetworkSpec{
 					NetworkNamespace: "testnamespace",
 					ResourceName:     "testresource",
-					Capabilities:     "foo",
+					Capabilities:     `{"infinibandGUID": true}`,
 				},
 			},
 		},
@@ -337,6 +337,122 @@ func TestOVSRendering(t *testing.T) {
 
 			assert.Equal(t, string(g), b.String(), "bytes do not match .golden file [%s]", gp)
 		})
+	}
+}
+
+func TestRenderRejectsInvalidJSON(t *testing.T) {
+	tests := []struct {
+		tname   string
+		network v1.SriovNetwork
+	}{
+		{
+			tname: "invalid capabilities",
+			network: v1.SriovNetwork{
+				TypeMeta:   metav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "SriovNetwork"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "test"},
+				Spec: v1.SriovNetworkSpec{
+					ResourceName: "res",
+					Capabilities: `not-json`,
+				},
+			},
+		},
+		{
+			tname: "invalid ipam",
+			network: v1.SriovNetwork{
+				TypeMeta:   metav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "SriovNetwork"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "test"},
+				Spec: v1.SriovNetworkSpec{
+					ResourceName: "res",
+					IPAM:         `not-json`,
+				},
+			},
+		},
+		{
+			tname: "invalid metaplugins",
+			network: v1.SriovNetwork{
+				TypeMeta:   metav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "SriovNetwork"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "test"},
+				Spec: v1.SriovNetworkSpec{
+					ResourceName:      "res",
+					MetaPluginsConfig: `not-json`,
+				},
+			},
+		},
+		{
+			tname: "nested metaplugin array",
+			network: v1.SriovNetwork{
+				TypeMeta:   metav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "SriovNetwork"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "test"},
+				Spec: v1.SriovNetworkSpec{
+					ResourceName:      "res",
+					MetaPluginsConfig: `[{"type":"vrf"}]`,
+				},
+			},
+		},
+		{
+			tname: "empty metaplugin array",
+			network: v1.SriovNetwork{
+				TypeMeta:   metav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "SriovNetwork"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "test"},
+				Spec: v1.SriovNetworkSpec{
+					ResourceName:      "res",
+					MetaPluginsConfig: `[]`,
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.tname, func(t *testing.T) {
+			_, err := tc.network.RenderNetAttDef()
+			if err == nil {
+				t.Error("expected render to fail with invalid JSON input")
+			}
+		})
+	}
+}
+
+func TestRenderProducesValidNADConfig(t *testing.T) {
+	network := v1.SriovNetwork{
+		TypeMeta:   metav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "SriovNetwork"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "test"},
+		Spec: v1.SriovNetworkSpec{
+			ResourceName:      "res",
+			Capabilities:      `{"mac": true}`,
+			IPAM:              `{"type": "host-local", "subnet": "10.10.0.0/16"}`,
+			MetaPluginsConfig: `{"type": "vrf", "vrfname": "blue"}, {"type": "tuning"}`,
+			LogFile:           "sriov.log",
+		},
+	}
+
+	rendered, err := network.RenderNetAttDef()
+	if err != nil {
+		t.Fatal("failed rendering:", err)
+	}
+
+	spec, ok := rendered.Object["spec"].(map[string]any)
+	if !ok {
+		t.Fatal("missing spec in rendered object")
+	}
+	config, ok := spec["config"].(string)
+	if !ok {
+		t.Fatal("missing spec.config in rendered object")
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(config), &parsed); err != nil {
+		t.Fatalf("rendered NAD config is not valid JSON: %v\nconfig: %s", err, config)
+	}
+	plugins, ok := parsed["plugins"].([]any)
+	if !ok {
+		t.Fatalf("missing plugins array in rendered config: %s", config)
+	}
+	if len(plugins) != 3 {
+		t.Fatalf("expected primary plugin plus two metaplugins, got %d: %s", len(plugins), config)
+	}
+	for i, plugin := range plugins {
+		if _, ok := plugin.(map[string]any); !ok {
+			t.Fatalf("plugins[%d] is not a plugin object: %#v", i, plugin)
+		}
 	}
 }
 

--- a/api/v1/testdata/TestIBRendering/simpleib.golden
+++ b/api/v1/testdata/TestIBRendering/simpleib.golden
@@ -10,6 +10,6 @@
     "namespace": "testnamespace"
   },
   "spec": {
-    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"type\":\"ib-sriov\",\"capabilities\":foo,\"ipam\":{} }"
+    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"type\":\"ib-sriov\",\"capabilities\":{\"infinibandGUID\":true},\"ipam\":{} }"
   }
 }

--- a/api/v1/testdata/TestOVSRendering/chained.golden
+++ b/api/v1/testdata/TestOVSRendering/chained.golden
@@ -10,6 +10,6 @@
     "namespace": "testnamespace"
   },
   "spec": {
-    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"plugins\": [ {\"type\":\"ovs\",\"mtu\":1500,\"ipam\":{} },\n{ \"type\": \"vrf\", \"vrfname\": \"blue\" }\n] }"
+    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"plugins\": [ {\"type\":\"ovs\",\"mtu\":1500,\"ipam\":{} }, {\"type\":\"vrf\",\"vrfname\":\"blue\"} ] }"
   }
 }

--- a/api/v1/testdata/TestOVSRendering/complexconf.golden
+++ b/api/v1/testdata/TestOVSRendering/complexconf.golden
@@ -10,6 +10,6 @@
     "namespace": "testnamespace"
   },
   "spec": {
-    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"type\":\"ovs\",\"capabilities\":{\"foo\": \"bar\"},\"bridge\":\"test\",\"vlan\":100,\"mtu\":1500,\"trunk\":[{\"id\":120},{\"minID\":500,\"maxID\":550}],\"interface_type\":\"netdev\",\"ipam\":{\"type\":\"foo\"} }"
+    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"type\":\"ovs\",\"capabilities\":{\"foo\":\"bar\"},\"bridge\":\"test\",\"vlan\":100,\"mtu\":1500,\"trunk\":[{\"id\":120},{\"minID\":500,\"maxID\":550}],\"interface_type\":\"netdev\",\"ipam\":{\"type\":\"foo\"} }"
   }
 }

--- a/api/v1/testdata/TestRendering/chained.golden
+++ b/api/v1/testdata/TestRendering/chained.golden
@@ -10,6 +10,6 @@
     "namespace": "testnamespace"
   },
   "spec": {
-    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"plugins\": [ {\"type\":\"sriov\",\"vlan\":0,\"vlanQoS\":0,\"ipam\":{} },\n{ \"type\": \"vrf\", \"vrfname\": \"blue\" }\n] }"
+    "config": "{ \"cniVersion\":\"1.0.0\", \"name\":\"test\",\"plugins\": [ {\"type\":\"sriov\",\"vlan\":0,\"vlanQoS\":0,\"ipam\":{} }, {\"type\":\"vrf\",\"vrfname\":\"blue\"} ] }"
   }
 }

--- a/controllers/sriovibnetwork_controller_test.go
+++ b/controllers/sriovibnetwork_controller_test.go
@@ -503,7 +503,7 @@ func generateExpectedIBNetConfig(cr *sriovnetworkv1.SriovIBNetwork) string {
 	state := getLinkState(cr.Spec.LinkState)
 
 	if cr.Spec.IPAM != "" {
-		ipam = cr.Spec.IPAM
+		ipam = sortJSONKeys(cr.Spec.IPAM)
 	}
 	configStr, err := formatJSON(fmt.Sprintf(`{ "cniVersion":"1.0.0", "name":"%s","type":"ib-sriov",%s"ipam":%s }`, cr.GetName(), state, ipam))
 	if err != nil {

--- a/controllers/sriovnetwork_controller_test.go
+++ b/controllers/sriovnetwork_controller_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -759,7 +760,7 @@ func generateExpectedNetConfig(cr *sriovnetworkv1.SriovNetwork) string {
 	state := getLinkState(cr.Spec.LinkState)
 
 	if cr.Spec.IPAM != "" {
-		ipam = cr.Spec.IPAM
+		ipam = sortJSONKeys(cr.Spec.IPAM)
 	}
 	vlanQoS := cr.Spec.VlanQoS
 
@@ -780,4 +781,18 @@ func generateExpectedNetConfig(cr *sriovnetworkv1.SriovNetwork) string {
 		panic(err)
 	}
 	return configStr
+}
+
+// sortJSONKeys re-serializes JSON so expected controller configuration matches
+// RenderNetAttDef's render-time JSON canonicalization.
+func sortJSONKeys(s string) string {
+	var v any
+	if err := json.Unmarshal([]byte(s), &v); err != nil {
+		return s
+	}
+	b, err := json.Marshal(v)
+	if err != nil {
+		return s
+	}
+	return string(b)
 }

--- a/pkg/webhook/validate_network_fields.go
+++ b/pkg/webhook/validate_network_fields.go
@@ -1,0 +1,122 @@
+package webhook
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var bridgeNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+var interfaceTypeRegexp = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+func rejectJSONUnsafeChars(field, value string) error {
+	if strings.ContainsAny(value, "\"\\") {
+		return fmt.Errorf("%s must not contain quotes or backslashes", field)
+	}
+	return nil
+}
+
+func validateCapabilities(capabilities string) error {
+	if capabilities == "" {
+		return nil
+	}
+	var caps map[string]bool
+	if err := json.Unmarshal([]byte(capabilities), &caps); err != nil {
+		return fmt.Errorf("capabilities must be a JSON object with boolean values, e.g. '{\"mac\": true}': %w", err)
+	}
+	return nil
+}
+
+func validateIPAM(ipam string) error {
+	if ipam == "" {
+		return nil
+	}
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(ipam), &obj); err != nil {
+		return fmt.Errorf("ipam must be a valid JSON object: %w", err)
+	}
+	t, ok := obj["type"]
+	if !ok {
+		return fmt.Errorf("ipam must contain a \"type\" field")
+	}
+	s, ok := t.(string)
+	if !ok {
+		return fmt.Errorf("ipam \"type\" must be a string")
+	}
+	if s == "" {
+		return fmt.Errorf("ipam \"type\" must not be empty")
+	}
+	return nil
+}
+
+func validateMetaPlugins(metaPlugins string) error {
+	if metaPlugins == "" {
+		return nil
+	}
+
+	var plugins []map[string]any
+	// MetaPluginsConfig is a comma-separated fragment inserted into the
+	// template-generated plugins array. Wrap it so each fragment is decoded and
+	// validated as an object without accepting a nested JSON array.
+	if err := json.Unmarshal([]byte("["+metaPlugins+"]"), &plugins); err != nil {
+		return fmt.Errorf("metaPlugins must be one or more JSON plugin objects: %w", err)
+	}
+	if len(plugins) == 0 {
+		return fmt.Errorf("metaPlugins must contain at least one plugin object")
+	}
+
+	for i, p := range plugins {
+		t, ok := p["type"]
+		if !ok {
+			return fmt.Errorf("metaPlugins[%d] must contain a \"type\" field", i)
+		}
+		s, ok := t.(string)
+		if !ok {
+			return fmt.Errorf("metaPlugins[%d] \"type\" must be a string", i)
+		}
+		if strings.TrimSpace(s) == "" {
+			return fmt.Errorf("metaPlugins[%d] \"type\" must not be empty", i)
+		}
+	}
+	return nil
+}
+
+func validateLogFile(logFile string) error {
+	if logFile == "" {
+		return nil
+	}
+	return rejectJSONUnsafeChars("logFile", logFile)
+}
+
+func validateBridgeName(bridge string) error {
+	if bridge == "" {
+		return nil
+	}
+	if err := rejectJSONUnsafeChars("bridge", bridge); err != nil {
+		return err
+	}
+	if len(bridge) > 15 {
+		return fmt.Errorf("bridge name must be at most 15 characters")
+	}
+	if !bridgeNameRegexp.MatchString(bridge) {
+		return fmt.Errorf("bridge name must start with an alphanumeric character and contain only alphanumeric characters, dots, underscores, or dashes")
+	}
+	return nil
+}
+
+func validateInterfaceType(interfaceType string) error {
+	if interfaceType == "" {
+		return nil
+	}
+	if err := rejectJSONUnsafeChars("interfaceType", interfaceType); err != nil {
+		return err
+	}
+	if len(interfaceType) > 32 {
+		return fmt.Errorf("interfaceType must be at most 32 characters")
+	}
+	if !interfaceTypeRegexp.MatchString(interfaceType) {
+		return fmt.Errorf("interfaceType must contain only alphanumeric characters, underscores, or dashes")
+	}
+	return nil
+}

--- a/pkg/webhook/validate_network_fields_test.go
+++ b/pkg/webhook/validate_network_fields_test.go
@@ -1,0 +1,175 @@
+package webhook
+
+import (
+	"testing"
+)
+
+func TestValidateCapabilities(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{"empty", "", false},
+		{"valid single", `{"mac": true}`, false},
+		{"valid multiple", `{"mac": true, "ips": true}`, false},
+		{"not JSON", `not json`, true},
+		{"JSON array", `[true]`, true},
+		{"JSON string", `"mac"`, true},
+		{"non-bool value", `{"mac": "yes"}`, true},
+		{"injection via value", `{"mac": true}, "evil": true`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateCapabilities(tc.input)
+			if tc.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tc.shouldFail && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateIPAM(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{"empty", "", false},
+		{"valid host-local", `{"type": "host-local", "subnet": "10.10.0.0/16"}`, false},
+		{"valid dhcp", `{"type": "dhcp"}`, false},
+		{"not JSON", `not json`, true},
+		{"missing type", `{"subnet": "10.10.0.0/16"}`, true},
+		{"type not string", `{"type": 123}`, true},
+		{"JSON array", `[{"type": "dhcp"}]`, true},
+		{"empty type", `{"type": ""}`, true},
+		{"injection trailing comma", `{"type": "dhcp"}, "evil": true`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateIPAM(tc.input)
+			if tc.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tc.shouldFail && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateMetaPlugins(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{"empty", "", false},
+		{"valid single plugin", `{"type": "vrf", "vrfname": "blue"}`, false},
+		{"valid two plugins", `{"type": "vrf"}, {"type": "tuning"}`, false},
+		{"not JSON", `not json`, true},
+		{"nested array", `[{"type": "vrf"}]`, true},
+		{"empty array", `[]`, true},
+		{"whitespace only", "  ", true},
+		{"element missing type", `{"vrfname": "blue"}`, true},
+		{"element empty type", `{"type": ""}`, true},
+		{"element whitespace type", `{"type": "  "}`, true},
+		{"element type not string", `{"type": 123}`, true},
+		{"injection via object", `{"type": "vrf"}, "evil": true`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateMetaPlugins(tc.input)
+			if tc.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tc.shouldFail && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateLogFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{"empty", "", false},
+		{"simple filename", "cni.log", false},
+		{"relative path", "sriov/cni.log", false},
+		{"quote injection", `cni","evil":"true`, true},
+		{"backslash", `cni\log`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateLogFile(tc.input)
+			if tc.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tc.shouldFail && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateBridgeName(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{"empty", "", false},
+		{"valid", "br-sriov", false},
+		{"valid with dot", "br0.1", false},
+		{"too long", "abcdefghijklmnop", true},
+		{"starts with dash", "-br0", true},
+		{"special chars", "br;rm -rf /", true},
+		{"quote injection", `br","evil":"x`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateBridgeName(tc.input)
+			if tc.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tc.shouldFail && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateInterfaceType(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		shouldFail bool
+	}{
+		{"empty", "", false},
+		{"system", "system", false},
+		{"dpdk", "dpdk", false},
+		{"internal", "internal", false},
+		{"with underscore", "my_type", false},
+		{"with dash", "my-type", false},
+		{"too long", "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", true},
+		{"special chars", "type;echo", true},
+		{"quote injection", `type","evil":"x`, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateInterfaceType(tc.input)
+			if tc.shouldFail && err == nil {
+				t.Error("expected error but got none")
+			}
+			if !tc.shouldFail && err != nil {
+				t.Errorf("expected no error but got: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/webhook/validate_networks.go
+++ b/pkg/webhook/validate_networks.go
@@ -3,32 +3,63 @@ package webhook
 import (
 	"fmt"
 
-	v1 "k8s.io/api/admission/v1"
-
 	sriovnetworkv1 "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/controllers"
 	"github.com/k8snetworkplumbingwg/sriov-network-operator/pkg/vars"
 )
 
-func validateSriovNetwork(cr *sriovnetworkv1.SriovNetwork, operation v1.Operation) (bool, []string, error) {
-	err := validateNetworkNamespace(cr)
-	if err != nil {
+func validateSriovNetwork(cr *sriovnetworkv1.SriovNetwork) (bool, []string, error) {
+	if err := validateNetworkNamespace(cr); err != nil {
+		return false, nil, err
+	}
+	if err := validateCapabilities(cr.Spec.Capabilities); err != nil {
+		return false, nil, err
+	}
+	if err := validateIPAM(cr.Spec.IPAM); err != nil {
+		return false, nil, err
+	}
+	if err := validateMetaPlugins(cr.Spec.MetaPluginsConfig); err != nil {
+		return false, nil, err
+	}
+	if err := validateLogFile(cr.Spec.LogFile); err != nil {
 		return false, nil, err
 	}
 	return true, nil, nil
 }
 
-func validateSriovIBNetwork(cr *sriovnetworkv1.SriovIBNetwork, operation v1.Operation) (bool, []string, error) {
-	err := validateNetworkNamespace(cr)
-	if err != nil {
+func validateSriovIBNetwork(cr *sriovnetworkv1.SriovIBNetwork) (bool, []string, error) {
+	if err := validateNetworkNamespace(cr); err != nil {
+		return false, nil, err
+	}
+	if err := validateCapabilities(cr.Spec.Capabilities); err != nil {
+		return false, nil, err
+	}
+	if err := validateIPAM(cr.Spec.IPAM); err != nil {
+		return false, nil, err
+	}
+	if err := validateMetaPlugins(cr.Spec.MetaPluginsConfig); err != nil {
 		return false, nil, err
 	}
 	return true, nil, nil
 }
 
-func validateOVSNetwork(cr *sriovnetworkv1.OVSNetwork, operation v1.Operation) (bool, []string, error) {
-	err := validateNetworkNamespace(cr)
-	if err != nil {
+func validateOVSNetwork(cr *sriovnetworkv1.OVSNetwork) (bool, []string, error) {
+	if err := validateNetworkNamespace(cr); err != nil {
+		return false, nil, err
+	}
+	if err := validateCapabilities(cr.Spec.Capabilities); err != nil {
+		return false, nil, err
+	}
+	if err := validateIPAM(cr.Spec.IPAM); err != nil {
+		return false, nil, err
+	}
+	if err := validateMetaPlugins(cr.Spec.MetaPluginsConfig); err != nil {
+		return false, nil, err
+	}
+	if err := validateBridgeName(cr.Spec.Bridge); err != nil {
+		return false, nil, err
+	}
+	if err := validateInterfaceType(cr.Spec.InterfaceType); err != nil {
 		return false, nil, err
 	}
 	return true, nil, nil

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -107,7 +107,7 @@ func ValidateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 			return toV1AdmissionResponse(err)
 		}
 
-		if reviewResponse.Allowed, reviewResponse.Warnings, err = validateSriovNetwork(&network, ar.Request.Operation); err != nil {
+		if reviewResponse.Allowed, reviewResponse.Warnings, err = validateSriovNetwork(&network); err != nil {
 			reviewResponse.Result = &metav1.Status{
 				Reason: metav1.StatusReason(err.Error()),
 			}
@@ -121,7 +121,7 @@ func ValidateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 			return toV1AdmissionResponse(err)
 		}
 
-		if reviewResponse.Allowed, reviewResponse.Warnings, err = validateSriovIBNetwork(&network, ar.Request.Operation); err != nil {
+		if reviewResponse.Allowed, reviewResponse.Warnings, err = validateSriovIBNetwork(&network); err != nil {
 			reviewResponse.Result = &metav1.Status{
 				Reason: metav1.StatusReason(err.Error()),
 			}
@@ -135,7 +135,7 @@ func ValidateCustomResource(ar v1.AdmissionReview) *v1.AdmissionResponse {
 			return toV1AdmissionResponse(err)
 		}
 
-		if reviewResponse.Allowed, reviewResponse.Warnings, err = validateOVSNetwork(&network, ar.Request.Operation); err != nil {
+		if reviewResponse.Allowed, reviewResponse.Warnings, err = validateOVSNetwork(&network); err != nil {
 			reviewResponse.Result = &metav1.Status{
 				Reason: metav1.StatusReason(err.Error()),
 			}


### PR DESCRIPTION
String fields in SriovNetwork, SriovIBNetwork, and OVSNetwork CRDs are interpolated verbatim into the NetworkAttachmentDefinition CNI JSON config via Go text templates. Malformed values can produce invalid JSON output, causing unpredictable CNI behavior.

Add two layers of defense:

1. Webhook validation rejects malformed input at admission time. JSON fields (capabilities, ipam, metaPlugins) must parse as the expected JSON structure. Quoted string fields (logFile, bridge, interfaceType) are checked for well-formedness.

2. Render-time re-serialization in RenderNetAttDef() guarantees well-formed output regardless of input. JSON fields go through an unmarshal/remarshal cycle; string fields are escaped via json.Marshal before template interpolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Validation**
  * Strengthened validation for capabilities, IPAM, meta-plugins, bridge names, interface types, and log file values.
  * Invalid JSON and malformed or unsafe inputs now fail with clear validation errors.

* **Configuration Rendering**
  * Rendered CNI configurations are normalized into compact, valid JSON.
  * Improved escaping for user-provided SR-IOV and OVS fields.

* **Tests**
  * Added coverage for invalid inputs and valid rendered configurations.
  * Updated expected rendering results to reflect normalized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->