### PR TITLE
webhook: allow dash in resource name, add k8s naming reference

### DIFF
--- a/pkg/webhook/validate.go
+++ b/pkg/webhook/validate.go
@@ -143,10 +143,33 @@ func validateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy, o
 	return admit, warnings, nil
 }
 
+// resourceNameMaxLen is the maximum length of a resource name, matching the
+// Kubernetes DNS label limit (https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names).
+const resourceNameMaxLen = 63
+
+// resourceNameRegexp allows alphanumeric characters in any position, plus
+// hyphens and underscores in non-boundary positions (no leading/trailing hyphens or underscores).
+// Underscores are included for backward-compatibility with existing resource names.
+var resourceNameRegexp = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9_-]*[a-zA-Z0-9])?$`)
+
+func validateResourceName(name string) error {
+	if name == "" {
+		return fmt.Errorf("resource name must not be empty")
+	}
+	if len(name) > resourceNameMaxLen {
+		return fmt.Errorf("resource name %q must be no more than %d characters", name, resourceNameMaxLen)
+	}
+	if !resourceNameRegexp.MatchString(name) {
+		return fmt.Errorf("resource name %q is invalid: must consist of alphanumeric characters or hyphens, "+
+			"and must start and end with an alphanumeric character "+
+			"(e.g. 'myresource', 'net-device-1'), see https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names", name)
+	}
+	return nil
+}
+
 func staticValidateSriovNetworkNodePolicy(cr *sriovnetworkv1.SriovNetworkNodePolicy) (bool, error) {
-	var validString = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
-	if !validString.MatchString(cr.Spec.ResourceName) {
-		return false, fmt.Errorf("resource name \"%s\" contains invalid characters, the accepted syntax of the regular expressions is: \"^[a-zA-Z0-9_]+$\"", cr.Spec.ResourceName)
+	if err := validateResourceName(cr.Spec.ResourceName); err != nil {
+		return false, err
 	}
 
 	if cr.Spec.NicSelector.Vendor == "" && cr.Spec.NicSelector.DeviceID == "" && len(cr.Spec.NicSelector.PfNames) == 0 && len(cr.Spec.NicSelector.RootDevices) == 0 && cr.Spec.NicSelector.NetFilter == "" {

--- a/pkg/webhook/validate_test.go
+++ b/pkg/webhook/validate_test.go
@@ -739,6 +739,44 @@ func TestValidatePoliciesWithDifferentNumVfForTheSameResourceAndTheSameRootDevic
 	g.Expect(err).To(MatchError("root device 0000:86:00.1 is overlapped with existing policy previousPolicy"))
 }
 
+func TestValidateResourceName(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		expectErr bool
+		errSubstr string
+	}{
+		{name: "valid simple", input: "myresource"},
+		{name: "valid with hyphen", input: "my-resource"},
+		{name: "valid uppercase", input: "MyResource"},
+		{name: "valid single char", input: "a"},
+		{name: "underscore in name", input: "my_resource"},
+		{name: "underscore with hyphen", input: "net_device-1"},
+		{name: "underscore only", input: "_", expectErr: true, errSubstr: "invalid"},
+		{name: "valid 63 chars", input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"},
+		{name: "empty", input: "", expectErr: true, errSubstr: "must not be empty"},
+		{name: "leading hyphen", input: "-resource", expectErr: true, errSubstr: "invalid"},
+		{name: "trailing hyphen", input: "resource-", expectErr: true, errSubstr: "invalid"},
+		{name: "only hyphen", input: "-", expectErr: true, errSubstr: "invalid"},
+		{name: "64 chars", input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", expectErr: true, errSubstr: "no more than 63"},
+		{name: "invalid char space", input: "my resource", expectErr: true, errSubstr: "invalid"},
+		{name: "invalid char dot", input: "my.resource", expectErr: true, errSubstr: "invalid"},
+		{name: "invalid char slash", input: "my/resource", expectErr: true, errSubstr: "invalid"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			err := validateResourceName(tc.input)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring(tc.errSubstr))
+			} else {
+				g.Expect(err).NotTo(HaveOccurred())
+			}
+		})
+	}
+}
+
 func TestStaticValidateSriovNetworkNodePolicyWithValidVendorDevice(t *testing.T) {
 	policy := &SriovNetworkNodePolicy{
 		Spec: SriovNetworkNodePolicySpec{


### PR DESCRIPTION
Allow '-' in SriovNetworkNodePolicy resource names to align with Kubernetes naming conventions.

Kubernetes error while we try to create a resource with underscore:
```
"error": "error while patching sriovnetwork.openshift.io/v1, Kind=SriovNetworkNodePolicy network-operator/rail0_unused: SriovNetworkNodePolicy.sriovnetwork.openshift.io \"rail0_unused\" is invalid: metadata.name: Invalid value: \"rail0_unused\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for SR-IOV network node policy resource names.
  * Resource names may contain only alphanumeric characters and internal hyphens; underscores and boundary hyphens are rejected.
  * Empty names and names longer than 63 characters are now rejected.
  * Validation provides clearer error messages for invalid resource names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->