### PR TITLE
Retry VF driver discovery before reporting no driver

### DIFF
--- a/api/v1/helper_test.go
+++ b/api/v1/helper_test.go
@@ -1111,6 +1111,30 @@ func TestNeedToUpdateSriov(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "driverless VF needs update",
+			args: args{
+				ifaceSpec: &v1.Interface{
+					NumVfs: 1,
+					VfGroups: []v1.VfGroup{
+						{
+							VfRange:    "0-0",
+							DeviceType: consts.DeviceTypeNetDevice,
+						},
+					},
+				},
+				ifaceStatus: &v1.InterfaceExt{
+					NumVfs: 1,
+					VFs: []v1.VirtualFunction{
+						{
+							VfID:   0,
+							Driver: "",
+						},
+					},
+				},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/host/internal/sriov/sriov.go
+++ b/pkg/host/internal/sriov/sriov.go
@@ -32,11 +32,22 @@ const (
 	// sysfsWriteTimeout is the timeout for writing to sysfs files (e.g. sriov_numvfs).
 	// Kernel drivers can block indefinitely on these writes if the device is in a bad state.
 	sysfsWriteTimeout = 2 * time.Minute
+
+	// vfDriverReadAttempts and vfDriverReadInterval bound how long discovery
+	// re-reads a VF's bound driver before reporting it as driverless. VFs can
+	// be briefly unbound during normal lifecycle events such as driver rebinds.
+	vfDriverReadAttempts = 5
+	vfDriverReadInterval = 200 * time.Millisecond
 )
 
 type interfaceToConfigure struct {
 	Iface       sriovnetworkv1.Interface
 	IfaceStatus sriovnetworkv1.InterfaceExt
+}
+
+type vfInfoResult struct {
+	index int
+	vf    sriovnetworkv1.VirtualFunction
 }
 
 type sriov struct {
@@ -138,10 +149,62 @@ func (s *sriov) ResetSriovDevice(ifaceStatus sriovnetworkv1.InterfaceExt) error 
 	return nil
 }
 
-func (s *sriov) getVfInfo(vfAddr string, pfName string, eswitchMode string, devices []*ghw.PCIDevice) sriovnetworkv1.VirtualFunction {
-	driver, err := s.dputilsLib.GetDriverName(vfAddr)
+func (s *sriov) getVfInfos(ctx context.Context, vfAddrs []string, pfName string, eswitchMode string, devices []*ghw.PCIDevice) []sriovnetworkv1.VirtualFunction {
+	results := make(chan vfInfoResult, len(vfAddrs))
+	for index, vfAddr := range vfAddrs {
+		go func(index int, vfAddr string) {
+			results <- vfInfoResult{
+				index: index,
+				vf:    s.getVfInfo(ctx, vfAddr, pfName, eswitchMode, devices),
+			}
+		}(index, vfAddr)
+	}
+
+	vfs := make([]sriovnetworkv1.VirtualFunction, len(vfAddrs))
+	for range vfAddrs {
+		result := <-results
+		vfs[result.index] = result.vf
+	}
+	return vfs
+}
+
+func (s *sriov) getVfDriverName(ctx context.Context, vfAddr string) (string, error) {
+	return s.getVfDriverNameWithRetry(ctx, vfAddr, vfDriverReadAttempts, vfDriverReadInterval)
+}
+
+func (s *sriov) getVfDriverNameWithRetry(ctx context.Context, vfAddr string, attempts int, interval time.Duration) (string, error) {
+	if attempts < 1 {
+		attempts = 1
+	}
+
+	var driver string
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		driver, err = s.dputilsLib.GetDriverName(vfAddr)
+		if err == nil && driver != "" {
+			return driver, nil
+		}
+		if attempt < attempts && interval > 0 {
+			select {
+			case <-ctx.Done():
+				return driver, fmt.Errorf("waiting to retry VF driver read for device %s: %w", vfAddr, ctx.Err())
+			case <-time.After(interval):
+			}
+		}
+	}
+
 	if err != nil {
-		log.Log.Error(err, "getVfInfo(): unable to parse device driver", "device", vfAddr)
+		return driver, fmt.Errorf("unable to parse device driver after %d attempts for device %s: %w", attempts, vfAddr, err)
+	}
+	log.Log.Info("getVfDriverName(): VF has no driver bound after retries",
+		"device", vfAddr, "attempts", attempts)
+	return driver, nil
+}
+
+func (s *sriov) getVfInfo(ctx context.Context, vfAddr string, pfName string, eswitchMode string, devices []*ghw.PCIDevice) sriovnetworkv1.VirtualFunction {
+	driver, err := s.getVfDriverName(ctx, vfAddr)
+	if err != nil {
+		log.Log.Error(err, "getVfInfo(): unable to get VF driver", "device", vfAddr)
 	}
 	id, err := s.dputilsLib.GetVFID(vfAddr)
 	if err != nil {
@@ -332,10 +395,7 @@ func (s *sriov) DiscoverSriovDevices(storeManager store.ManagerInterface) ([]sri
 						"device", device)
 					continue
 				}
-				for _, vf := range vfs {
-					instance := s.getVfInfo(vf, pfNetName, iface.EswitchMode, devices)
-					iface.VFs = append(iface.VFs, instance)
-				}
+				iface.VFs = append(iface.VFs, s.getVfInfos(context.Background(), vfs, pfNetName, iface.EswitchMode, devices)...)
 			}
 		}
 		pfList = append(pfList, iface)

--- a/pkg/host/internal/sriov/sriov_test.go
+++ b/pkg/host/internal/sriov/sriov_test.go
@@ -1,10 +1,12 @@
 package sriov
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"strconv"
 	"syscall"
+	"time"
 
 	"github.com/jaypipes/ghw/pkg/pci"
 	"github.com/jaypipes/pcidb"
@@ -146,6 +148,58 @@ var _ = Describe("SRIOV", func() {
 					GUID:            "guid1",
 				}},
 			}))
+		})
+	})
+
+	Context("getVfDriverName", func() {
+		It("returns the driver without retry when it is available", func() {
+			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.2").Return("mlx5_core", nil).Times(1)
+
+			driver, err := s.(*sriov).getVfDriverNameWithRetry(context.Background(), "0000:d8:00.2", 3, 0)
+
+			Expect(err).NotTo(HaveOccurred(), "expected no error when the VF driver is available")
+			Expect(driver).To(Equal("mlx5_core"), "expected the discovered VF driver to match")
+		})
+
+		It("retries transient driver read failures", func() {
+			gomock.InOrder(
+				dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.2").Return("", syscall.ENOENT),
+				dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.2").Return("mlx5_core", nil),
+			)
+
+			driver, err := s.(*sriov).getVfDriverNameWithRetry(context.Background(), "0000:d8:00.2", 3, 0)
+
+			Expect(err).NotTo(HaveOccurred(), "expected transient VF driver read failure to recover")
+			Expect(driver).To(Equal("mlx5_core"), "expected the recovered VF driver to match")
+		})
+
+		It("returns an empty driver and error after retry exhaustion", func() {
+			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.2").Return("", syscall.ENOENT).Times(3)
+
+			driver, err := s.(*sriov).getVfDriverNameWithRetry(context.Background(), "0000:d8:00.2", 3, 0)
+
+			Expect(err).To(HaveOccurred(), "expected an error after VF driver read retry exhaustion")
+			Expect(driver).To(BeEmpty(), "expected no VF driver after retry exhaustion")
+		})
+
+		It("returns an empty driver without error when no driver is bound", func() {
+			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.2").Return("", nil).Times(3)
+
+			driver, err := s.(*sriov).getVfDriverNameWithRetry(context.Background(), "0000:d8:00.2", 3, 0)
+
+			Expect(err).NotTo(HaveOccurred(), "expected no error when the VF has no driver bound")
+			Expect(driver).To(BeEmpty(), "expected no VF driver when none is bound")
+		})
+
+		It("stops retrying when the context is canceled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			dputilsLibMock.EXPECT().GetDriverName("0000:d8:00.2").Return("", syscall.ENOENT).Times(1)
+
+			driver, err := s.(*sriov).getVfDriverNameWithRetry(ctx, "0000:d8:00.2", 3, time.Hour)
+
+			Expect(err).To(MatchError(ContainSubstring("context canceled")), "expected retry wait to observe context cancellation")
+			Expect(driver).To(BeEmpty(), "expected no VF driver after context cancellation")
 		})
 	})
 


### PR DESCRIPTION
## Summary

Retry VF driver discovery for a short bounded window before reporting a VF as driverless.

A VF can be briefly unbound during normal lifecycle operations such as driver rebinds. If config-daemon samples `/sys/bus/pci/devices/<vf>/driver` in that window, the current code publishes the VF with an empty driver. `NeedToUpdateSriov()` then treats that empty driver as drift, and the generic plugin can request an unnecessary node drain.

This change keeps the existing behavior for a persistently driverless VF, but avoids turning a single transient driver read miss into node-state drift.

## Changes

- Add bounded VF driver discovery retry in `getVfInfo()` path.
- Return as soon as a non-empty driver is observed.
- Preserve empty-driver reporting after retry exhaustion so real driverless VFs still trigger the existing update logic.
- Add unit coverage for immediate success, transient read failure recovery, retry exhaustion, and the downstream empty-driver `NeedToUpdateSriov()` behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SR-IOV virtual function handling when a VF has no bound driver, ensuring correct update decisions.
  - Added retry-based VF driver discovery to reduce transient failures during device detection.
  - VF information collection is now parallelized for faster SR-IOV discovery.
  - Discovery now stops promptly on cancellation to improve responsiveness during shutdown.
- **Tests**
  - Expanded SR-IOV retry and cancellation coverage to validate success, transient recovery, retry exhaustion, and “driverless” behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->