### PR TITLE
Cache mstconfig query results in Mellanox vendor plugin using NodeState CRD generation

### DIFF
--- a/pkg/helper/mock/mock_helper.go
+++ b/pkg/helper/mock/mock_helper.go
@@ -695,6 +695,18 @@ func (mr *MockHostHelpersInterfaceMockRecorder) HasDriver(pciAddr any) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasDriver", reflect.TypeOf((*MockHostHelpersInterface)(nil).HasDriver), pciAddr)
 }
 
+// InvalidateCache mocks base method.
+func (m *MockHostHelpersInterface) InvalidateCache() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InvalidateCache")
+}
+
+// InvalidateCache indicates an expected call of InvalidateCache.
+func (mr *MockHostHelpersInterfaceMockRecorder) InvalidateCache() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCache", reflect.TypeOf((*MockHostHelpersInterface)(nil).InvalidateCache))
+}
+
 // IsKernelArgsSet mocks base method.
 func (m *MockHostHelpersInterface) IsKernelArgsSet(cmdLine, karg string) bool {
 	m.ctrl.T.Helper()
@@ -1138,6 +1150,18 @@ func (m *MockHostHelpersInterface) SetDevlinkDeviceParam(pciAddr, paramName, val
 func (mr *MockHostHelpersInterfaceMockRecorder) SetDevlinkDeviceParam(pciAddr, paramName, value any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDevlinkDeviceParam", reflect.TypeOf((*MockHostHelpersInterface)(nil).SetDevlinkDeviceParam), pciAddr, paramName, value)
+}
+
+// SetGeneration mocks base method.
+func (m *MockHostHelpersInterface) SetGeneration(gen int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetGeneration", gen)
+}
+
+// SetGeneration indicates an expected call of SetGeneration.
+func (mr *MockHostHelpersInterfaceMockRecorder) SetGeneration(gen any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGeneration", reflect.TypeOf((*MockHostHelpersInterface)(nil).SetGeneration), gen)
 }
 
 // SetNetdevMTU mocks base method.

--- a/pkg/plugins/mellanox/mellanox_plugin.go
+++ b/pkg/plugins/mellanox/mellanox_plugin.go
@@ -44,6 +44,10 @@ func (p *MellanoxPlugin) Name() string {
 func (p *MellanoxPlugin) OnNodeStateChange(new *sriovnetworkv1.SriovNetworkNodeState) (needDrain bool, needReboot bool, err error) {
 	log.Log.Info("mellanox plugin OnNodeStateChange()")
 
+	// Update generation for mstconfig query cache invalidation.
+	// If generation changed, the cache is automatically cleared.
+	p.helpers.SetGeneration(new.GetGeneration())
+
 	needDrain = false
 	needReboot = false
 	err = nil

--- a/pkg/plugins/mellanox/mellanox_plugin_test.go
+++ b/pkg/plugins/mellanox/mellanox_plugin_test.go
@@ -57,6 +57,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 
 	Context("OnNodeStateChange", func() {
 		It("should return error if we are trying to configure mlx devices and the system is in lock down mode", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(true)
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{
 				{Name: "eno1",
@@ -83,6 +84,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should not return error the system is in lock down mode but we don't configure any mlx device", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(true)
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{}
 			sriovNetworkNodeState.Status.Interfaces = sriovnetworkv1.InterfaceExts{
@@ -101,6 +103,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should return error if the nic require fw changes but the nic is externally manage", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().GetMlxNicFwData("0000:d8:00.0").Return(&mlx.MlxNic{TotalVfs: 0}, &mlx.MlxNic{TotalVfs: 0}, nil)
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{
@@ -129,6 +132,10 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should return true on reboot if we need to update the number of vfs in the firmware", func() {
+			// Use non-zero generation (42) to verify propagation — catches regressions
+			// where SetGeneration(0) might be hardcoded
+			sriovNetworkNodeState.Generation = 42
+			h.EXPECT().SetGeneration(int64(42))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().GetMlxNicFwData("0000:d8:00.0").Return(&mlx.MlxNic{TotalVfs: 0}, &mlx.MlxNic{TotalVfs: 0}, nil)
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{
@@ -157,6 +164,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should return true on reboot adding vfs for one PF and removing for the other", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().GetMlxNicFwData("0000:d8:00.0").Return(&mlx.MlxNic{TotalVfs: 0}, &mlx.MlxNic{TotalVfs: 0}, nil)
 			h.EXPECT().GetMlxNicFwData("0000:d9:00.0").Return(&mlx.MlxNic{TotalVfs: 10}, &mlx.MlxNic{TotalVfs: 10}, nil)
@@ -203,6 +211,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should return false if we just need to reset the vfs", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().GetMlxNicFwData("0000:d8:00.0").Return(&mlx.MlxNic{TotalVfs: 10}, &mlx.MlxNic{TotalVfs: 10}, nil)
 			h.EXPECT().LoadPfsStatus("0000:d8:00.0").Return(&sriovnetworkv1.Interface{ExternallyManaged: false}, true, nil).AnyTimes()
@@ -229,6 +238,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should return error if we are not able to read the PF status file form host", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().LoadPfsStatus("0000:d8:00.0").Return(nil, false, fmt.Errorf("failed to read file"))
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{}
@@ -249,6 +259,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should failed if policy is externally manage and we need to change nic type", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().GetMlxNicFwData("0000:d8:00.0").Return(&mlx.MlxNic{TotalVfs: 10, LinkTypeP1: "ETH"}, &mlx.MlxNic{TotalVfs: 10, LinkTypeP1: "ETH"}, nil)
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{
@@ -281,6 +292,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should failed if not able to check if the nic is externally managed PF", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().LoadPfsStatus("0000:d8:00.0").Return(&sriovnetworkv1.Interface{ExternallyManaged: true}, true, nil).AnyTimes()
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{}
@@ -303,6 +315,7 @@ var _ = Describe("SRIOV", Ordered, func() {
 		})
 
 		It("should not reset the firmware if the device was not configured by us", func() {
+			h.EXPECT().SetGeneration(int64(0))
 			h.EXPECT().IsKernelLockdownMode().Return(false)
 			h.EXPECT().LoadPfsStatus("0000:d8:00.0").Return(nil, false, nil)
 			sriovNetworkNodeState.Spec.Interfaces = sriovnetworkv1.Interfaces{}

--- a/pkg/vendors/mellanox/mellanox.go
+++ b/pkg/vendors/mellanox/mellanox.go
@@ -56,6 +56,14 @@ type MlxNic struct {
 	LinkTypeP2  string
 }
 
+// MlxNicFwDataCache holds all cached mstconfig query results for a single NIC.
+type MlxNicFwDataCache struct {
+	FwCurrent     *MlxNic
+	FwNext        *MlxNic
+	BlueFieldMode BlueFieldMode
+	BfModeQueried bool // whether BlueFieldMode was populated (since zero-value is a valid mode)
+}
+
 //go:generate ../../../bin/mockgen -destination mock/mock_mellanox.go -source mellanox.go
 type MellanoxInterface interface {
 	MstConfigReadData(string) (string, string, error)
@@ -64,18 +72,45 @@ type MellanoxInterface interface {
 
 	MlxConfigFW(attributesToChange map[string]MlxNic) error
 	MlxResetFW(pciAddresses []string, mellanoxNicsStatus map[string]map[string]sriovnetworkv1.InterfaceExt) error
+
+	// SetGeneration sets the NodeState generation for cache invalidation.
+	// If the generation differs from the cached one, the cache is fully invalidated.
+	SetGeneration(gen int64)
+	// InvalidateCache clears the entire mstconfig query cache.
+	InvalidateCache()
 }
 
 type mellanoxHelper struct {
-	utils      utils.CmdInterface
-	hostHelper host.HostManagerInterface
+	utils           utils.CmdInterface
+	hostHelper      host.HostManagerInterface
+	cacheGeneration int64
+	cache           map[string]*MlxNicFwDataCache // keyed by PCI address
 }
 
 func New(utilsHelper utils.CmdInterface, hostHelper host.HostManagerInterface) MellanoxInterface {
 	return &mellanoxHelper{
 		utils:      utilsHelper,
 		hostHelper: hostHelper,
+		cache:      make(map[string]*MlxNicFwDataCache),
 	}
+}
+
+func (m *mellanoxHelper) SetGeneration(gen int64) {
+	if m.cacheGeneration != gen {
+		log.Log.V(2).Info("mellanox cache: generation changed, invalidating cache",
+			"old", m.cacheGeneration, "new", gen)
+		m.InvalidateCache()
+		m.cacheGeneration = gen
+	}
+}
+
+func (m *mellanoxHelper) InvalidateCache() {
+	m.cache = make(map[string]*MlxNicFwDataCache)
+}
+
+// invalidateCacheEntry removes a single PCI address entry from the cache.
+func (m *mellanoxHelper) invalidateCacheEntry(pciAddress string) {
+	delete(m.cache, pciAddress)
 }
 
 func (m *mellanoxHelper) MstConfigReadData(pciAddress string) (string, string, error) {
@@ -87,6 +122,13 @@ func (m *mellanoxHelper) MstConfigReadData(pciAddress string) (string, string, e
 
 func (m *mellanoxHelper) GetMellanoxBlueFieldMode(PciAddress string) (BlueFieldMode, error) {
 	log.Log.V(2).Info("MellanoxBlueFieldMode(): checking mode for device", "device", PciAddress)
+
+	// Check cache first
+	if entry, ok := m.cache[PciAddress]; ok && entry.BfModeQueried {
+		log.Log.V(2).Info("MellanoxBlueFieldMode(): returning cached result", "device", PciAddress)
+		return entry.BlueFieldMode, nil
+	}
+
 	stdout, stderr, err := m.MstConfigReadData(PciAddress)
 	if err != nil {
 		log.Log.Error(err, "MellanoxBlueFieldMode(): failed to get mlx nic fw data", "stderr", stderr)
@@ -125,6 +167,7 @@ func (m *mellanoxHelper) GetMellanoxBlueFieldMode(PciAddress string) (BlueFieldM
 		return -1, fmt.Errorf("failed to find %s in the mstconfig output command", internalCPUModel)
 	}
 
+	var bfMode BlueFieldMode
 	// check for DPU
 	if strings.Contains(internalCPUPageSupplierstatus, ecpf) &&
 		strings.Contains(internalCPUEswitchManagerStatus, ecpf) &&
@@ -132,19 +175,30 @@ func (m *mellanoxHelper) GetMellanoxBlueFieldMode(PciAddress string) (BlueFieldM
 		strings.Contains(internalCPUOffloadEngineStatus, enabled) &&
 		strings.Contains(internalCPUModelStatus, embeddedCPU) {
 		log.Log.V(2).Info("MellanoxBlueFieldMode(): device in DPU mode", "device", PciAddress)
-		return BluefieldDpu, nil
+		bfMode = BluefieldDpu
 	} else if strings.Contains(internalCPUPageSupplierstatus, extHostPf) &&
 		strings.Contains(internalCPUEswitchManagerStatus, extHostPf) &&
 		strings.Contains(internalCPUIbVportoStatus, extHostPf) &&
 		strings.Contains(internalCPUOffloadEngineStatus, disabled) &&
 		strings.Contains(internalCPUModelStatus, embeddedCPU) {
 		log.Log.V(2).Info("MellanoxBlueFieldMode(): device in ConnectX mode", "device", PciAddress)
-		return BluefieldConnectXMode, nil
+		bfMode = BluefieldConnectXMode
+	} else {
+		log.Log.Error(nil, "MellanoxBlueFieldMode(): unknown device status",
+			"device", PciAddress, "mstconfig-output", stdout)
+		return -1, fmt.Errorf("MellanoxBlueFieldMode(): unknown device status for %s", PciAddress)
 	}
 
-	log.Log.Error(err, "MellanoxBlueFieldMode(): unknown device status",
-		"device", PciAddress, "mstconfig-output", stdout)
-	return -1, fmt.Errorf("MellanoxBlueFieldMode(): unknown device status for %s", PciAddress)
+	// Store in cache
+	entry := m.cache[PciAddress]
+	if entry == nil {
+		entry = &MlxNicFwDataCache{}
+		m.cache[PciAddress] = entry
+	}
+	entry.BlueFieldMode = bfMode
+	entry.BfModeQueried = true
+
+	return bfMode, nil
 }
 
 func (m *mellanoxHelper) MlxResetFW(pciAddresses []string, mellanoxNicsStatus map[string]map[string]sriovnetworkv1.InterfaceExt) error {
@@ -172,6 +226,9 @@ func (m *mellanoxHelper) MlxResetFW(pciAddresses []string, mellanoxNicsStatus ma
 		_, stderr, err := m.utils.RunCommand("mstfwreset", cmdArgs...)
 		if err != nil {
 			log.Log.Error(err, "mellanox-plugin resetFW(): mstfwreset failed, continuing as best-effort", "stderr", stderr, "pciAddress", pciAddress)
+		} else {
+			// Invalidate cache for this PCI address after successful firmware reset
+			m.invalidateCacheEntry(pciAddress)
 		}
 	}
 
@@ -215,12 +272,24 @@ func (m *mellanoxHelper) MlxConfigFW(attributesToChange map[string]MlxNic) error
 			log.Log.Error(err, "mellanox-plugin configFW(): failed", "stderr", strerr)
 			return err
 		}
+		// Invalidate cache for this PCI address after successful firmware write
+		m.invalidateCacheEntry(pciAddr)
 	}
 	return nil
 }
 
 func (m *mellanoxHelper) GetMlxNicFwData(pciAddress string) (current, next *MlxNic, err error) {
 	log.Log.Info("mellanox-plugin getMlnxNicFwData()", "device", pciAddress)
+
+	// Check cache first
+	if entry, ok := m.cache[pciAddress]; ok && entry.FwCurrent != nil && entry.FwNext != nil {
+		log.Log.V(2).Info("mellanox-plugin getMlnxNicFwData(): returning cached result", "device", pciAddress)
+		// Return copies to prevent callers from mutating cached data
+		currentCopy := *entry.FwCurrent
+		nextCopy := *entry.FwNext
+		return &currentCopy, &nextCopy, nil
+	}
+
 	attrs := []string{TotalVfs, EnableSriov, LinkTypeP1, LinkTypeP2}
 
 	out, stderr, err := m.MstConfigReadData(pciAddress)
@@ -237,7 +306,20 @@ func (m *mellanoxHelper) GetMlxNicFwData(pciAddress string) (current, next *MlxN
 	next, err = mlnxNicFromMap(mstNextData)
 	if err != nil {
 		log.Log.Error(err, "mellanox-plugin mlnxNicFromMap() for next mstconfig data failed")
+		return
 	}
+
+	// Store copies in cache to prevent callers from mutating cached data
+	entry := m.cache[pciAddress]
+	if entry == nil {
+		entry = &MlxNicFwDataCache{}
+		m.cache[pciAddress] = entry
+	}
+	currentCopy := *current
+	nextCopy := *next
+	entry.FwCurrent = &currentCopy
+	entry.FwNext = &nextCopy
+
 	return
 }
 

--- a/pkg/vendors/mellanox/mellanox_test.go
+++ b/pkg/vendors/mellanox/mellanox_test.go
@@ -600,6 +600,261 @@ var _ = Describe("SRIOV", func() {
 			Expect(result).To(Equal("0000:d9:00.1"))
 		})
 	})
+
+	Context("Cache - GetMlxNicFwData", func() {
+		It("should return cached result on second call (no mstconfig query)", func() {
+			// First call - triggers mstconfig
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1) // Only called once
+
+			m.SetGeneration(1)
+
+			current1, next1, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current1.TotalVfs).To(Equal(10))
+			Expect(next1.TotalVfs).To(Equal(10))
+
+			// Second call - should use cache, no RunCommand expected
+			current2, next2, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current2.TotalVfs).To(Equal(10))
+			Expect(next2.TotalVfs).To(Equal(10))
+		})
+
+		It("should invalidate cache when generation changes", func() {
+			// First call with generation 1
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			m.SetGeneration(1)
+			current, next, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current.TotalVfs).To(Equal(10))
+			Expect(next.TotalVfs).To(Equal(10))
+
+			// Change generation - cache should be invalidated
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(20, 20, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			m.SetGeneration(2)
+			current, next, err = m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current.TotalVfs).To(Equal(20))
+			Expect(next.TotalVfs).To(Equal(20))
+		})
+
+		It("should not invalidate cache when same generation is set", func() {
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1) // Only called once
+
+			m.SetGeneration(1)
+			_, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Set same generation - cache should stay valid
+			m.SetGeneration(1)
+			_, _, err = m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should cache multiple PCI addresses independently", func() {
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d9:00.0", "q").Return(
+				getMstconfigOutput(20, 20, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			m.SetGeneration(1)
+
+			current1, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current1.TotalVfs).To(Equal(10))
+
+			current2, _, err := m.GetMlxNicFwData("0000:d9:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current2.TotalVfs).To(Equal(20))
+
+			// Both should be cached - no more RunCommand calls
+			current1Again, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current1Again.TotalVfs).To(Equal(10))
+
+			current2Again, _, err := m.GetMlxNicFwData("0000:d9:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current2Again.TotalVfs).To(Equal(20))
+		})
+	})
+
+	Context("Cache - MlxConfigFW invalidation", func() {
+		It("should invalidate cache entry after successful mstconfig set", func() {
+			// First query - populates cache
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(0, 0, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			m.SetGeneration(1)
+			_, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			// GetMellanoxBlueFieldMode should trigger mstconfig since it's not cached for BF mode yet
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getBFMstconfigOutput(false, false),
+				"", nil).Times(1)
+			bfMode, err := m.GetMellanoxBlueFieldMode("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bfMode).To(Equal(BluefieldConnectXMode))
+
+			// Write FW config - should invalidate cache for this PCI address
+			u.EXPECT().RunCommand("mstconfig", "-d", "0000:d8:00.0", "-y", "set", "SRIOV_EN=True", "NUM_OF_VFS=10").Return("", "", nil)
+
+			err = m.MlxConfigFW(map[string]MlxNic{
+				"0000:d8:00.0": {EnableSriov: true, TotalVfs: 10},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Next query should hit mstconfig again (cache was invalidated)
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			current, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current.TotalVfs).To(Equal(10))
+		})
+	})
+
+	Context("Cache - MlxResetFW invalidation", func() {
+		It("should invalidate cache entry after successful firmware reset", func() {
+			// First query - populates cache
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			m.SetGeneration(1)
+			_, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Reset FW - should invalidate cache
+			mockHostHelper.EXPECT().SetSriovNumVfs("0000:d8:00.0", 0).Return(nil)
+			u.EXPECT().RunCommand("mstfwreset", "-d", "0000:d8:00.0", "--skip_driver", "-l", "3", "-y", "reset").Return("", "", nil)
+
+			mellanoxNicsStatus := map[string]map[string]sriovnetworkv1.InterfaceExt{
+				"0000:d8:00.": {"0000:d8:00.0": {PciAddress: "0000:d8:00.0"}},
+			}
+
+			err = m.MlxResetFW([]string{"0000:d8:00.0"}, mellanoxNicsStatus)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Next query should hit mstconfig again (cache was invalidated)
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(0, 0, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			current, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current.TotalVfs).To(Equal(0))
+		})
+
+		It("should not invalidate cache entry if firmware reset fails", func() {
+			// First query - populates cache
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			m.SetGeneration(1)
+			_, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Reset FW - fails
+			mockHostHelper.EXPECT().SetSriovNumVfs("0000:d8:00.0", 0).Return(nil)
+			u.EXPECT().RunCommand("mstfwreset", "-d", "0000:d8:00.0", "--skip_driver", "-l", "3", "-y", "reset").Return("", "error", testError)
+
+			mellanoxNicsStatus := map[string]map[string]sriovnetworkv1.InterfaceExt{
+				"0000:d8:00.": {"0000:d8:00.0": {PciAddress: "0000:d8:00.0"}},
+			}
+
+			err = m.MlxResetFW([]string{"0000:d8:00.0"}, mellanoxNicsStatus)
+			Expect(err).ToNot(HaveOccurred()) // mstfwreset failure is best-effort, no error returned
+
+			// Cache should still be valid - invalidation only happens on success path
+			current, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(current.TotalVfs).To(Equal(10))
+		})
+	})
+
+	Context("Cache - GetMellanoxBlueFieldMode", func() {
+		It("should return cached BlueFieldMode on second call", func() {
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getBFMstconfigOutput(false, false),
+				"", nil).Times(1) // Only called once
+
+			m.SetGeneration(1)
+			bfMode1, err := m.GetMellanoxBlueFieldMode("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bfMode1).To(Equal(BluefieldConnectXMode))
+
+			// Second call - should use cache
+			bfMode2, err := m.GetMellanoxBlueFieldMode("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bfMode2).To(Equal(BluefieldConnectXMode))
+		})
+
+		It("should cache DPU mode correctly", func() {
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getBFMstconfigOutput(true, false),
+				"", nil).Times(1) // Only called once
+
+			m.SetGeneration(1)
+			bfMode1, err := m.GetMellanoxBlueFieldMode("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bfMode1).To(Equal(BluefieldDpu))
+
+			// Second call - should use cache
+			bfMode2, err := m.GetMellanoxBlueFieldMode("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(bfMode2).To(Equal(BluefieldDpu))
+		})
+	})
+
+	Context("Cache - InvalidateCache", func() {
+		It("should clear all cached entries", func() {
+			// Populate cache for two PCI addresses
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d9:00.0", "q").Return(
+				getMstconfigOutput(20, 20, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			m.SetGeneration(1)
+			_, _, err := m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			_, _, err = m.GetMlxNicFwData("0000:d9:00.0")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Invalidate cache explicitly
+			m.InvalidateCache()
+
+			// Both should require fresh queries
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d8:00.0", "q").Return(
+				getMstconfigOutput(10, 10, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+			u.EXPECT().RunCommand("mstconfig", "-e", "-d", "0000:d9:00.0", "q").Return(
+				getMstconfigOutput(20, 20, "True", "True", "True", true, false, false),
+				"", nil).Times(1)
+
+			_, _, err = m.GetMlxNicFwData("0000:d8:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			_, _, err = m.GetMlxNicFwData("0000:d9:00.0")
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })
 
 func getMstconfigOutput(numOfVfsCurrent, numofVfsNextBoot int, sriovEnableDefault, sriovEnableCurrent, sriovEnableNextBoot string, withETHLinkType, withIBLinkType, withUnknowLinkType bool) string {

--- a/pkg/vendors/mellanox/mock/mock_mellanox.go
+++ b/pkg/vendors/mellanox/mock/mock_mellanox.go
@@ -72,6 +72,18 @@ func (mr *MockMellanoxInterfaceMockRecorder) GetMlxNicFwData(pciAddress any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMlxNicFwData", reflect.TypeOf((*MockMellanoxInterface)(nil).GetMlxNicFwData), pciAddress)
 }
 
+// InvalidateCache mocks base method.
+func (m *MockMellanoxInterface) InvalidateCache() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "InvalidateCache")
+}
+
+// InvalidateCache indicates an expected call of InvalidateCache.
+func (mr *MockMellanoxInterfaceMockRecorder) InvalidateCache() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCache", reflect.TypeOf((*MockMellanoxInterface)(nil).InvalidateCache))
+}
+
 // MlxConfigFW mocks base method.
 func (m *MockMellanoxInterface) MlxConfigFW(attributesToChange map[string]mlxutils.MlxNic) error {
 	m.ctrl.T.Helper()
@@ -114,4 +126,16 @@ func (m *MockMellanoxInterface) MstConfigReadData(arg0 string) (string, string, 
 func (mr *MockMellanoxInterfaceMockRecorder) MstConfigReadData(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MstConfigReadData", reflect.TypeOf((*MockMellanoxInterface)(nil).MstConfigReadData), arg0)
+}
+
+// SetGeneration mocks base method.
+func (m *MockMellanoxInterface) SetGeneration(gen int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetGeneration", gen)
+}
+
+// SetGeneration indicates an expected call of SetGeneration.
+func (mr *MockMellanoxInterfaceMockRecorder) SetGeneration(gen any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetGeneration", reflect.TypeOf((*MockMellanoxInterface)(nil).SetGeneration), gen)
 }


### PR DESCRIPTION
## Summary

This PR introduces a per-PCI-address cache for `mstconfig q` query results in the Mellanox vendor plugin to eliminate redundant firmware configuration queries during the sriov-network-operator reconcile loop. Each `mstconfig q` invocation takes ~8 seconds, and multiple calls per NIC per reconcile cycle were causing significant delays (32-64 seconds for a node with 8 Mellanox NICs).

## Key Changes

- **Added `MlxNicFwDataCache` struct** to hold cached firmware data (`FwCurrent`, `FwNext`) and BlueField mode per PCI address
- **Added cache fields to `mellanoxHelper`** (`cache map[string]*MlxNicFwDataCache`, `cacheGeneration int64`) with generation-based invalidation tied to the `SriovNetworkNodeState` CRD generation
- **Added `SetGeneration(int64)` and `InvalidateCache()` methods** to the `MellanoxInterface` — `SetGeneration` automatically clears the cache when the NodeState generation changes
- **Modified `GetMlxNicFwData()`** to check cache before executing `mstconfig q`; on cache miss, results are parsed and stored
- **Modified `GetMellanoxBlueFieldMode()`** to check cache before executing `mstconfig q`; cached results share the same per-PCI-address entry
- **Added cache invalidation after writes** — `MlxConfigFW()` and `MlxResetFW()` invalidate the cache entry for the affected PCI address after successful firmware writes/resets
- **Updated `MellanoxPlugin.OnNodeStateChange()`** to call `SetGeneration()` at the start of each reconcile, triggering automatic cache invalidation when the spec changes
- **Regenerated mocks** for `MellanoxInterface` and `HostHelpersInterface` to include the new methods
- **Added comprehensive unit tests** covering cache hits, generation-based invalidation, write-based invalidation, failed reset (cache preserved), multi-PCI-address independence, and explicit `InvalidateCache()` behavior

## Notable Implementation Decisions

- **Cache invalidation is generation-based**: The cache is fully cleared when the NodeState generation changes, ensuring fresh data is read whenever the operator spec is updated
- **Parsed values are cached, not raw output**: Each function (`GetMlxNicFwData`, `GetMellanoxBlueFieldMode`) caches its parsed results rather than raw `mstconfig` output to avoid re-parsing on every access
- **Per-entry invalidation on writes**: Only the affected PCI address entry is removed from cache after `mstconfig set` or `mstfwreset`, preserving cache for unaffected NICs
- **Failed operations preserve cache**: If `mstfwreset` fails, the cache entry is not invalidated since the firmware state hasn't actually changed
- **`BfModeQueried` flag**: A boolean flag distinguishes between "BlueField mode not yet queried" and "BlueField mode is zero-value" since the zero-value of `BlueFieldMode` is a valid mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-NIC caching for Mellanox firmware and device mode information.
  * Cache is invalidated when node configuration generations change or when manually requested.
  * Cached entries are cleared after successful firmware configuration or reset operations.
* **Bug Fixes**
  * Failed firmware resets now preserve previously valid cached data.
* **Tests**
  * Expanded coverage for caching, invalidation, and cache eviction behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->