### PR TITLE
Add liveness and readiness probes to network-resources-injector in operator

### DIFF
--- a/bindata/manifests/webhook/server.yaml
+++ b/bindata/manifests/webhook/server.yaml
@@ -77,6 +77,7 @@ spec:
         - --insecure=true
         - --logtostderr=true
         - --alsologtostderr=true
+        - --health-check-port=8444
         {{- if .TLSCipherSuites }}
         - --tls-cipher-suites={{.TLSCipherSuites}}
         {{- end }}
@@ -104,6 +105,26 @@ spec:
           requests:
             cpu: 10m
             memory: 50Mi
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /healthz
+            port: 8444
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          successThreshold: 1
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /readyz
+            port: 8444
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
         volumeMounts:
         - mountPath: /etc/tls
           name: tls


### PR DESCRIPTION
This PR adds liveness and readiness health probes to the `network-resources-injector` (NRI) container deployed by the sriov-network-operator, and enables the NRI health check HTTP server by adding the required `--health-check-port` argument. Previously, the DaemonSet had no health probes and the health check server was never started, meaning Kubernetes had no way to assess the container's health.

## Key Changes

- **`bindata/manifests/webhook/server.yaml`**: Added `--health-check-port=8444` to the `webhook-server` container args to start the NRI health check HTTP server, and added `livenessProbe` and `readinessProbe` definitions targeting the `/healthz` and `/readyz` endpoints respectively on port `8444` over plain HTTP.

- **`deployment/sriov-network-operator-chart/templates/injector.yaml`**: Applied the same changes to the Helm chart template — added `--health-check-port=8444` arg and both liveness/readiness probes to ensure consistency between the raw manifest and Helm-based deployments.

## Probe Configuration

| Probe | Path | Port | Scheme | Initial Delay | Period | Failure Threshold |
|-------|------|------|--------|---------------|--------|-------------------|
| Liveness | `/healthz` | 8444 | HTTP | 15s | 20s | 3 |
| Readiness | `/readyz` | 8444 | HTTP | 5s | 10s | 3 |

## Notable Implementation Decisions

- **Port `8444`** is used for the health check server (not `8081`, which is the operator's own health port, nor `6443`, which is the TLS webhook server).
- **Scheme is `HTTP`** — the NRI health check server runs plain HTTP, completely separate from the mutating webhook TLS server.
- The `/readyz` endpoint is being introduced in a parallel PR to the `network-resources-injector` project itself; this PR prepares the operator-side configuration to use it once available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health-check endpoints on port 8444.
  * Added liveness and readiness probes for improved service health monitoring.
  * Enabled health-check traffic through the network policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->