### PR TITLE
fix(daemon): preserve applied generation across status updates

### DIFF
--- a/pkg/daemon/daemon.go
+++ b/pkg/daemon/daemon.go
@@ -371,6 +371,7 @@ func (dn *NodeReconciler) CheckSystemdStatus() (*hosttypes.SriovResult, bool, er
 // 7. Updating the lastAppliedGeneration to the current generation.
 func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetworkv1.SriovNetworkNodeState, reqReboot bool, sriovResult *hosttypes.SriovResult) (ctrl.Result, error) {
 	reqLogger := log.FromContext(ctx).WithName("Apply")
+	appliedGeneration := desiredNodeState.Generation
 
 	// Restart the device plugin *before* applying configuration if the
 	// BlockDevicePluginUntilConfiguredFeatureGate feature is enabled.
@@ -455,8 +456,10 @@ func (dn *NodeReconciler) apply(ctx context.Context, desiredNodeState *sriovnetw
 		return ctrl.Result{}, err
 	}
 
-	// update the lastAppliedGeneration
-	dn.lastAppliedGeneration = desiredNodeState.Generation
+	// Preserve the generation that this reconcile actually applied. updateSyncState()
+	// refreshes ObjectMeta from the live object and may observe a newer generation
+	// that arrived mid-apply, but that newer spec still needs its own reconcile.
+	dn.lastAppliedGeneration = appliedGeneration
 
 	return ctrl.Result{RequeueAfter: consts.DaemonRequeueTime}, nil
 }


### PR DESCRIPTION
Capture the generation at the start of apply so a concurrent NodeState update is not marked as already applied after updateSyncState refreshes ObjectMeta. This keeps the daemon from skipping the follow-up reconcile that re-requests a full reboot drain after rolling a partial drain back to Idle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed apply status tracking so the recorded applied generation remains consistent with the generation targeted when the operation began.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->